### PR TITLE
Allow passing of only scene_ids in construct_parameters

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
-        <text x="80" y="14">77%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">76%</text>
+        <text x="80" y="14">76%</text>
     </g>
 </svg>

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -342,6 +342,22 @@ def test_construct_parameter_scene_ids(workflow_mock):
     }
 
 
+def test_construct_parameter_only_ids(workflow_mock):
+    url_workflow_tasks = (
+        f"{workflow_mock.auth._endpoint()}/projects/{workflow_mock.auth.project_id}/workflows/"
+        f"{workflow_mock.workflow_id}/tasks"
+    )
+    with requests_mock.Mocker() as m:
+        m.get(url=url_workflow_tasks, json=json_workflow_tasks)
+
+        parameters = workflow_mock.construct_parameters(scene_ids=["s2_123223"],)
+    assert isinstance(parameters, dict)
+    assert parameters == {
+        "sobloo-s2-l1c-aoiclipped:1": {"ids": ["s2_123223"], "limit": 1},
+        "tiling:1": {"tile_width": 768},
+    }
+
+
 def test_construct_parameter_order_ids(workflow_mock):
     url_workflow_tasks = (
         f"{workflow_mock.auth._endpoint()}/projects/{workflow_mock.auth.project_id}/workflows/"

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -322,6 +322,7 @@ class Workflow(Tools):
         else:
             if limit is not None:
                 input_parameters[data_block_name]["limit"] = limit
+
             if scene_ids is not None:
                 if not isinstance(scene_ids, list):
                     scene_ids = [scene_ids]
@@ -332,14 +333,16 @@ class Workflow(Tools):
             elif start_date is not None and end_date is not None:
                 datetime = f"{start_date}T00:00:00Z/{end_date}T00:00:00Z"
                 input_parameters[data_block_name]["time"] = datetime
-            aoi_fc = any_vector_to_fc(vector=geometry,)
-            aoi_feature = fc_to_query_geometry(
-                fc=aoi_fc,
-                geometry_operation=geometry_operation,  # type: ignore
-                squash_multiple_features=handle_multiple_features,
-            )
 
-            input_parameters[data_block_name][geometry_operation] = aoi_feature
+            if geometry is not None:
+                aoi_fc = any_vector_to_fc(vector=geometry,)
+                aoi_feature = fc_to_query_geometry(
+                    fc=aoi_fc,
+                    geometry_operation=geometry_operation,  # type: ignore
+                    squash_multiple_features=handle_multiple_features,
+                )
+
+                input_parameters[data_block_name][geometry_operation] = aoi_feature
         return input_parameters
 
     def _helper_run_job(


### PR DESCRIPTION
We found in https://github.com/up42/up42-py/pull/101 that the construct parameters is currently not supporting the creation of job parameters that include only scene ids (without a geometry). This change ensures that the parameters are generated even when no geometry is passed.