### PR TITLE
Remove gcs range download

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-mkdocs==1.0.4
+mkdocs==1.1
 mkdocs-material
 pandoc
 pygments

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -225,14 +225,14 @@ def test_job_download_result_no_tiff_live(auth_live):
 
 @pytest.mark.skip
 @pytest.mark.live
-def test_job_download_result_live_slow_gcs_new_token(auth_live):
+def test_job_download_result_live_2gb_big_exceeding_2min_gcs_treshold(auth_live):
     job = up42.Job(
         auth=auth_live,
         project_id=auth_live.project_id,
-        job_id="99bc9fab-cffa-4010-bdac-2b0620c7e1cb",
+        job_id="30f82b44-1505-4773-ab23-31fa61ba9b4c",
     )
     with tempfile.TemporaryDirectory() as tempdir:
         out_files = job.download_results(Path(tempdir))
         for file in out_files:
             assert Path(file).exists()
-        assert len(out_files) == 98
+        assert len(out_files) == 490

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -262,9 +262,7 @@ def test_download_result_from_gcs():
         out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
         out_tgz_file = open(out_tgz, "rb")
         m.get(
-            url=cloud_storage_url,
-            content=out_tgz_file.read(),
-            headers={"x-goog-stored-content-length": f"20000001"},
+            url=cloud_storage_url, content=out_tgz_file.read(),
         )
         with tempfile.TemporaryDirectory() as tempdir:
             out_files = download_results_from_gcs(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,9 +258,6 @@ def test_fc_to_query_geometry_raises_with_not_accepted():
 def test_download_result_from_gcs():
     cloud_storage_url = "http://clouddownload.api.com/abcdef"
 
-    def _simplified_get_download_url():
-        return cloud_storage_url
-
     with requests_mock.Mocker() as m:
         out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
         out_tgz_file = open(out_tgz, "rb")
@@ -271,8 +268,7 @@ def test_download_result_from_gcs():
         )
         with tempfile.TemporaryDirectory() as tempdir:
             out_files = download_results_from_gcs(
-                func_get_download_url=_simplified_get_download_url,
-                output_directory=tempdir,
+                download_url=cloud_storage_url, output_directory=tempdir,
             )
             for file in out_files:
                 assert Path(file).exists()

--- a/up42/job.py
+++ b/up42/job.py
@@ -191,9 +191,9 @@ class Job(Tools):
         output_directory.mkdir(parents=True, exist_ok=True)
         logger.info("Download directory: %s", str(output_directory))
 
+        download_url = self._get_download_url()
         out_filepaths = download_results_from_gcs(
-            func_get_download_url=self._get_download_url,
-            output_directory=output_directory,
+            download_url=download_url, output_directory=output_directory,
         )
 
         self.results = out_filepaths

--- a/up42/jobtask.py
+++ b/up42/jobtask.py
@@ -106,9 +106,9 @@ class JobTask(Tools):
         output_directory.mkdir(parents=True, exist_ok=True)
         logger.info("Download directory: %s", str(output_directory))
 
+        download_url = self._get_download_url()
         out_filepaths = download_results_from_gcs(
-            func_get_download_url=self._get_download_url,
-            output_directory=output_directory,
+            download_url=download_url, output_directory=output_directory,
         )
 
         self.results = out_filepaths

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -76,7 +76,10 @@ def download_results_from_gcs(
                 if chunk:  # filter out keep-alive new chunks
                     dst_tgz.write(chunk)
         except requests.exceptions.HTTPError as err:
-            raise SystemExit(err)
+            logger.debug("Connection error, please try again! %s", err)
+            raise requests.exceptions.HTTPError(
+                f"Connection error, please try again! {err}"
+            )
 
     # Unpack and exclude data.json
     out_filepaths: List[str] = []

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from typing import Dict, List, Union, Callable
+from typing import Dict, List, Union
 from pathlib import Path
 import tempfile
 import tarfile
@@ -53,14 +53,14 @@ def is_notebook() -> bool:
 
 
 def download_results_from_gcs(
-    func_get_download_url: Callable, output_directory: Union[str, Path]
+    download_url: str, output_directory: Union[str, Path]
 ) -> List[str]:
     """
     General download function for results of job and jobtask from cloud storage
     provider.
 
     Args:
-        func_get_download_url:
+        download_url: The signed gcs url to download.
         output_directory: The file output directory, defaults to the current working
             directory.
     """
@@ -69,24 +69,16 @@ def download_results_from_gcs(
     # Download
     tgz_file = tempfile.mktemp()
     with open(tgz_file, "wb") as dst_tgz:
-        headers = {"Range": "bytes=0-512"}
-        r = requests.get(func_get_download_url(), headers=headers)
-        bytes_total = int(r.headers["x-goog-stored-content-length"])
-        chunk_size = 10000000  # 10mb
-        # TODO: Find better solution for gcs token issue.
-        for start in tqdm(range(0, bytes_total, chunk_size)):
-            end = start + chunk_size - 1  # Bytes ranges are inclusive
-            headers = {"Range": f"bytes={start}-{end}"}
-            try:
-                r = requests.get(func_get_download_url(), headers=headers)
-                r.raise_for_status()
-                dst_tgz.write(r.content)
-            except requests.exceptions.HTTPError:
-                # Tokens expires before download complete.
-                r = requests.get(func_get_download_url(), headers=headers)
-                dst_tgz.write(r.content)
+        try:
+            r = requests.get(download_url)
+            r.raise_for_status()
+            for chunk in tqdm(r.iter_content(chunk_size=1024)):
+                if chunk:  # filter out keep-alive new chunks
+                    dst_tgz.write(chunk)
+        except requests.exceptions.HTTPError as err:
+            raise SystemExit(err)
 
-    # Unpack
+    # Unpack and exclude data.json
     out_filepaths: List[str] = []
     with tarfile.open(tgz_file) as tar:
         members = tar.getmembers()


### PR DESCRIPTION
- Removes the range header download (actually not the solution for gcs inconsistencies).
- Uses chunks.
- Adds (skipped) huge download to test gcs 2min treshold (test successfull).