### PR TITLE
Block name for workflow task

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ input_tasks= [blocks['sobloo-s2-l1c-aoiclipped'],
 workflow.add_workflow_tasks(input_tasks=input_tasks)
 
 # Define the aoi and input parameters of the workflow to run it.
-aoi = workflow.read_vector_file("data/aoi_berlin.geojson", as_dataframe=True)
+aoi = workflow.get_example_aoi(as_dataframe=True)
+#aoi = workflow.read_vector_file("data/aoi_berlin.geojson", as_dataframe=True)
 input_parameters = workflow.construct_parameters(geometry=aoi, 
                                                  geometry_operation="bbox", 
                                                  start_date="2018-01-01",

--- a/docs/30-seconds-example.md
+++ b/docs/30-seconds-example.md
@@ -29,7 +29,8 @@ workflow.add_workflow_tasks(input_tasks=input_tasks)
 
 ```python
 # Define the aoi and input parameters of the workflow to run it.
-aoi = workflow.read_vector_file("data/aoi_berlin.geojson", as_dataframe=True)
+aoi = workflow.get_example_aoi(as_dataframe=True)
+#aoi = workflow.read_vector_file("data/aoi_berlin.geojson", as_dataframe=True)
 input_parameters = workflow.construct_parameters(geometry=aoi, 
                                                  geometry_operation="bbox", 
                                                  start_date="2018-01-01",

--- a/examples/30-seconds-example.ipynb
+++ b/examples/30-seconds-example.ipynb
@@ -47,7 +47,8 @@
    "outputs": [],
    "source": [
     "# Define the aoi and input parameters of the workflow to run it.\n",
-    "aoi = workflow.read_vector_file(\"data/aoi_berlin.geojson\", as_dataframe=True)\n",
+    "aoi = workflow.get_example_aoi(as_dataframe=True)\n",
+    "#aoi = workflow.read_vector_file(\"data/aoi_berlin.geojson\", as_dataframe=True)\n",
     "input_parameters = workflow.construct_parameters(geometry=aoi, \n",
     "                                                 geometry_operation=\"bbox\", \n",
     "                                                 start_date=\"2018-01-01\",\n",

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -51,6 +51,27 @@ json_workflow_tasks = {
     "error": {},
 }
 
+json_blocks = {
+    "data": [
+        {
+            "id": "4ed70368-d4e1-4462-bef6-14e768049471",
+            "name": "tiling",
+            "displayName": "Raster Tiling",
+        },
+        {
+            "id": "c0d04ec3-98d7-4183-902f-5bcb2a176d89",
+            "name": "sharpening",
+            "displayName": "Sharpening Filter",
+        },
+        {
+            "id": "a2daaab4-196d-4226-a018-a810444dcad1",
+            "name": "sobloo-s2-l1c-aoiclipped",
+            "displayName": "Sentinel-2 L1C MSI AOI clipped",
+        },
+    ],
+    "error": {},
+}
+
 
 def test_workflow_get_info(workflow_mock):
     del workflow_mock.info
@@ -143,6 +164,17 @@ def test_get_workflow_tasks_live(workflow_live):
     assert "sobloo-s2-l1c-aoiclipped:1" in list(workflow_tasks.keys())
 
 
+def test_construct_full_workflow_tasks_dict_unkwown_block_raises(workflow_mock):
+    input_tasks = ["some_block"]
+    with requests_mock.Mocker() as m:
+        url_get_blocks = f"{workflow_mock.auth._endpoint()}/blocks"
+        m.get(
+            url=url_get_blocks, json=json_blocks,
+        )
+        with pytest.raises(ValueError):
+            workflow_mock._construct_full_workflow_tasks_dict(input_tasks=input_tasks)
+
+
 def test_construct_full_workflow_tasks_dict(workflow_mock):
     input_tasks = [
         "a2daaab4-196d-4226-a018-a810444dcad1",
@@ -151,21 +183,7 @@ def test_construct_full_workflow_tasks_dict(workflow_mock):
     with requests_mock.Mocker() as m:
         url_get_blocks = f"{workflow_mock.auth._endpoint()}/blocks"
         m.get(
-            url=url_get_blocks,
-            json={
-                "data": [
-                    {"id": "4ed70368-d4e1-4462-bef6-14e768049471", "name": "tiling"},
-                    {
-                        "id": "c0d04ec3-98d7-4183-902f-5bcb2a176d89",
-                        "name": "sharpening",
-                    },
-                    {
-                        "id": "a2daaab4-196d-4226-a018-a810444dcad1",
-                        "name": "sobloo-s2-l1c-aoiclipped",
-                    },
-                ],
-                "error": {},
-            },
+            url=url_get_blocks, json=json_blocks,
         )
         full_workflow_tasks_dict = workflow_mock._construct_full_workflow_tasks_dict(
             input_tasks=input_tasks
@@ -188,21 +206,7 @@ def test_construct_full_workflow_tasks_dict_from_blockname(workflow_mock):
     with requests_mock.Mocker() as m:
         url_get_blocks = f"{workflow_mock.auth._endpoint()}/blocks"
         m.get(
-            url=url_get_blocks,
-            json={
-                "data": [
-                    {"id": "4ed70368-d4e1-4462-bef6-14e768049471", "name": "tiling"},
-                    {
-                        "id": "c0d04ec3-98d7-4183-902f-5bcb2a176d89",
-                        "name": "sharpening",
-                    },
-                    {
-                        "id": "a2daaab4-196d-4226-a018-a810444dcad1",
-                        "name": "sobloo-s2-l1c-aoiclipped",
-                    },
-                ],
-                "error": {},
-            },
+            url=url_get_blocks, json=json_blocks,
         )
         full_workflow_tasks_dict = workflow_mock._construct_full_workflow_tasks_dict(
             input_tasks=input_tasks

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -175,34 +175,20 @@ def test_construct_full_workflow_tasks_dict_unkwown_block_raises(workflow_mock):
             workflow_mock._construct_full_workflow_tasks_dict(input_tasks=input_tasks)
 
 
-def test_construct_full_workflow_tasks_dict(workflow_mock):
-    input_tasks = [
-        "a2daaab4-196d-4226-a018-a810444dcad1",
-        "4ed70368-d4e1-4462-bef6-14e768049471",
-    ]
-    with requests_mock.Mocker() as m:
-        url_get_blocks = f"{workflow_mock.auth._endpoint()}/blocks"
-        m.get(
-            url=url_get_blocks, json=json_blocks,
-        )
-        full_workflow_tasks_dict = workflow_mock._construct_full_workflow_tasks_dict(
-            input_tasks=input_tasks
-        )
-    assert isinstance(full_workflow_tasks_dict, list)
-    assert full_workflow_tasks_dict[0]["name"] == "sobloo-s2-l1c-aoiclipped:1"
-    assert full_workflow_tasks_dict[0]["parentName"] is None
-    assert full_workflow_tasks_dict[1]["name"] == "tiling:1"
-    assert full_workflow_tasks_dict[1]["parentName"] == "sobloo-s2-l1c-aoiclipped:1"
-    assert (
-        full_workflow_tasks_dict[1]["blockId"] == "4ed70368-d4e1-4462-bef6-14e768049471"
-    )
-
-
-def test_construct_full_workflow_tasks_dict_from_blockname(workflow_mock):
-    input_tasks = [
-        "sobloo-s2-l1c-aoiclipped",
-        "tiling",
-    ]
+@pytest.mark.parametrize(
+    "input_tasks",
+    [
+        [
+            "a2daaab4-196d-4226-a018-a810444dcad1",
+            "4ed70368-d4e1-4462-bef6-14e768049471",
+        ],
+        ["sobloo-s2-l1c-aoiclipped", "tiling"],
+        ["Sentinel-2 L1C MSI AOI clipped", "Raster Tiling",],
+        ["a2daaab4-196d-4226-a018-a810444dcad1", "tiling",],
+        ["Sentinel-2 L1C MSI AOI clipped", "4ed70368-d4e1-4462-bef6-14e768049471",],
+    ],
+)
+def test_construct_full_workflow_tasks_dict(workflow_mock, input_tasks):
     with requests_mock.Mocker() as m:
         url_get_blocks = f"{workflow_mock.auth._endpoint()}/blocks"
         m.get(

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -180,6 +180,43 @@ def test_construct_full_workflow_tasks_dict(workflow_mock):
     )
 
 
+def test_construct_full_workflow_tasks_dict_from_blockname(workflow_mock):
+    input_tasks = [
+        "sobloo-s2-l1c-aoiclipped",
+        "tiling",
+    ]
+    with requests_mock.Mocker() as m:
+        url_get_blocks = f"{workflow_mock.auth._endpoint()}/blocks"
+        m.get(
+            url=url_get_blocks,
+            json={
+                "data": [
+                    {"id": "4ed70368-d4e1-4462-bef6-14e768049471", "name": "tiling"},
+                    {
+                        "id": "c0d04ec3-98d7-4183-902f-5bcb2a176d89",
+                        "name": "sharpening",
+                    },
+                    {
+                        "id": "a2daaab4-196d-4226-a018-a810444dcad1",
+                        "name": "sobloo-s2-l1c-aoiclipped",
+                    },
+                ],
+                "error": {},
+            },
+        )
+        full_workflow_tasks_dict = workflow_mock._construct_full_workflow_tasks_dict(
+            input_tasks=input_tasks
+        )
+    assert isinstance(full_workflow_tasks_dict, list)
+    assert full_workflow_tasks_dict[0]["name"] == "sobloo-s2-l1c-aoiclipped:1"
+    assert full_workflow_tasks_dict[0]["parentName"] is None
+    assert full_workflow_tasks_dict[1]["name"] == "tiling:1"
+    assert full_workflow_tasks_dict[1]["parentName"] == "sobloo-s2-l1c-aoiclipped:1"
+    assert (
+        full_workflow_tasks_dict[1]["blockId"] == "4ed70368-d4e1-4462-bef6-14e768049471"
+    )
+
+
 @pytest.mark.skip
 # TODO: Resolve
 def test_add_workflow_tasks_full(workflow_mock, caplog):

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -318,7 +318,10 @@ class Tools:
             block_type = block_type.lower()
         except AttributeError:
             pass
-
+        if not hasattr(self, "auth"):
+            raise Exception(
+                "Requires authentication with UP42, use up42.authenticate()!"
+            )
         url = f"{self.auth._endpoint()}/blocks"
         response_json = self.auth._request(request_type="GET", url=url)
         public_blocks_json = response_json["data"]
@@ -364,6 +367,10 @@ class Tools:
         Returns:
             A dict of the block details metadata for the specific block.
         """
+        if not hasattr(self, "auth"):
+            raise Exception(
+                "Requires authentication with UP42, use up42.authenticate()!"
+            )
         url = f"{self.auth._endpoint()}/blocks/{block_id}"  # public blocks
         response_json = self.auth._request(request_type="GET", url=url)
         details_json = response_json["data"]
@@ -429,6 +436,10 @@ class Tools:
                 manifest_json = json.load(src)
         else:
             manifest_json = path_or_json
+        if not hasattr(self, "auth"):
+            raise Exception(
+                "Requires authentication with UP42, use up42.authenticate()!"
+            )
         url = f"{self.auth._endpoint()}/validate-schema/block"
         response_json = self.auth._request(
             request_type="POST", url=url, data=manifest_json

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -100,6 +100,7 @@ class Workflow(Tools):
     ) -> List[Dict]:
         """
         Constructs the full workflow task definition from a simplified version.
+        Accepts blocks ids, block names, block display names & combinations of them.
 
         Args:
             input_tasks: List of block names, block ids, oder block display names.
@@ -160,7 +161,8 @@ class Workflow(Tools):
 
         # All all following (processing) blocks.
         for block_id in input_tasks_ids[1:]:
-            # Check if multiple of the same block are in the input tasks definition.
+            # Check if multiple of the same block are in the input tasks definition,
+            # so that is does not get skipped as it has the same id.
             counts = Counter([x["blockId"] for x in full_input_tasks_definition])
             try:
                 count_block = int(counts[block_id]) + 1
@@ -176,24 +178,33 @@ class Workflow(Tools):
             previous_task_name = next_task["name"]
         return full_input_tasks_definition
 
-    def add_workflow_tasks(self, input_tasks: Union[List, List[Dict]]) -> None:
+    def add_workflow_tasks(self, input_tasks: Union[List[str], List[Dict]]) -> None:
         """
         Adds or overwrites workflow tasks in a workflow on UP42.
 
         Args:
-            input_tasks: The input tasks, can be provided in the simplified (list of block ids,
-                is automatically transformed to the full version) or full version
-                (dict of block id, block name and parent block name).
-                - Name is arbitrary but best use the block name. Always use :1 to be able to
-                    identify the order when two times the same workflow task is used.
-                - API by itself validates if the underlying block for the selected block-id is
-                    available.
+            input_tasks: The input tasks (a list of block ids, block names or block
+                display names.
 
         Example:
             ```python
             input_tasks_simple = ['a2daaab4-196d-4226-a018-a810444dcad1',
                                   '4ed70368-d4e1-4462-bef6-14e768049471']
             ```
+
+            ```python
+            input_tasks = ["a2daaab4-196d-4226-a018-a810444dcad1",
+                           "4ed70368-d4e1-4462-bef6-14e768049471"]
+            ```
+
+            ```python
+            input_tasks = ["Sentinel-2 L1C MSI AOI clipped",
+                           "Raster Tiling"]
+
+        Optional: The input_tasks can also be provided as the full, detailed workflow task
+        definition (dict of block id, block name and parent block name). Always use :1
+        to be able to identify the order when two times the same workflow task is used.
+        The name is arbitrary, but best use the block name.
 
         Example:
             ```python
@@ -205,7 +216,6 @@ class Workflow(Tools):
                                  'blockId': '4ed70368-d4e1-4462-bef6-14e768049471'}]
             ```
         """
-        # TODO: User should be able to only provide block task names or display name.
         # Construct proper task definition from simplified input.
         if isinstance(input_tasks[0], str) and not isinstance(input_tasks[0], dict):
             input_tasks = self._construct_full_workflow_tasks_dict(input_tasks)

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -184,7 +184,7 @@ class Workflow(Tools):
 
         Args:
             input_tasks: The input tasks (a list of block ids, block names or block
-                display names.
+                display names. Use up42.get_blocks() to see these options.
 
         Example:
             ```python
@@ -200,6 +200,7 @@ class Workflow(Tools):
             ```python
             input_tasks = ["Sentinel-2 L1C MSI AOI clipped",
                            "Raster Tiling"]
+
 
         Optional: The input_tasks can also be provided as the full, detailed workflow task
         definition (dict of block id, block name and parent block name). Always use :1

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -103,7 +103,7 @@ class Workflow(Tools):
         Accepts blocks ids, block names, block display names & combinations of them.
 
         Args:
-            input_tasks: List of block names, block ids, oder block display names.
+            input_tasks: List of block names, block ids, or block display names.
 
         Returns:
             The full workflow task definition.
@@ -183,8 +183,14 @@ class Workflow(Tools):
         Adds or overwrites workflow tasks in a workflow on UP42.
 
         Args:
-            input_tasks: The input tasks (a list of block ids, block names or block
-                display names. Use up42.get_blocks() to see these options.
+            input_tasks: The input tasks, specifying the blocks. Can be a list of the
+                block ids, block names or block display names (The name shown on the
+                [marketplace](https://marketplace.up42.com).
+
+        !!! Info
+            Using block ids specifies a specific version of the block that will be added
+            to the workflow. With block names or block display names, the most recent
+            version of a block will always be added.
 
         Example:
             ```python

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -102,32 +102,45 @@ class Workflow(Tools):
         Constructs the full workflow task definition from a simplified version.
 
         Args:
-            input_tasks: List of workflow task ids, see example.
+            input_tasks: List of block names, block ids, oder block display names.
 
         Returns:
             The full workflow task definition.
 
         Example:
-            ```json
+            ```python
+            input_tasks = ["sobloo-s2-l1c-aoiclipped",
+                           "tiling"]
+            ```
+
+            ```python
             input_tasks = ["a2daaab4-196d-4226-a018-a810444dcad1",
                            "4ed70368-d4e1-4462-bef6-14e768049471"]
+            ```
+
+            ```python
+            input_tasks = ["Sentinel-2 L1C MSI AOI clipped",
+                           "Raster Tiling"]
             ```
         """
         full_input_tasks_definition = []
 
         # Get public + custom blocks.
         logging.getLogger("up42.tools").setLevel(logging.CRITICAL)
-        blocks_name_id: Dict = self.get_blocks(basic=True)  # type: ignore
+        blocks: Dict = self.get_blocks(basic=False)  # type: ignore
         logging.getLogger("up42.tools").setLevel(logging.INFO)
-        blocks_id_name = {
-            value: key for key, value in blocks_name_id.items()
-        }  # pylint: disable=
+        block_names = [block["name"] for block in blocks]
+        block_ids = [block["id"] for block in blocks]
+        block_display_names = [block["displayName"] for block in blocks]
+
         for task in input_tasks:
-            if task not in blocks_id_name:
-                raise Exception(
+            if task not in block_names + block_ids + block_display_names:
+                raise ValueError(
                     f"The specified input task {task} does not match any "
                     f"available block."
                 )
+
+        blocks_id_name = {value: key for key, value in blocks_name_id.items()}
 
         first_task = {
             "name": f"{blocks_id_name[input_tasks[0]]}:1",

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -193,8 +193,7 @@ class Workflow(Tools):
             ```
 
             ```python
-            input_tasks = ["a2daaab4-196d-4226-a018-a810444dcad1",
-                           "4ed70368-d4e1-4462-bef6-14e768049471"]
+            input_tasks = ["sobloo-s2-l1c-aoiclipped", "tiling"]
             ```
 
             ```python


### PR DESCRIPTION
Enables to add workflow tasks by block_name & block_display_name (in addition to block_id) or combinations.

            input_tasks = ['a2daaab4-196d-4226-a018-a810444dcad1',
                                  '4ed70368-d4e1-4462-bef6-14e768049471']

            input_tasks = ["sobloo-s2-l1c-aoiclipped", "tiling"]

            input_tasks = ["Sentinel-2 L1C MSI AOI clipped",
                           "Raster Tiling"]

Makes the docs examples a bit clearer as `[blocks['sobloo-s2-l1c-aoiclipped'], blocks['sharpening']]` is no longer required, will adjust later.