### PR TITLE
Job collection improvements

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -130,19 +130,19 @@ def test_get_jobs(project_mock):
         )
         m.get(url=url_job_info, json={"data": {"xyz": 789}, "error": {}})
 
-        jobs = project_mock.get_jobs()
-        assert isinstance(jobs, list)
-        assert isinstance(jobs[0], Job)
-        assert jobs[0].job_id == job_id
+        jobcollection = project_mock.get_jobs()
+        assert isinstance(jobcollection.jobs, list)
+        assert isinstance(jobcollection.jobs[0], Job)
+        assert jobcollection.jobs[0].job_id == job_id
 
 
 @pytest.mark.skip
 @pytest.mark.live
 def test_get_jobs_live(project_live):
     # Skip by default as too many jobs in test project, triggers too many job info requests.
-    jobs = project_live.get_jobs()
-    assert isinstance(jobs, list)
-    assert isinstance(jobs[0], Job)
+    jobcollection = project_live.get_jobs()
+    assert isinstance(jobcollection.jobs, list)
+    assert isinstance(jobcollection.jobs[0], Job)
 
 
 def test_get_project_settings(project_mock):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -674,12 +674,12 @@ def test_get_jobs(workflow_mock):
         )
         m.get(url=url_job_info, json={"data": {"xyz": 789}, "error": {}})
 
-        jobs = workflow_mock.get_jobs()
-        assert isinstance(jobs, list)
-        assert isinstance(jobs[0], Job)
-        assert jobs[0].job_id == job_id
+        jobcollection = workflow_mock.get_jobs()
+        assert isinstance(jobcollection, JobCollection)
+        assert isinstance(jobcollection.jobs[0], Job)
+        assert jobcollection.jobs[0].job_id == job_id
         assert (
-            len(jobs) == 1
+            len(jobcollection.jobs) == 1
         )  # Filters out the job that is not associated with the workflow object
 
 
@@ -687,10 +687,12 @@ def test_get_jobs(workflow_mock):
 @pytest.mark.live
 def test_get_jobs_live(workflow_live):
     # Skip by default as too many jobs in test project, triggers too many job info requests.
-    jobs = workflow_live.get_jobs()
-    assert isinstance(jobs, list)
-    assert isinstance(jobs[0], Job)
-    assert all([j.info["workflowId"] == workflow_live.workflow_id for j in jobs])
+    jobcollection = workflow_live.get_jobs()
+    assert isinstance(jobcollection, list)
+    assert isinstance(jobcollection.jobs[0], Job)
+    assert all(
+        [j.info["workflowId"] == workflow_live.workflow_id for j in jobcollection.jobs]
+    )
 
 
 # TODO: Resolve

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -66,9 +66,9 @@ class JobCollection(Tools):
 
         out_filepaths = {}
         for job in self.jobs:
-            output_directory = output_directory / f"job_{job.job_id}"
+            out_dir = output_directory / f"job_{job.job_id}"
             out_filepaths_job = job.download_results(
-                output_directory=output_directory, unpacking=unpacking
+                output_directory=out_dir, unpacking=unpacking
             )
             out_filepaths[job.job_id] = out_filepaths_job
 

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -5,11 +5,7 @@ from .auth import Auth
 from .job import Job
 from .tools import Tools
 
-from .utils import (
-    get_logger,
-    download_results_from_gcs,
-    download_results_from_gcs_without_unpacking,
-)
+from .utils import get_logger
 
 logger = get_logger(__name__)
 
@@ -59,7 +55,7 @@ class JobCollection(Tools):
             unpacking: By default the final result which is in TAR archive format will be unpacked.
 
         Returns:
-            List of the downloaded results' filepaths.
+            Dict of the job_ids and jobs' downloaded results filepaths.
         """
         if output_directory is None:
             output_directory = Path.cwd() / f"project_{self.auth.project_id}"
@@ -67,23 +63,12 @@ class JobCollection(Tools):
             output_directory = Path(output_directory)
 
         out_filepaths = {}
-        for job_id in self.jobs_id:
-            # TODO: Overwrite argument
-            logger.info("Downloading results of job %s", job_id)
-
-            output_directory_id = output_directory / f"job_{job_id}"
-            output_directory_id.mkdir(parents=True, exist_ok=True)
-            logger.info("Download directory: %s", str(output_directory_id))
-
-            download_url = self._get_download_url(job_id)
-            if unpacking:
-                out_filepaths[job_id] = download_results_from_gcs(
-                    download_url=download_url, output_directory=output_directory_id,
-                )
-            else:
-                out_filepaths[job_id] = download_results_from_gcs_without_unpacking(
-                    download_url=download_url, output_directory=output_directory_id,
-                )
+        for job in self.jobs:
+            output_directory = output_directory / f"job_{job.job_id}"
+            out_filepaths_job = job.download_results(
+                output_directory=output_directory, unpacking=unpacking
+            )
+            out_filepaths[job.job_id] = out_filepaths_job
 
         self.results = out_filepaths
         return out_filepaths

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -30,6 +30,8 @@ class JobCollection(Tools):
             f"auth={self.auth})"
         )
 
+    # TODO: Make class subscriptable.
+
     # TODO: Maybe add _jobs_info method?
     # TODO: Maybe add _jobs_status method?
 

--- a/up42/project.py
+++ b/up42/project.py
@@ -121,6 +121,7 @@ class Project(Tools):
         Returns:
             All job objects in a JobCollection, or alternatively the jobs info as json.
         """
+        # TODO: Add selection for test/real job.
         url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs"
         response_json = self.auth._request(request_type="GET", url=url)
         jobs_json = response_json["data"]

--- a/up42/project.py
+++ b/up42/project.py
@@ -5,6 +5,7 @@ from tqdm import tqdm
 
 from .auth import Auth
 from .job import Job
+from .jobcollection import JobCollection
 from .tools import Tools
 from .utils import get_logger
 from .workflow import Workflow
@@ -107,17 +108,18 @@ class Project(Tools):
             ]
             return workflows
 
-    def get_jobs(self, return_json: bool = False) -> Union[List["Job"], Dict]:
+    def get_jobs(self, return_json: bool = False) -> Union[JobCollection, Dict]:
         """
-        Get all jobs in the project as job objects or json.
+        Get all jobs in the project as a JobCollection or json.
 
-        Use Workflow().get_job() to get jobs associated with a specific workflow.
+        Use Workflow().get_job() to get a JobCollection with jobs associated with a
+        specific workflow.
 
         Args:
-            return_json: If true, returns the job info jsons instead of job objects.
+            return_json: If true, returns the job info jsons instead of JobCollection.
 
         Returns:
-            All job objects as a list, or alternatively the jobs info as json.
+            All job objects in a JobCollection, or alternatively the jobs info as json.
         """
         url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs"
         response_json = self.auth._request(request_type="GET", url=url)
@@ -132,7 +134,10 @@ class Project(Tools):
                 Job(self.auth, job_id=job["id"], project_id=self.project_id)
                 for job in tqdm(jobs_json)
             ]
-            return jobs
+            jobcollection = JobCollection(
+                auth=self.auth, project_id=self.project_id, jobs=jobs
+            )
+            return jobcollection
 
     def get_project_settings(self) -> List:
         """

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -245,9 +245,11 @@ class Tools:
             if self.results is None:
                 raise ValueError("You first need to download the results!")
             filepaths = self.results
-            # Flatten jobcollection results dictionary.
+            # In case of jobcollection flatten results dictionary.
             if isinstance(filepaths, dict):
-                filepaths = [item for sublist in list(filepaths.values()) for item in sublist]
+                filepaths = [
+                    item for sublist in list(filepaths.values()) for item in sublist
+                ]
 
         plot_file_format = [".tif"]  # TODO: Add other fileformats.
         _plot_images(

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -248,7 +248,7 @@ class Tools:
             # Unpack results path dict in case of jobcollection.
             if isinstance(filepaths, dict):
                 filepaths = [
-                    item for sublist in list(filepaths.values()) for item in sublist
+                    item for sublist in list(filepaths.values()) for item in sublist  # type: ignore
                 ]
 
         plot_file_format = [".tif"]  # TODO: Add other fileformats.

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -245,7 +245,7 @@ class Tools:
             if self.results is None:
                 raise ValueError("You first need to download the results!")
             filepaths = self.results
-            # In case of jobcollection flatten results dictionary.
+            # Unpack results path dict in case of jobcollection.
             if isinstance(filepaths, dict):
                 filepaths = [
                     item for sublist in list(filepaths.values()) for item in sublist

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -245,6 +245,9 @@ class Tools:
             if self.results is None:
                 raise ValueError("You first need to download the results!")
             filepaths = self.results
+            # Flatten jobcollection results dictionary.
+            if isinstance(filepaths, dict):
+                filepaths = [item for sublist in list(filepaths.values()) for item in sublist]
 
         plot_file_format = [".tif"]  # TODO: Add other fileformats.
         _plot_images(

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -374,6 +374,8 @@ class Workflow(Tools):
         Returns:
             List of dictionary of constructed input parameters.
         """
+        # TODO: Make list if single argument is given.
+        # TODO: Rename arguments
         result_params = []
         # scene_ids mapped to geometries
         if scene_ids is not None and geometries is not None:
@@ -629,13 +631,14 @@ class Workflow(Tools):
         Returns:
             The spawned test jobcollection object.
         """
-        return self._helper_run_parallel_jobs(
+        jobcollection = self._helper_run_parallel_jobs(
             input_parameters_list=input_parameters_list,
             max_concurrent_jobs=10,
             name=name,
         )
+        return jobcollection
 
-    def get_jobs(self, return_json: bool = False) -> Union[JobCollection, Dict]:
+    def get_jobs(self, return_json: bool = False) -> Union[JobCollection, List[Dict]]:
         """
         Get all jobs associated with the workflow as a JobCollection or json.
 
@@ -645,6 +648,7 @@ class Workflow(Tools):
         Returns:
             A JobCollection, or alternatively the jobs info as json.
         """
+        # TODO: Add selection for test/real job.
         url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs"
         response_json = self.auth._request(request_type="GET", url=url)
         jobs_json = response_json["data"]

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -505,6 +505,9 @@ class Workflow(Tools):
                 logger.info("Running this job as Test Query...")
                 logger.info("+++++++++++++++++++++++++++++++++")
 
+        if name is None:
+            name = self.info["name"]
+
         jobs_list = []
         job_nr = 0
         # Run all jobs in parallel batches of the max_concurrent_jobs (max. 10.)
@@ -518,15 +521,13 @@ class Workflow(Tools):
             for params in batch:
                 logger.info("Selected input_parameters: %s.", params)
 
-                if name is None:
-                    name = self.info["name"]
-                name = (
+                job_name = (
                     f"{name}_{job_nr}_py"  # Temporary recognition of python API usage.
                 )
 
                 url = (
                     f"{self.auth._endpoint()}/projects/{self.project_id}/"
-                    f"workflows/{self.workflow_id}/jobs?name={name}"
+                    f"workflows/{self.workflow_id}/jobs?name={job_name}"
                 )
                 response_json = self.auth._request(
                     request_type="POST", url=url, data=params

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -635,18 +635,16 @@ class Workflow(Tools):
             name=name,
         )
 
-    def get_jobs(self, return_json: bool = False) -> Union[List["Job"], Dict]:
+    def get_jobs(self, return_json: bool = False) -> Union[JobCollection, Dict]:
         """
-        Get all jobs associated with the workflow as job objects or json.
+        Get all jobs associated with the workflow as a JobCollection or json.
 
         Args:
-            return_json: If true, returns the job info jsons instead of job objects.
+            return_json: If true, returns the job info jsons instead of a JobCollection.
 
         Returns:
-            All job objects as a list, or alternatively the jobs info as json.
+            A JobCollection, or alternatively the jobs info as json.
         """
-        # TODO: Need to return a JobCollection objects instead of list
-
         url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs"
         response_json = self.auth._request(request_type="GET", url=url)
         jobs_json = response_json["data"]
@@ -668,7 +666,10 @@ class Workflow(Tools):
                 Job(self.auth, job_id=job["id"], project_id=self.project_id)
                 for job in tqdm(jobs_workflow_json)
             ]
-            return jobs
+            jobcollection = JobCollection(
+                auth=self.auth, project_id=self.project_id, jobs=jobs
+            )
+            return jobcollection
 
     def update_name(self, name: str = None, description: str = None) -> None:
         """


### PR DESCRIPTION
- .get_jobs returns Jobcollection (for Project & Workflow)
- Enable jobcollection.plot()
- Simplify Jobcollection download
- fix run_parallel_jobs naming schema
