### PR TITLE
Add parameters mapping

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">76%</text>
-        <text x="80" y="14">76%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
+        <text x="80" y="14">77%</text>
     </g>
 </svg>

--- a/docs/reference/jobcollection.md
+++ b/docs/reference/jobcollection.md
@@ -1,0 +1,3 @@
+# Job class
+
+::: up42.jobcollection.JobCollection

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
         - Project: reference/project.md
         - Workflow: reference/workflow.md
         - Job: reference/job.md
+        - JobCollection: reference/jobcollection.md
         - JobTask: reference/jobtask.md
         - Catalog: reference/catalog.md
         - Tools: reference/tools.md

--- a/tests/context.py
+++ b/tests/context.py
@@ -17,6 +17,7 @@ from up42.auth import Auth
 from up42.project import Project
 from up42.workflow import Workflow
 from up42.job import Job
+from up42.jobcollection import JobCollection
 from up42.jobtask import JobTask
 from up42.catalog import Catalog
 from up42.__init__ import (

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,7 +3,16 @@ import os
 import pytest
 import requests_mock
 
-from .context import Auth, Project, Workflow, Job, JobTask, Tools, Catalog
+from .context import (
+    Auth,
+    Project,
+    Workflow,
+    Job,
+    JobCollection,
+    JobTask,
+    Tools,
+    Catalog,
+)
 
 # TODO: Use patch.dict instead of 2 fictures?
 @pytest.fixture()
@@ -102,6 +111,13 @@ def job_mock(auth_mock):
 
         job = Job(auth=auth_mock, project_id=auth_mock.project_id, job_id=job_id)
     return job
+
+
+@pytest.fixture()
+def jobcollection_mock(auth_mock, job_mock):
+    return JobCollection(
+        auth=auth_mock, project_id=auth_mock.project_id, jobs=[job_mock]
+    )
 
 
 @pytest.fixture()

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -1,0 +1,6 @@
+# pylint: disable=unused-import,wrong-import-order
+from .fixtures import auth_mock, job_mock, jobcollection_mock
+
+
+def test_jobcollection(jobcollection_mock):
+    assert len(jobcollection_mock.jobs) == 1

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -422,6 +422,23 @@ def test_construct_parameters_parallel(workflow_mock):
     }
 
 
+def test_construct_parameters_parallel_scene_ids(workflow_mock):
+    url_workflow_tasks = (
+        f"{workflow_mock.auth._endpoint()}/projects/{workflow_mock.auth.project_id}/workflows/"
+        f"{workflow_mock.workflow_id}/tasks"
+    )
+    with requests_mock.Mocker() as m:
+        m.get(url=url_workflow_tasks, json=json_workflow_tasks)
+
+        parameters_list = workflow_mock.construct_parameters_parallel(
+            scene_ids=["S2abc", "S2123"]
+        )
+    assert parameters_list[0] == {
+        "sobloo-s2-l1c-aoiclipped:1": {"scene_ids": ["S2abc"]},
+        "tiling:1": {"tile_width": 768},
+    }
+
+
 def test_run_job(workflow_mock, job_mock):
     with requests_mock.Mocker() as m:
         job_name = f"{workflow_mock.info['name']}_py"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -375,7 +375,7 @@ def test_construct_parameter_order_ids(workflow_mock):
     }
 
 
-def test_mapping_to_params(workflow_mock):
+def test_construct_parameters_parallel(workflow_mock):
     url_workflow_tasks = (
         f"{workflow_mock.auth._endpoint()}/projects/{workflow_mock.auth.project_id}/workflows/"
         f"{workflow_mock.workflow_id}/tasks"
@@ -383,7 +383,7 @@ def test_mapping_to_params(workflow_mock):
     with requests_mock.Mocker() as m:
         m.get(url=url_workflow_tasks, json=json_workflow_tasks)
 
-        parameters_list = workflow_mock.mapping_to_parameters(
+        parameters_list = workflow_mock.construct_parameters_parallel(
             geometries=[
                 Feature(geometry=shapely.geometry.point.Point(1, 3)),
                 Feature(geometry=shapely.geometry.point.Point(1, 5)),
@@ -404,7 +404,7 @@ def test_mapping_to_params(workflow_mock):
     with requests_mock.Mocker() as m:
         m.get(url=url_workflow_tasks, json=json_workflow_tasks)
 
-        parameters_list = workflow_mock.mapping_to_parameters(
+        parameters_list = workflow_mock.construct_parameters_parallel(
             geometries=[
                 shapely.geometry.point.Point(1, 3),
                 shapely.geometry.point.Point(1, 5),

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -388,10 +388,18 @@ def test_mapping_to_params(workflow_mock):
                 Feature(geometry=shapely.geometry.point.Point(1, 3)),
                 Feature(geometry=shapely.geometry.point.Point(1, 5)),
             ],
-            time_series=["2014-01-01T00:00:00Z/2016-12-31T00:00:00Z"],
+            time_series=[("2014-01-01", "2016-12-31")],
         )
     assert isinstance(parameters_list, list)
     assert len(parameters_list) == 2
+    assert parameters_list[0] == {
+        "sobloo-s2-l1c-aoiclipped:1": {
+            "time": "2014-01-01T00:00:00Z/2016-12-31T00:00:00Z",
+            "limit": 1,
+            "intersects": {"coordinates": (1.0, 3.0), "type": "Point"},
+        },
+        "tiling:1": {"tile_width": 768},
+    }
 
 
 def test_run_job(workflow_mock, job_mock):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -388,7 +388,7 @@ def test_mapping_to_params(workflow_mock):
                 Feature(geometry=shapely.geometry.point.Point(1, 3)),
                 Feature(geometry=shapely.geometry.point.Point(1, 5)),
             ],
-            time_series=[("2014-01-01", "2016-12-31")],
+            interval_dates=[("2014-01-01", "2016-12-31")],
         )
     assert isinstance(parameters_list, list)
     assert len(parameters_list) == 2
@@ -409,7 +409,7 @@ def test_mapping_to_params(workflow_mock):
                 shapely.geometry.point.Point(1, 3),
                 shapely.geometry.point.Point(1, 5),
             ],
-            time_series=[("2014-01-01", "2016-12-31")],
+            interval_dates=[("2014-01-01", "2016-12-31")],
             geometry_operation="bbox",
         )
     assert parameters_list[0] == {

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -461,7 +461,7 @@ def test_construct_parameters_parallel_scene_ids(workflow_mock):
         )
     assert len(parameters_list) == 2
     assert parameters_list[0] == {
-        "sobloo-s2-l1c-aoiclipped:1": {"scene_ids": ["S2abc"]},
+        "sobloo-s2-l1c-aoiclipped:1": {"ids": ["S2abc"], "limit": 1},
         "tiling:1": {"tile_width": 768},
     }
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -401,6 +401,26 @@ def test_mapping_to_params(workflow_mock):
         "tiling:1": {"tile_width": 768},
     }
 
+    with requests_mock.Mocker() as m:
+        m.get(url=url_workflow_tasks, json=json_workflow_tasks)
+
+        parameters_list = workflow_mock.mapping_to_parameters(
+            geometries=[
+                shapely.geometry.point.Point(1, 3),
+                shapely.geometry.point.Point(1, 5),
+            ],
+            time_series=[("2014-01-01", "2016-12-31")],
+            geometry_operation="bbox",
+        )
+    assert parameters_list[0] == {
+        "sobloo-s2-l1c-aoiclipped:1": {
+            "time": "2014-01-01T00:00:00Z/2016-12-31T00:00:00Z",
+            "limit": 1,
+            "bbox": [0.99999, 2.99999, 1.00001, 3.00001],
+        },
+        "tiling:1": {"tile_width": 768},
+    }
+
 
 def test_run_job(workflow_mock, job_mock):
     with requests_mock.Mocker() as m:

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -1,0 +1,26 @@
+from typing import List
+
+from .auth import Auth
+from .job import Job
+from .tools import Tools
+
+from .utils import get_logger
+
+logger = get_logger(__name__)
+
+# pylint: disable=duplicate-code
+class JobCollection(Tools):
+    def __init__(self, auth: Auth, project_id: str, jobs: List[Job]):
+        """
+        The JobCollection class provides facilities for creating job parameters,
+        running multiple jobs in parallel and merging job results.
+        """
+        self.auth = auth
+        self.project_id = project_id
+        self.jobs = jobs
+
+    def __repr__(self):
+        return (
+            f"JobCollection(jobs={self.jobs}, project_id={self.project_id}, "
+            f"auth={self.auth})"
+        )

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -12,8 +12,8 @@ logger = get_logger(__name__)
 class JobCollection(Tools):
     def __init__(self, auth: Auth, project_id: str, jobs: List[Job]):
         """
-        The JobCollection class provides facilities for creating job parameters,
-        running multiple jobs in parallel and merging job results.
+        The JobCollection class provides facilities for downloading and merging
+        multiple jobs results.
         """
         self.auth = auth
         self.project_id = project_id

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections import Counter
 from pathlib import Path
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Union, Optional, Tuple
 
 from geopandas import GeoDataFrame
 from shapely.geometry import Point, Polygon
@@ -346,18 +346,34 @@ class Workflow(Tools):
         return input_parameters
 
     def mapping_to_parameters(
-        self, geometries: List[Feature], time_series: List[str]
+        self,
+        geometries: List[
+            Union[
+                Dict,
+                Feature,
+                FeatureCollection,
+                geojson_Polygon,
+                List,
+                GeoDataFrame,
+                Polygon,
+                Point,
+            ]
+        ],
+        time_series: List[Tuple[str, str]],
+        limit_per_job: int = 1,
+        geometry_operation: str = "intersects",
     ) -> List[dict]:
         result_params = []
         for geo in geometries:
             # TODO: Fix time_series handling
-            for time in time_series:
+            for start_date, end_date in time_series:
                 result_params.append(
                     self.construct_parameters(
                         geometry=geo,
-                        geometry_operation="intersects",
-                        start_date=time,
-                        end_date=time,
+                        geometry_operation=geometry_operation,
+                        start_date=start_date,
+                        end_date=end_date,
+                        limit=limit_per_job,
                     )
                 )
 

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -351,10 +351,7 @@ class Workflow(Tools):
             Union[
                 Dict,
                 Feature,
-                FeatureCollection,
                 geojson_Polygon,
-                List,
-                GeoDataFrame,
                 Polygon,
                 Point,
             ]

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -351,6 +351,7 @@ class Workflow(Tools):
             List[Union[Dict, Feature, geojson_Polygon, Polygon, Point,]]
         ] = None,
         interval_dates: Optional[List[Tuple[str, str]]] = None,
+        scene_ids: Optional[List] = None,
         limit_per_job: int = 1,
         geometry_operation: str = "intersects",
     ) -> List[dict]:
@@ -362,7 +363,8 @@ class Workflow(Tools):
         Args:
             geometries: List of unit geometries to map with times.
             interval_dates: List of tuples of start and end dates,
-                i.e. `("2014-01-01","2015-01-01")`
+                i.e. `("2014-01-01","2015-01-01")`.
+            scene_ids: List of scene ids. Will be mapped 1:1 to each job. All other arguments are ignored.
             limit_per_job: Limit passed to be passed to each individual job parameter.
             geometry_operation: Geometry operation to be passed to each job parameter.
 
@@ -370,17 +372,28 @@ class Workflow(Tools):
             List of dictionary of constructed input parameters.
         """
         result_params = []
-        for geo in geometries:
-            for start_date, end_date in interval_dates:
+        if scene_ids is not None:
+            for scene_id in scene_ids:
                 result_params.append(
-                    self.construct_parameters(
-                        geometry=geo,
-                        geometry_operation=geometry_operation,
-                        start_date=start_date,
-                        end_date=end_date,
-                        limit=limit_per_job,
-                    )
+                    self.construct_parameters(geometry=None, scene_ids=[scene_id],)
                 )
+
+        elif geometries is not None and interval_dates is not None:
+            for geo in geometries:
+                for start_date, end_date in interval_dates:
+                    result_params.append(
+                        self.construct_parameters(
+                            geometry=geo,
+                            geometry_operation=geometry_operation,
+                            start_date=start_date,
+                            end_date=end_date,
+                            limit=limit_per_job,
+                        )
+                    )
+        else:
+            raise ValueError(
+                "Please provides geometies and time_interval or scene_ids."
+            )
 
         return result_params
 

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -352,7 +352,7 @@ class Workflow(Tools):
         limit_per_job: int = 1,
         geometry_operation: str = "intersects",
     ) -> List[dict]:
-        """"
+        """
         Maps a list of geometries and a list of time series into a list
         of input parameters of a workflow. If you pass 2 geometries and 1 time
         interval this will result in 2 x 1 input parameters.

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -345,6 +345,24 @@ class Workflow(Tools):
                 input_parameters[data_block_name][geometry_operation] = aoi_feature
         return input_parameters
 
+    def mapping_to_parameters(
+        self, geometries: List[Feature], time_series: List[str]
+    ) -> List[dict]:
+        result_params = []
+        for geo in geometries:
+            # TODO: Fix time_series handling
+            for time in time_series:
+                result_params.append(
+                    self.construct_parameters(
+                        geometry=geo,
+                        geometry_operation="intersects",
+                        start_date=time,
+                        end_date=time,
+                    )
+                )
+
+        return result_params
+
     def _helper_run_job(
         self,
         input_parameters: Union[Dict, str, Path] = None,

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -345,10 +345,12 @@ class Workflow(Tools):
                 input_parameters[data_block_name][geometry_operation] = aoi_feature
         return input_parameters
 
-    def mapping_to_parameters(
+    def construct_parameters_parallel(
         self,
-        geometries: List[Union[Dict, Feature, geojson_Polygon, Polygon, Point,]],
-        interval_dates: List[Tuple[str, str]],
+        geometries: Optional[
+            List[Union[Dict, Feature, geojson_Polygon, Polygon, Point,]]
+        ] = None,
+        interval_dates: Optional[List[Tuple[str, str]]] = None,
         limit_per_job: int = 1,
         geometry_operation: str = "intersects",
     ) -> List[dict]:

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -364,7 +364,8 @@ class Workflow(Tools):
             geometries: List of unit geometries to map with times.
             interval_dates: List of tuples of start and end dates,
                 i.e. `("2014-01-01","2015-01-01")`.
-            scene_ids: List of scene ids. Will be mapped 1:1 to each job. All other arguments are ignored.
+            scene_ids: List of scene ids. Will be mapped 1:1 to each job.
+                All other arguments are ignored except geometries if passed.
             limit_per_job: Limit passed to be passed to each individual job parameter.
             geometry_operation: Geometry operation to be passed to each job parameter.
 
@@ -372,13 +373,19 @@ class Workflow(Tools):
             List of dictionary of constructed input parameters.
         """
         result_params = []
-        if scene_ids is not None:
-            for scene_id in scene_ids:
-                result_params.append(
-                    self.construct_parameters(geometry=None, scene_ids=[scene_id],)
-                )
-
-        elif geometries is not None and interval_dates is not None:
+        # scene_ids mapped to geometries
+        if scene_ids is not None and geometries is not None:
+            for geo in geometries:
+                for scene_id in scene_ids:
+                    result_params.append(
+                        self.construct_parameters(
+                            geometry=geo,
+                            scene_ids=[scene_id],
+                            geometry_operation=geometry_operation,
+                        )
+                    )
+        # interval_dates mapped to geometries
+        elif interval_dates is not None and geometries is not None:
             for geo in geometries:
                 for start_date, end_date in interval_dates:
                     result_params.append(
@@ -390,9 +397,16 @@ class Workflow(Tools):
                             limit=limit_per_job,
                         )
                     )
+        # only scene_ids
+        elif scene_ids is not None:
+            for scene_id in scene_ids:
+                result_params.append(
+                    self.construct_parameters(geometry=None, scene_ids=[scene_id],)
+                )
         else:
             raise ValueError(
-                "Please provides geometies and time_interval or scene_ids."
+                "Please provides geometries and scene_ids, geometries"
+                "and time_interval or scene_ids."
             )
 
         return result_params

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -347,23 +347,29 @@ class Workflow(Tools):
 
     def mapping_to_parameters(
         self,
-        geometries: List[
-            Union[
-                Dict,
-                Feature,
-                geojson_Polygon,
-                Polygon,
-                Point,
-            ]
-        ],
-        time_series: List[Tuple[str, str]],
+        geometries: List[Union[Dict, Feature, geojson_Polygon, Polygon, Point,]],
+        interval_dates: List[Tuple[str, str]],
         limit_per_job: int = 1,
         geometry_operation: str = "intersects",
     ) -> List[dict]:
+        """"
+        Maps a list of geometries and a list of time series into a list
+        of input parameters of a workflow. If you pass 2 geometries and 1 time
+        interval this will result in 2 x 1 input parameters.
+
+        Args:
+            geometries: List of unit geometries to map with times.
+            interval_dates: List of tuples of start and end dates,
+                i.e. `("2014-01-01","2015-01-01")`
+            limit_per_job: Limit passed to be passed to each individual job parameter.
+            geometry_operation: Geometry operation to be passed to each job parameter.
+
+        Returns:
+            List of dictionary of constructed input parameters.
+        """
         result_params = []
         for geo in geometries:
-            # TODO: Fix time_series handling
-            for start_date, end_date in time_series:
+            for start_date, end_date in interval_dates:
                 result_params.append(
                     self.construct_parameters(
                         geometry=geo,


### PR DESCRIPTION
This is the first out of three (1/3) PRs intended to provide the parallel job run feature in the python SDK. We will work on the feature branch `add-parallel-jobs` and only when after all 3 PRs are merged we will make a PR to master for deployment.

- [x] Adds JobCollection class (for now not used, will be returned when parallel job run is called)
- [x] Add mapping to parameters function

Handles three cases:

1. Mapping n x Scene IDs with n x Geometries
2. Mapping n x Time Intervals with n x Geometries
3. Mapping n x Scene IDs

Requires merge of https://github.com/up42/up42-py/pull/102 for passing tests.