### PR TITLE
Handle additional geojson output

### DIFF
--- a/up42/job.py
+++ b/up42/job.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Union
 
 import folium
 from geopandas import GeoDataFrame
+import geopandas as gpd
 import numpy as np
 import requests
 import requests.exceptions
@@ -261,9 +262,15 @@ class Job(Tools):
                 "dashArray": "5, 5",
             }
 
-        # Add feature to map.
-        # TODO: Blocks that have results in separate json file.
-        df: GeoDataFrame = self.get_results_json(as_dataframe=True)  # type: ignore
+        # Add features to map.
+        # Some blocks store vector results in an additional geojson.
+        json_fp = [fp for fp in self.results if fp.endswith(".geojson")]
+        if json_fp:
+            json_fp = json_fp[0]
+        else:
+            json_fp = [fp for fp in self.results if fp.endswith(".json")]
+        df: GeoDataFrame = gpd.read_file(json_fp)
+
         centroid = box(*df.total_bounds).centroid
         m = folium_base_map(lat=centroid.y, lon=centroid.x,)
 

--- a/up42/job.py
+++ b/up42/job.py
@@ -238,9 +238,10 @@ class Job(Tools):
 
         Args:
             show_images: Shows images if True (default), only features if False.
-            name_column: Name of the column that provides the Feature/Layer name.
-        # TODO: Make generic with scene_id column integrated.
+            name_column: Name of the feature property that provides the Feature/Layer name.
         """
+        # TODO: Make generic with scene_id column integrated.
+        # TODO: Add way to also display data block image together with processing output vectors
         if self.results is None:
             raise ValueError(
                 "You first need to download the results via job.download_results()!"
@@ -263,12 +264,12 @@ class Job(Tools):
             }
 
         # Add features to map.
-        # Some blocks store vector results in an additional geojson.
+        # Some blocks store vector results in an additional geojson file.
         json_fp = [fp for fp in self.results if fp.endswith(".geojson")]
         if json_fp:
             json_fp = json_fp[0]
         else:
-            json_fp = [fp for fp in self.results if fp.endswith(".json")]
+            json_fp = [fp for fp in self.results if fp.endswith(".json")][0]
         df: GeoDataFrame = gpd.read_file(json_fp)
 
         centroid = box(*df.total_bounds).centroid

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -229,7 +229,7 @@ def _plot_images(
     ]
     if not imagepaths:
         raise ValueError(
-            f"Only files of the formats {plot_file_format} can " "currently be plotted."
+            f"This function only plots files of format {plot_file_format}."
         )
 
     if not titles:


### PR DESCRIPTION
Adds support for the additional geojson file of some blocks (ship-identification etc.) to `.map_results()`. If a dedicated geojson file exists in the output files this is picked over the data.json for visualization.

![image](https://user-images.githubusercontent.com/12833517/87477426-62650300-c628-11ea-8cc2-acfe308f7ea7.png)
