### PR TITLE
Avoid provider arg catalog quicklook

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -43,7 +43,7 @@ catalog.plot_coverage(scenes=search_results,
 
 
 ```python
-catalog.download_quicklooks(image_ids=search_results.id.to_list(), provider="oneatlas")
+catalog.download_quicklooks(image_ids=search_results.id.to_list(), sensor="pleiades")
 ```
 
 

--- a/examples/catalog.ipynb
+++ b/examples/catalog.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catalog.download_quicklooks(image_ids=search_results.id.to_list(), provider=\"oneatlas\")"
+    "catalog.download_quicklooks(image_ids=search_results.id.to_list(), sensor=\"pleiades\")"
    ]
   },
   {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,8 @@ mkdocs-minify-plugin
 mkdocstrings
 black
 requests-mock
-pytest==2.5.0
+pylint==2.5.0
+pytest
 pytest-pylint
 pytest-sugar
 mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ mkdocs-minify-plugin
 mkdocstrings
 black
 requests-mock
-pytest
+pytest==2.5.0
 pytest-pylint
 pytest-sugar
 mypy

--- a/tests/mock_data/search_params_simple.json
+++ b/tests/mock_data/search_params_simple.json
@@ -16,7 +16,9 @@
     "query": {
         "cloudCoverage": {"lte": 20},
         "dataBlock": {
-            "in": ["oneatlas-pleiades-fullscene", "oneatlas-pleiades-aoiclipped"]
+            "in": ["oneatlas-pleiades-fullscene", "oneatlas-pleiades-aoiclipped",
+                   "oneatlas-spot-fullscene", "oneatlas-spot-aoiclipped",
+                   "sobloo-sentinel1-l1c-grd-full", "sobloo-sentinel1-l1c-grd-aoiclipped", "sobloo-sentinel1-l1c-slc-full"]
         }
     },
     "sortby": [{"field": "properties.cloudCoverage", "direction": "desc"}]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -27,7 +27,7 @@ def test_construct_parameters(catalog_mock):
         geometry=mock_search_parameters["intersects"],
         start_date="2014-01-01",
         end_date="2016-12-31",
-        sensors=["pleiades"],
+        sensors=["pleiades", "spot", "sentinel1"],
         max_cloudcover=20,
         sortby="cloudCoverage",
         limit=4,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -105,7 +105,7 @@ def test_download_quicklook(catalog_mock):
             m.get(url, content=open(quicklook_file, "rb").read())
 
             out_paths = catalog_mock.download_quicklooks(
-                [sel_id], output_directory=tempdir
+                image_ids=[sel_id], sensor="pleiades", output_directory=tempdir
             )
 
         assert len(out_paths) == 1
@@ -117,7 +117,9 @@ def test_download_quicklook(catalog_mock):
 def test_download_quicklook_live(catalog_live):
     with tempfile.TemporaryDirectory() as tempdir:
         out_paths = catalog_live.download_quicklooks(
-            ["6dffb8be-c2ab-46e3-9c1c-6958a54e4527"], output_directory=tempdir
+            image_ids=["6dffb8be-c2ab-46e3-9c1c-6958a54e4527"],
+            sensor="pleiades",
+            output_directory=tempdir,
         )
         assert len(out_paths) == 1
         assert Path(out_paths[0]).exists()

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -41,11 +41,11 @@ def initialize_project() -> "Project":
     return Project(auth=_auth, project_id=_auth.project_id)
 
 
-def initialize_catalog(backend: str = "ONE_ATLAS") -> "Catalog":
+def initialize_catalog() -> "Catalog":
     """Directly returns a Catalog object."""
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
-    return Catalog(auth=_auth, backend=backend)
+    return Catalog(auth=_auth)
 
 
 def initialize_workflow(workflow_id) -> "Workflow":

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -51,7 +51,7 @@ supported_sensors = {
 
 # pylint: disable=duplicate-code
 class Catalog(Tools):
-    def __init__(self, auth: Auth, backend: str = "ONE_ATLAS"):
+    def __init__(self, auth: Auth):
         """The Catalog class enables access to the UP42 catalog search. You can search
         for satellite image scenes for different sensors and criteria like cloud cover etc.
 
@@ -59,11 +59,10 @@ class Catalog(Tools):
             construct_parameters, search, download_quicklooks
         """
         self.auth = auth
-        self.querystring = {"backend": backend}
         self.quicklooks = None
 
     def __repr__(self):
-        return f"Catalog(querystring={self.querystring}, auth={self.auth})"
+        return f"Catalog(auth={self.auth})"
 
     # pylint: disable=dangerous-default-value
     @staticmethod
@@ -173,9 +172,7 @@ class Catalog(Tools):
         """
         logger.info("Searching catalog with: %r", search_paramaters)
         url = f"{self.auth._endpoint()}/catalog/stac/search"
-        response_json = self.auth._request(
-            "POST", url, search_paramaters, self.querystring  # TODO
-        )
+        response_json = self.auth._request("POST", url, search_paramaters)
         logger.info("%d results returned.", len(response_json["features"]))
         # UP42 results are always in EPSG 4326
         dst_crs = "EPSG:4326"

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -24,11 +24,11 @@ supported_sensors = {
         "provider": "oneatlas",
     },
     "spot": {
-        "block": ["oneatlas-spot-fullscene", "oneatlas-spot-aoiclipped",],
+        "blocks": ["oneatlas-spot-fullscene", "oneatlas-spot-aoiclipped",],
         "provider": "oneatlas",
     },
     "sentinel1": {
-        "block": [
+        "blocks": [
             "sobloo-sentinel1-l1c-grd-full",
             "sobloo-sentinel1-l1c-grd-aoiclipped",
             "sobloo-sentinel1-l1c-slc-full",
@@ -174,7 +174,7 @@ class Catalog(Tools):
         logger.info("Searching catalog with: %r", search_paramaters)
         url = f"{self.auth._endpoint()}/catalog/stac/search"
         response_json = self.auth._request(
-            "POST", url, search_paramaters, self.querystring
+            "POST", url, search_paramaters, self.querystring  # TODO
         )
         logger.info("%d results returned.", len(response_json["features"]))
         # UP42 results are always in EPSG 4326

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -220,9 +220,9 @@ class Catalog(Tools):
         output_directory: Union[str, Path, None] = None,
     ) -> List[str]:
         """
-        Gets the quicklooks of scenes, from oneatlas.
+        Gets the quicklooks of scenes from a single sensor. After download, can
+        be plotted via catalog.plot_quicklooks().
 
-        After download, can be plotted via catalog.plot_quicklooks().
         Args:
             image_ids: provider image_id in the form "6dffb8be-c2ab-46e3-9c1c-6958a54e4527"
             sensors: The satellite sensor(s) to search for, one of


### PR DESCRIPTION
- Instead of the image `provider` the user selects the `sensor` as argument for download_quicklooks. Much easier as the sensor needs to be specified for catalog search anyway and the user might not know about the provider. 
- Also removes the backend string as not required.
