### PR TITLE
Merge jobcollection results

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">76%</text>
-        <text x="80" y="14">76%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
+        <text x="80" y="14">77%</text>
     </g>
 </svg>

--- a/pylintrc
+++ b/pylintrc
@@ -17,8 +17,8 @@ disable=
     protected-access,
     redefined-outer-name,
     too-many-instance-attributes,
-    fixme
-
+    fixme,
+    not-callable
 [FORMAT]
 max-line-length=120
 single-line-if-stmt=yes

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -135,7 +135,7 @@ def jobs_mock(auth_mock):
 
 
 @pytest.fixture()
-def jobcollection_mock(auth_mock, job_mock):
+def jobcollection_single_mock(auth_mock, job_mock):
     return JobCollection(
         auth=auth_mock, project_id=auth_mock.project_id, jobs=[job_mock]
     )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -114,9 +114,37 @@ def job_mock(auth_mock):
 
 
 @pytest.fixture()
+def jobs_mock(auth_mock):
+    with requests_mock.Mocker() as m:
+        job_id = "jobid_123"
+        url_job_info = (
+            f"{auth_mock._endpoint()}/projects/{auth_mock.project_id}/jobs/{job_id}"
+        )
+        m.get(url=url_job_info, json={"data": {"xyz": 789}, "error": {}})
+
+        job1 = Job(auth=auth_mock, project_id=auth_mock.project_id, job_id=job_id)
+
+        job_id = "jobid_456"
+        url_job_info = (
+            f"{auth_mock._endpoint()}/projects/{auth_mock.project_id}/jobs/{job_id}"
+        )
+        m.get(url=url_job_info, json={"data": {"xyz": 789}, "error": {}})
+
+        job2 = Job(auth=auth_mock, project_id=auth_mock.project_id, job_id=job_id)
+    return [job1, job2]
+
+
+@pytest.fixture()
 def jobcollection_mock(auth_mock, job_mock):
     return JobCollection(
         auth=auth_mock, project_id=auth_mock.project_id, jobs=[job_mock]
+    )
+
+
+@pytest.fixture()
+def jobcollection_multiple_mock(auth_mock, jobs_mock):
+    return JobCollection(
+        auth=auth_mock, project_id=auth_mock.project_id, jobs=jobs_mock
     )
 
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -198,9 +198,13 @@ def test_job_download_result(job_mock):
 
         with tempfile.TemporaryDirectory() as tempdir:
             out_files = job_mock.download_results(tempdir)
-            for file in out_files:
-                assert Path(file).exists()
-            assert len(out_files) == 2
+            out_paths = [Path(p) for p in out_files]
+            for path in out_paths:
+                assert path.exists()
+            assert len(out_paths) == 2
+            assert out_paths[0].name == "data.json"
+            assert out_paths[1].parent.exists()
+            assert out_paths[1].parent.is_dir()
 
 
 def test_job_download_result_nounpacking(job_mock):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -250,9 +250,9 @@ def test_job_download_result_no_tiff_live(auth_live):
         )
         out_files = job.download_results(Path(tempdir))
         assert Path(out_files[0]).exists()
-        assert Path(out_files[0]).suffix == ".nc"
         assert Path(out_files[1]).exists()
-        assert Path(out_files[1]).name == "data.json"
+        assert any(".nc" in s for s in out_files)
+        assert any("data.json" in s for s in out_files)
         assert len(out_files) == 2
 
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -256,6 +256,23 @@ def test_job_download_result_no_tiff_live(auth_live):
         assert len(out_files) == 2
 
 
+@pytest.mark.live
+def test_job_download_result_dimap_live(auth_live):
+    with tempfile.TemporaryDirectory() as tempdir:
+        job = up42.Job(
+            auth=auth_live,
+            project_id=auth_live.project_id,
+            job_id=os.getenv("TEST_UP42_JOB_ID_DIMAP_FILE"),
+        )
+        out_files = job.download_results(Path(tempdir))
+        print(out_files)
+        assert Path(out_files[0]).exists()
+        assert Path(out_files[20]).exists()
+        assert Path(out_files[1]).exists()
+        assert Path(out_files[1]).name == "data.json"
+        assert len(out_files) == 44
+
+
 @pytest.mark.skip
 @pytest.mark.live
 def test_job_download_result_live_2gb_big_exceeding_2min_gcs_treshold(auth_live):

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import tempfile
 
 import pytest
+import requests_mock
 
 # pylint: disable=unused-import,wrong-import-order
 from .fixtures import (
@@ -16,6 +17,30 @@ from .fixtures import (
 
 def test_jobcollection(jobcollection_mock):
     assert len(jobcollection_mock.jobs) == 1
+
+
+def test_jobcollection_download_result(jobcollection_mock):
+    with requests_mock.Mocker() as m:
+        download_url = "http://up42.api.com/abcdef"
+        url_download_result = (
+            f"{jobcollection_mock.auth._endpoint()}/projects/"
+            f"{jobcollection_mock.project_id}/jobs/{jobcollection_mock.jobs_id[0]}/downloads/results/"
+        )
+        m.get(url_download_result, json={"data": {"url": download_url}, "error": {}})
+
+        out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
+        out_tgz_file = open(out_tgz, "rb")
+        m.get(
+            url=download_url,
+            content=out_tgz_file.read(),
+            headers={"x-goog-stored-content-length": "163"},
+        )
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            out_dict = jobcollection_mock.download_results(tempdir)
+            for job_id in out_dict:
+                assert Path(out_dict[job_id][0]).exists()
+                assert len(out_dict[job_id]) == 2
 
 
 @pytest.mark.live

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -43,8 +43,8 @@ def test_jobcollection_download_results(jobcollection_single_mock):
                 headers={"x-goog-stored-content-length": "163"},
             )
 
-        with tempfile.TemporaryDirectory() as tempdir:
-            out_dict = jobcollection_single_mock.download_results(tempdir, merge=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dict = jobcollection_single_mock.download_results(tmpdir, merge=False)
             for job_id in out_dict:
                 assert Path(out_dict[job_id][0]).exists()
                 assert len(out_dict[job_id]) == 2
@@ -72,8 +72,8 @@ def test_jobcollection_download_results_merged(jobcollection_multiple_mock):
                 headers={"x-goog-stored-content-length": "163"},
             )
 
-        with tempfile.TemporaryDirectory() as tempdir:
-            out_dict = jobcollection_multiple_mock.download_results(tempdir, merge=True)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dict = jobcollection_multiple_mock.download_results(tmpdir, merge=True)
             print(out_dict)
             assert len(out_dict) == 3
             assert Path(out_dict["merged_result"][0]).exists()
@@ -93,15 +93,15 @@ def test_jobcollection_download_results_merged(jobcollection_multiple_mock):
                     in merged_data_json.features[0].properties["up42.data_path"]
                 )
                 assert (
-                    tempdir
+                    tmpdir
                     / Path(merged_data_json.features[0].properties["up42.data_path"])
                 ).exists()
 
 
 @pytest.mark.live
 def test_jobcollection_download_results_live(jobcollection_live):
-    with tempfile.TemporaryDirectory() as tempdir:
-        out_files_dict = jobcollection_live.download_results(Path(tempdir), merge=False)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_files_dict = jobcollection_live.download_results(Path(tmpdir), merge=False)
         jobid_1, jobid_2 = jobcollection_live.jobs_id
         for _, value in out_files_dict.items():
             for p in value:

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -36,12 +36,12 @@ def test_jobcollection_download_results(jobcollection_single_mock):
         m.get(url_download_result, json={"data": {"url": download_url}, "error": {}})
 
         out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
-        out_tgz_file = open(out_tgz, "rb")
-        m.get(
-            url=download_url,
-            content=out_tgz_file.read(),
-            headers={"x-goog-stored-content-length": "163"},
-        )
+        with open(out_tgz, "rb") as out_tgz_file:
+            m.get(
+                url=download_url,
+                content=out_tgz_file.read(),
+                headers={"x-goog-stored-content-length": "163"},
+            )
 
         with tempfile.TemporaryDirectory() as tempdir:
             out_dict = jobcollection_single_mock.download_results(tempdir, merge=False)
@@ -65,12 +65,12 @@ def test_jobcollection_download_results_merged(jobcollection_multiple_mock):
         m.get(url_download_result_2, json={"data": {"url": download_url}, "error": {}})
 
         out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
-        out_tgz_file = open(out_tgz, "rb")
-        m.get(
-            url=download_url,
-            content=out_tgz_file.read(),
-            headers={"x-goog-stored-content-length": "163"},
-        )
+        with open(out_tgz, "rb") as out_tgz_file:
+            m.get(
+                url=download_url,
+                content=out_tgz_file.read(),
+                headers={"x-goog-stored-content-length": "163"},
+            )
 
         with tempfile.TemporaryDirectory() as tempdir:
             out_dict = jobcollection_multiple_mock.download_results(tempdir, merge=True)

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -19,7 +19,7 @@ def test_jobcollection(jobcollection_mock):
 
 
 @pytest.mark.live
-def test_job_download_result_live(jobcollection_live):
+def test_jobcollection_download_result_live(jobcollection_live):
     with tempfile.TemporaryDirectory() as tempdir:
         out_files_dict = jobcollection_live.download_results(Path(tempdir))
         jobid_1, jobid_2 = jobcollection_live.jobs_id

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -92,7 +92,11 @@ def test_jobcollection_download_result_merged(jobcollection_multiple_mock):
                     "jobid_123"
                     in merged_data_json.features[0].properties["up42.data_path"]
                 )
-                assert (tempdir / Path(merged_data_json.features[0].properties["up42.data_path"])).exists()
+                assert (
+                    tempdir
+                    / Path(merged_data_json.features[0].properties["up42.data_path"])
+                ).exists()
+
 
 @pytest.mark.live
 def test_jobcollection_download_result_live(jobcollection_live):

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -8,7 +8,9 @@ import requests_mock
 from .fixtures import (
     auth_mock,
     job_mock,
+    jobs_mock,
     jobcollection_mock,
+    jobcollection_multiple_mock,
     auth_live,
     jobs_live,
     jobcollection_live,
@@ -17,6 +19,10 @@ from .fixtures import (
 
 def test_jobcollection(jobcollection_mock):
     assert len(jobcollection_mock.jobs) == 1
+
+
+def test_jobcollection_multiple(jobcollection_multiple_mock):
+    assert len(jobcollection_multiple_mock.jobs) == 2
 
 
 def test_jobcollection_download_result(jobcollection_mock):

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -26,7 +26,7 @@ def test_jobcollection_multiple(jobcollection_multiple_mock):
     assert len(jobcollection_multiple_mock.jobs) == 2
 
 
-def test_jobcollection_download_result(jobcollection_single_mock):
+def test_jobcollection_download_results(jobcollection_single_mock):
     with requests_mock.Mocker() as m:
         download_url = "http://up42.api.com/abcdef"
         url_download_result = (
@@ -50,7 +50,7 @@ def test_jobcollection_download_result(jobcollection_single_mock):
                 assert len(out_dict[job_id]) == 2
 
 
-def test_jobcollection_download_result_merged(jobcollection_multiple_mock):
+def test_jobcollection_download_results_merged(jobcollection_multiple_mock):
     with requests_mock.Mocker() as m:
         download_url = "http://up42.api.com/abcdef"
         url_download_result_1 = (
@@ -99,7 +99,7 @@ def test_jobcollection_download_result_merged(jobcollection_multiple_mock):
 
 
 @pytest.mark.live
-def test_jobcollection_download_result_live(jobcollection_live):
+def test_jobcollection_download_results_live(jobcollection_live):
     with tempfile.TemporaryDirectory() as tempdir:
         out_files_dict = jobcollection_live.download_results(Path(tempdir), merge=False)
         jobid_1, jobid_2 = jobcollection_live.jobs_id

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -53,16 +53,15 @@ def test_jobcollection_download_results(jobcollection_single_mock):
 def test_jobcollection_download_results_merged(jobcollection_multiple_mock):
     with requests_mock.Mocker() as m:
         download_url = "http://up42.api.com/abcdef"
-        url_download_result_1 = (
-            f"{jobcollection_multiple_mock.auth._endpoint()}/projects/"
-            f"{jobcollection_multiple_mock.project_id}/jobs/{jobcollection_multiple_mock.jobs_id[0]}/downloads/results/"
-        )
-        url_download_result_2 = (
-            f"{jobcollection_multiple_mock.auth._endpoint()}/projects/"
-            f"{jobcollection_multiple_mock.project_id}/jobs/{jobcollection_multiple_mock.jobs_id[1]}/downloads/results/"
-        )
-        m.get(url_download_result_1, json={"data": {"url": download_url}, "error": {}})
-        m.get(url_download_result_2, json={"data": {"url": download_url}, "error": {}})
+
+        for job in jobcollection_multiple_mock.jobs:
+            url_download_result = (
+                f"{jobcollection_multiple_mock.auth._endpoint()}/projects/"
+                f"{jobcollection_multiple_mock.project_id}/jobs/{job.job_id}/downloads/results/"
+            )
+            m.get(
+                url_download_result, json={"data": {"url": download_url}, "error": {}}
+            )
 
         out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
         with open(out_tgz, "rb") as out_tgz_file:

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -10,7 +10,7 @@ from .fixtures import (
     auth_mock,
     job_mock,
     jobs_mock,
-    jobcollection_mock,
+    jobcollection_single_mock,
     jobcollection_multiple_mock,
     auth_live,
     jobs_live,
@@ -18,20 +18,20 @@ from .fixtures import (
 )
 
 
-def test_jobcollection(jobcollection_mock):
-    assert len(jobcollection_mock.jobs) == 1
+def test_jobcollection(jobcollection_single_mock):
+    assert len(jobcollection_single_mock.jobs) == 1
 
 
 def test_jobcollection_multiple(jobcollection_multiple_mock):
     assert len(jobcollection_multiple_mock.jobs) == 2
 
 
-def test_jobcollection_download_result(jobcollection_mock):
+def test_jobcollection_download_result(jobcollection_single_mock):
     with requests_mock.Mocker() as m:
         download_url = "http://up42.api.com/abcdef"
         url_download_result = (
-            f"{jobcollection_mock.auth._endpoint()}/projects/"
-            f"{jobcollection_mock.project_id}/jobs/{jobcollection_mock.jobs_id[0]}/downloads/results/"
+            f"{jobcollection_single_mock.auth._endpoint()}/projects/"
+            f"{jobcollection_single_mock.project_id}/jobs/{jobcollection_single_mock.jobs_id[0]}/downloads/results/"
         )
         m.get(url_download_result, json={"data": {"url": download_url}, "error": {}})
 
@@ -44,7 +44,7 @@ def test_jobcollection_download_result(jobcollection_mock):
         )
 
         with tempfile.TemporaryDirectory() as tempdir:
-            out_dict = jobcollection_mock.download_results(tempdir, merge=False)
+            out_dict = jobcollection_single_mock.download_results(tempdir, merge=False)
             for job_id in out_dict:
                 assert Path(out_dict[job_id][0]).exists()
                 assert len(out_dict[job_id]) == 2

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -174,4 +174,5 @@ def test_get_project_settings_live(project_live):
     project_settings = project_live.get_project_settings()
     assert isinstance(project_settings, list)
     assert len(project_settings) == 3
-    assert project_settings[0]["name"] == "MAX_CONCURRENT_JOBS"
+    project_settings_dict = {item["name"]: item for item in project_settings}
+    assert "MAX_CONCURRENT_JOBS" in project_settings_dict.keys()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -19,7 +19,7 @@ from .fixtures import (
     workflow_mock,
     workflow_live,
     job_mock,
-    jobcollection_mock,
+    jobcollection_single_mock,
 )
 import up42
 

--- a/up42/job.py
+++ b/up42/job.py
@@ -180,8 +180,7 @@ class Job(Tools):
         self, output_directory: Union[str, Path, None] = None, unpacking: bool = True
     ) -> List[str]:
         """
-        Downloads the job results. Unpacking the final file will happen as default. However
-        please note in the case of exotic formats like SAFE or DIMAP, the final result should not be unpacked.
+        Downloads the job results. Unpacking the final file will happen as default.
 
         Args:
             output_directory: The file output directory, defaults to the current working

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -78,7 +78,7 @@ class JobCollection(Tools):
                 out_features = []
                 for job_id in out_filepaths:
                     all_files = out_filepaths[job_id]
-                    data_json = [d for d in all_files if d.endswith("data.json")][0]
+                    data_json = [d for d in all_files if Path(d).name == "data.json"][0]
                     with open(data_json) as src:
                         data_json_fc = geojson.load(src)
                         for feat in data_json_fc.features:

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -35,15 +35,6 @@ class JobCollection(Tools):
     # TODO: Maybe add _jobs_info method?
     # TODO: Maybe add _jobs_status method?
 
-    def _get_download_url(self, job_id) -> str:
-        url = (
-            f"{self.auth._endpoint()}/projects/{self.project_id}/jobs/{job_id}"
-            f"/downloads/results/"
-        )
-        response_json = self.auth._request(request_type="GET", url=url)
-        download_url = response_json["data"]["url"]
-        return download_url
-
     def download_results(
         self, output_directory: Union[str, Path, None] = None, unpacking: bool = True
     ) -> Dict[str, List[str]]:

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -76,12 +76,8 @@ def download_results_from_gcs(
         tar.extractall(path=output_directory)
         output_folder_path = output_directory / "output"
         for src_path in output_directory.glob("output/**/*"):
-            # Try except block to exclude top level directories
-            try:
-                dst_path = output_directory / src_path.relative_to(output_folder_path)
-                shutil.move(str(src_path), str(dst_path))
-            except ValueError:
-                pass
+            dst_path = output_directory / src_path.relative_to(output_folder_path)
+            shutil.move(str(src_path), str(dst_path))
         out_filepaths = [str(x) for x in output_directory.glob("**/*") if x.is_file()]
 
     logger.info(

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -2,6 +2,7 @@ import copy
 import logging
 from typing import Dict, List, Union, Tuple
 from pathlib import Path
+import shutil
 import tempfile
 import tarfile
 import math
@@ -71,18 +72,17 @@ def download_results_from_gcs(
                 f"Connection error, please try again! {err}"
             )
 
-    # Unpack and exclude data.json
-    out_filepaths: List[str] = []
     with tarfile.open(tgz_file) as tar:
-        members = tar.getmembers()
-        files = [f for f in members if f.isfile()]
-        for file in files:
-            f = tar.extractfile(file)
-            content = f.read()  # type: ignore
-            out_fp = output_directory / f"{Path(file.name).name}"
-            with open(out_fp, "wb") as dst:
-                dst.write(content)
-            out_filepaths.append(str(out_fp))
+        tar.extractall(path=output_directory)
+        output_folder_path = output_directory / "output"
+        for src_path in output_directory.glob("output/**/*"):
+            # Try except block to exclude top level directories
+            try:
+                dst_path = output_directory / src_path.relative_to(output_folder_path)
+                shutil.move(str(src_path), str(dst_path))
+            except ValueError:
+                pass
+        out_filepaths = [str(x) for x in output_directory.glob("**/*") if x.is_file()]
 
     logger.info(
         "Download successful of %s files to output_directory '%s': %s",

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -75,7 +75,7 @@ def download_results_from_gcs(
     with tarfile.open(tgz_file) as tar:
         tar.extractall(path=output_directory)
         output_folder_path = output_directory / "output"
-        for src_path in output_directory.glob("output/**/*"):
+        for src_path in output_folder_path.glob("**/*"):
             dst_path = output_directory / src_path.relative_to(output_folder_path)
             shutil.move(str(src_path), str(dst_path))
         out_filepaths = [str(x) for x in output_directory.glob("**/*") if x.is_file()]


### PR DESCRIPTION
- Adds flag (defaults to True) to download_results in order to merge all data.json from a JobCollection into a single data.json with updated `up42.data_path`
- Keep folder structure when unpacking results from tar file
- Adds tests for unpacked result download and DIMAP file download
- Ignore not-callable temporarily