### PR TITLE
Use warped vrt for .map_results

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">75%</text>
-        <text x="80" y="14">75%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
+        <text x="80" y="14">77%</text>
     </g>
 </svg>

--- a/tests/context.py
+++ b/tests/context.py
@@ -12,7 +12,6 @@ from up42.utils import (
     any_vector_to_fc,
     fc_to_query_geometry,
     download_results_from_gcs,
-    read_raster_4326,
 )
 from up42.auth import Auth
 from up42.project import Project

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 import tempfile
-import tarfile
 
 import folium
 import geopandas as gpd
@@ -10,14 +9,12 @@ import pandas as pd
 import pytest
 from shapely.geometry import Point, Polygon, LinearRing
 import requests_mock
-import numpy as np
 
 from .context import (
     folium_base_map,
     any_vector_to_fc,
     fc_to_query_geometry,
     download_results_from_gcs,
-    read_raster_4326,
 )
 
 
@@ -273,21 +270,3 @@ def test_download_result_from_gcs():
             for file in out_files:
                 assert Path(file).exists()
             assert len(out_files) == 2
-
-
-def test_read_raster_4326():
-    fp_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
-
-    with tarfile.open(fp_tgz) as tar:
-        tar.extractall(fp_tgz.parent)
-
-    fp_tif = (
-        fp_tgz.parent
-        / "output/7e17f023-a8e3-43bd-aaac-5bbef749c7f4/7e17f023-a8e3-43bd-aaac-5bbef749c7f4_0-0.tif"
-    )
-
-    dst_array, dst_bounds = read_raster_4326(raster_fp=fp_tif)
-    assert isinstance(dst_array, np.ndarray)
-    assert isinstance(dst_bounds, tuple)
-    expected_4326_bounds = [13.359375, 52.48276179, 13.42531088, 52.52290594]
-    assert np.isclose(np.array(dst_bounds), np.array(expected_4326_bounds)).all()


### PR DESCRIPTION
- Uses rasterio warped vrt to ensure required crs, removes `read_raster_4326`from utils. Had totally forgotten about it.
- Adds mock test .map_results().