### PR TITLE
Improve track status

### DIFF
--- a/up42/job.py
+++ b/up42/job.py
@@ -104,7 +104,7 @@ class Job(Tools):
                 raise ValueError("Job has failed! See the above log.")
             elif status in ["CANCELLED", "CANCELLING"]:
                 logger.info("Job is %s! - %s", status, self.job_id)
-                raise ValueError("Job has been canceled!")
+                raise ValueError("Job has been cancelled!")
             elif status == "SUCCEEDED":
                 logger.info("Job finished successfully! - %s", self.job_id)
 


### PR DESCRIPTION
Removes initial 30s waiting time if job fails quickly, better/more precise logger messages.