### PR TITLE
Plot result only for specific file formats

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,6 +7,7 @@ import pytest
 from .fixtures import auth_live, tools_live  # pylint: disable=unused-import
 from .context import Tools
 
+
 @pytest.mark.live
 def test_validate_manifest_valid(tools_live):
     _location_ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -137,7 +137,7 @@ def plot_quicklook(figsize: Tuple[int, int] = (8, 8), filepaths: List = None) ->
 
 def plot_results(
     figsize: Tuple[int, int] = (8, 8),
-    filepaths: List[str] = None,
+    filepaths: List[Union[str, Path]] = None,
     titles: List[str] = None,
 ) -> None:
     tools = Tools(auth=_auth)

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -233,7 +233,7 @@ class Tools:
     def plot_result(
         self,
         figsize: Tuple[int, int] = (8, 8),
-        filepaths: List[str] = None,
+        filepaths: List[Union[str, Path]] = None,
         titles: List[str] = None,
     ) -> None:
         """
@@ -249,12 +249,17 @@ class Tools:
             if self.result is None:
                 raise ValueError("You first need to download the results.")
             filepaths = self.result
+        filepaths = [Path(path) for path in filepaths]
 
         plot_file_format = ["tif"]  # TODO: Add other fileformats.
-        imagepaths = [path for path in filepaths if str(path.suffix) in plot_file_format]
+        imagepaths = [
+            path for path in filepaths if str(path.suffix) in plot_file_format  # type: ignore
+        ]
         if not imagepaths:
-            raise ValueError(f"Only results of the formats {plot_file_format} can "
-                             "currently be plotted.")
+            raise ValueError(
+                f"Only results of the formats {plot_file_format} can "
+                "currently be plotted."
+            )
 
         if not titles:
             titles = [Path(fp).stem for fp in imagepaths]


### PR DESCRIPTION
Plotting function evaluates accepted file formats. Related to https://github.com/up42/up42-py/pull/15 which changes the download_result structure.