### PR TITLE
Get jobs for projects

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -416,7 +416,22 @@ def test_get_jobs(workflow_mock):
             f"{workflow_mock.auth._endpoint()}/projects/{workflow_mock.project_id}/jobs"
         )
         json_jobs = {
-            "data": [{"id": job_id, "status": "SUCCEEDED", "inputs": {}, "error": {},}]
+            "data": [
+                {
+                    "id": job_id,
+                    "status": "SUCCEEDED",
+                    "inputs": {},
+                    "error": {},
+                    "workflowId": "123456",
+                },
+                {
+                    "id": job_id,
+                    "status": "SUCCEEDED",
+                    "inputs": {},
+                    "error": {},
+                    "workflowId": workflow_mock.workflow_id,
+                },
+            ]
         }
         m.get(url=url_jobs, json=json_jobs)
 
@@ -430,6 +445,9 @@ def test_get_jobs(workflow_mock):
         assert isinstance(jobs, list)
         assert isinstance(jobs[0], up42.Job)
         assert jobs[0].job_id == job_id
+        assert (
+            len(jobs) == 1
+        )  # Filters out the job that is not associated with the workflow object
 
 
 @pytest.mark.skip

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -5,7 +5,7 @@ import requests_mock
 import shapely
 
 # pylint: disable=unused-import,wrong-import-order
-from .context import Workflow
+from .context import Workflow, Job
 from .fixtures import auth_mock, auth_live, workflow_mock, workflow_live, job_mock
 import up42
 
@@ -375,7 +375,7 @@ def test_run_job(workflow_mock, job_mock):
         )
 
         jb = workflow_mock.run_job(input_parameters_json)
-        assert isinstance(jb, up42.Job)
+        assert isinstance(jb, Job)
         assert jb.job_id == job_mock.job_id
 
 
@@ -387,7 +387,7 @@ def test_test_job_live(workflow_live):
     jb = workflow_live.test_job(
         input_parameters=input_parameters_json, track_status=True
     )
-    assert isinstance(jb, up42.Job)
+    assert isinstance(jb, Job)
     with open(input_parameters_json) as src:
         job_info_params = json.load(src)
         job_info_params.update({"config": {"mode": "DRY_RUN"}})
@@ -402,7 +402,7 @@ def test_run_job_live(workflow_live):
         Path(__file__).resolve().parent / "mock_data/input_params_simple.json"
     )
     jb = workflow_live.run_job(input_parameters_json, track_status=True)
-    assert isinstance(jb, up42.Job)
+    assert isinstance(jb, Job)
     with open(input_parameters_json) as src:
         assert jb.info["inputs"] == json.load(src)
         assert jb.info["mode"] == "DEFAULT"
@@ -443,20 +443,21 @@ def test_get_jobs(workflow_mock):
 
         jobs = workflow_mock.get_jobs()
         assert isinstance(jobs, list)
-        assert isinstance(jobs[0], up42.Job)
+        assert isinstance(jobs[0], Job)
         assert jobs[0].job_id == job_id
         assert (
             len(jobs) == 1
         )  # Filters out the job that is not associated with the workflow object
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 @pytest.mark.live
 def test_get_jobs_live(workflow_live):
-    # Too many jobs in test project
+    # Skip by default as too many jobs in test project, triggers too many job info requests.
     jobs = workflow_live.get_jobs()
     assert isinstance(jobs, list)
-    assert isinstance(jobs[0], up42.Job)
+    assert isinstance(jobs[0], Job)
+    assert all([j["info"]["workflowId"] == workflow_live.workflow_id for j in jobs])
 
 
 # TODO: Resolve

--- a/up42/project.py
+++ b/up42/project.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Union
 from tqdm import tqdm
 
 from .auth import Auth
+from .job import Job
 from .tools import Tools
 from .utils import get_logger
 from .workflow import Workflow
@@ -18,7 +19,7 @@ class Project(Tools):
         within an UP42 project. Also handles project user settings.
 
         Public Methods:
-            create_workflow, get_workflows, get_project_settings,
+            create_workflow, get_workflows, get_jobs, get_project_settings,
             update_project_settings
         """
         self.auth = auth
@@ -109,6 +110,33 @@ class Project(Tools):
                 for work in tqdm(workflows_json)
             ]
             return workflows
+
+    def get_jobs(self, return_json: bool = False) -> Union[List["Job"], Dict]:
+        """
+        Get all jobs in the project as job objects or json.
+
+        Use Workflow().get_job() to get jobs associated with a specific workflow.
+
+        Args:
+            return_json: If true, returns the job info jsons instead of job objects.
+
+        Returns:
+            All job objects as a list, or alternatively the jobs info as json.
+        """
+        url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs"
+        response_json = self.auth._request(request_type="GET", url=url)
+        jobs_json = response_json["data"]
+        logger.info(
+            "Got %s jobs in project %s.", len(jobs_json), self.project_id,
+        )
+        if return_json:
+            return jobs_json
+        else:
+            jobs = [
+                Job(self.auth, job_id=job["id"], project_id=self.project_id)
+                for job in tqdm(jobs_json)
+            ]
+            return jobs
 
     def get_project_settings(self) -> List:
         """

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -442,7 +442,7 @@ class Workflow(Tools):
 
     def get_jobs(self, return_json: bool = False) -> Union[List["Job"], Dict]:
         """
-        Get all jobs in the specific project as job objects or json.
+        Get all jobs associated with the workflow as job objects or json.
 
         Args:
             return_json: If true, returns the job info jsons instead of job objects.
@@ -453,18 +453,23 @@ class Workflow(Tools):
         url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs"
         response_json = self.auth._request(request_type="GET", url=url)
         jobs_json = response_json["data"]
+
+        jobs_workflow_json = [
+            j for j in jobs_json if j["workflowId"] == self.workflow_id
+        ]
+
         logger.info(
             "Got %s jobs for workflow %s in project %s.",
-            len(jobs_json),
+            len(jobs_workflow_json),
             self.workflow_id,
             self.project_id,
         )
         if return_json:
-            return jobs_json
+            return jobs_workflow_json
         else:
             jobs = [
                 Job(self.auth, job_id=job["id"], project_id=self.project_id)
-                for job in tqdm(jobs_json)
+                for job in tqdm(jobs_workflow_json)
             ]
             return jobs
 


### PR DESCRIPTION
- Adds Project().get_jobs() as getjob is actually unrelated to workflow and should be accessible at this level.
- Adds a filter to Workflow.get_jobs() to only return the jobs that are associated with the workflow object.