### PR TITLE
Add limitation for max concurrent jobs

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">78%</text>
-        <text x="80" y="14">78%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
+        <text x="80" y="14">77%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
-        <text x="80" y="14">77%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">78%</text>
+        <text x="80" y="14">78%</text>
     </g>
 </svg>

--- a/docs/reference/jobcollection.md
+++ b/docs/reference/jobcollection.md
@@ -1,3 +1,3 @@
-# Job class
+# JobCollection class
 
 ::: up42.jobcollection.JobCollection

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -237,3 +237,31 @@ def catalog_mock(auth_mock):
 @pytest.fixture()
 def catalog_live(auth_live):
     return Catalog(auth=auth_live)
+
+
+@pytest.fixture()
+def project_max_concurrent_jobs(project_mock):
+    def _project_max_concurrent_jobs(maximum=5):
+        m = requests_mock.Mocker()
+        url_project_info = (
+            f"{project_mock.auth._endpoint()}/projects/{project_mock.project_id}"
+        )
+        m.get(url=url_project_info, json={"data": {"xyz": 789}, "error": {}})
+        url_project_settings = (
+            f"{project_mock.auth._endpoint()}/projects"
+            f"/{project_mock.project_id}/settings"
+        )
+        m.get(
+            url=url_project_settings,
+            json={
+                "data": [
+                    {"name": "MAX_CONCURRENT_JOBS", "value": str(maximum)},
+                    {"name": "MAX_AOI_SIZE", "value": "1000"},
+                    {"name": "JOB_QUERY_LIMIT_PARAMETER_MAX_VALUE", "value": "200"},
+                ],
+                "error": {},
+            },
+        )
+        return m
+
+    return _project_max_concurrent_jobs

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -170,6 +170,7 @@ def test_get_logs(job_mock, jobtask_mock):
         )
         m.get(url_log, json="")
         assert job_mock.get_logs(as_return=True)[jobtask_mock.jobtask_id] == ""
+        assert not job_mock.get_logs()
 
 
 def test_get_jobtasks(job_mock, jobtask_mock):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -9,8 +9,8 @@ import pytest
 from folium import Map
 
 # pylint: disable=unused-import
+from .context import Job, JobTask
 from .fixtures import auth_mock, auth_live, job_mock, job_live, jobtask_mock
-import up42  # pylint: disable=wrong-import-order
 
 
 def test_job_get_info(job_mock):
@@ -24,7 +24,7 @@ def test_job_get_info(job_mock):
         m.get(url=url_job_info, text='{"data": {"xyz":789}, "error":{}}')
 
         info = job_mock._get_info()
-    assert isinstance(job_mock, up42.Job)
+    assert isinstance(job_mock, Job)
     assert info["xyz"] == 789
     assert job_mock.info["xyz"] == 789
 
@@ -180,7 +180,7 @@ def test_get_jobtasks(job_mock, jobtask_mock):
         )
         m.get(url=url_job_tasks, json={"data": [{"id": jobtask_mock.jobtask_id}]})
         job_tasks = job_mock.get_jobtasks()
-        assert isinstance(job_tasks[0], up42.JobTask)
+        assert isinstance(job_tasks[0], JobTask)
         assert job_tasks[0].jobtask_id == jobtask_mock.jobtask_id
 
 
@@ -268,7 +268,7 @@ def test_job_download_result_live(job_live):
 @pytest.mark.live
 def test_job_download_result_no_tiff_live(auth_live):
     with tempfile.TemporaryDirectory() as tempdir:
-        job = up42.Job(
+        job = Job(
             auth=auth_live,
             project_id=auth_live.project_id,
             job_id=os.getenv("TEST_UP42_JOB_ID_NC_FILE"),
@@ -284,7 +284,7 @@ def test_job_download_result_no_tiff_live(auth_live):
 @pytest.mark.live
 def test_job_download_result_dimap_live(auth_live):
     with tempfile.TemporaryDirectory() as tempdir:
-        job = up42.Job(
+        job = Job(
             auth=auth_live,
             project_id=auth_live.project_id,
             job_id=os.getenv("TEST_UP42_JOB_ID_DIMAP_FILE"),
@@ -301,7 +301,7 @@ def test_job_download_result_dimap_live(auth_live):
 @pytest.mark.skip
 @pytest.mark.live
 def test_job_download_result_live_2gb_big_exceeding_2min_gcs_treshold(auth_live):
-    job = up42.Job(
+    job = Job(
         auth=auth_live,
         project_id=auth_live.project_id,
         job_id="30f82b44-1505-4773-ab23-31fa61ba9b4c",

--- a/tests/test_jobtask.py
+++ b/tests/test_jobtask.py
@@ -5,8 +5,8 @@ import requests_mock
 import pytest
 
 # pylint: disable=unused-import
+from .context import JobTask
 from .fixtures import auth_mock, auth_live, jobtask_mock, jobtask_live
-import up42  # pylint: disable=wrong-import-order
 
 
 def test_get_info(jobtask_mock):
@@ -21,7 +21,7 @@ def test_get_info(jobtask_mock):
         m.get(url=url_jobtask_info, text='{"data": {"xyz":789}, "error":{}}')
 
         info = jobtask_mock._get_info()
-    assert isinstance(jobtask_mock, up42.JobTask)
+    assert isinstance(jobtask_mock, JobTask)
     assert info["xyz"] == 789
     assert jobtask_mock.info["xyz"] == 789
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -9,6 +9,7 @@ from .fixtures import (
     auth_live,
     project_mock,
     project_live,
+    project_max_concurrent_jobs,
 )
 
 
@@ -169,6 +170,12 @@ def test_get_project_settings(project_mock):
     assert project_settings[0]["name"] == "MAX_CONCURRENT_JOBS"
 
 
+def test_max_concurrent_jobs(project_mock, project_max_concurrent_jobs):
+    with project_max_concurrent_jobs(5):
+        max_concurrent_jobs = project_mock.max_concurrent_jobs
+    assert max_concurrent_jobs == 5
+
+
 @pytest.mark.live
 def test_get_project_settings_live(project_live):
     project_settings = project_live.get_project_settings()
@@ -176,3 +183,9 @@ def test_get_project_settings_live(project_live):
     assert len(project_settings) == 3
     project_settings_dict = {item["name"]: item for item in project_settings}
     assert "MAX_CONCURRENT_JOBS" in project_settings_dict.keys()
+
+
+@pytest.mark.live
+def test_max_concurrent_jobs_live(project_live):
+    max_concurrent_jobs = project_live.max_concurrent_jobs
+    assert max_concurrent_jobs == 10

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -188,4 +188,4 @@ def test_get_project_settings_live(project_live):
 @pytest.mark.live
 def test_max_concurrent_jobs_live(project_live):
     max_concurrent_jobs = project_live.max_concurrent_jobs
-    assert max_concurrent_jobs == 10
+    assert max_concurrent_jobs == 100

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -7,14 +7,14 @@ from geojson import FeatureCollection
 from geopandas import GeoDataFrame
 
 # pylint: disable=wrong-import-position
-from .tools import Tools
-from .auth import Auth
-from .project import Project
-from .workflow import Workflow
-from .job import Job
-from .jobtask import JobTask
-from .catalog import Catalog
-from .utils import get_logger
+from tools import Tools
+from auth import Auth
+from project import Project
+from workflow import Workflow
+from job import Job
+from jobtask import JobTask
+from catalog import Catalog
+from utils import get_logger
 
 logger = get_logger(__name__, level=logging.INFO)
 

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -7,14 +7,14 @@ from geojson import FeatureCollection
 from geopandas import GeoDataFrame
 
 # pylint: disable=wrong-import-position
-from tools import Tools
-from auth import Auth
-from project import Project
-from workflow import Workflow
-from job import Job
-from jobtask import JobTask
-from catalog import Catalog
-from utils import get_logger
+from up42.tools import Tools
+from up42.auth import Auth
+from up42.project import Project
+from up42.workflow import Workflow
+from up42.job import Job
+from up42.jobtask import JobTask
+from up42.catalog import Catalog
+from up42.utils import get_logger
 
 logger = get_logger(__name__, level=logging.INFO)
 

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -43,7 +43,7 @@ def initialize_project() -> "Project":
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
     logger.info(f"Working on Project with project_id {_auth.project_id}")
-    return Project(auth=_auth, project_id=_auth.project_id)
+    return Project(auth=_auth, project_id=str(_auth.project_id))
 
 
 def initialize_catalog() -> "Catalog":
@@ -57,7 +57,9 @@ def initialize_workflow(workflow_id) -> "Workflow":
     """Directly returns a Workflow object (has to exist on UP42)."""
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
-    return Workflow(auth=_auth, workflow_id=workflow_id, project_id=_auth.project_id)
+    return Workflow(
+        auth=_auth, workflow_id=workflow_id, project_id=str(_auth.project_id)
+    )
 
 
 def initialize_job(job_id, order_ids: List[str] = None) -> "Job":
@@ -65,7 +67,7 @@ def initialize_job(job_id, order_ids: List[str] = None) -> "Job":
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
     return Job(
-        auth=_auth, job_id=job_id, project_id=_auth.project_id, order_ids=order_ids
+        auth=_auth, job_id=job_id, project_id=str(_auth.project_id), order_ids=order_ids
     )
 
 
@@ -74,7 +76,10 @@ def initialize_jobtask(jobtask_id, job_id) -> "JobTask":
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
     return JobTask(
-        auth=_auth, jobtask_id=jobtask_id, job_id=job_id, project_id=_auth.project_id
+        auth=_auth,
+        jobtask_id=jobtask_id,
+        job_id=job_id,
+        project_id=str(_auth.project_id),
     )
 
 

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -39,8 +39,8 @@ class Auth(Tools):
             project_api_key: The project-specific API key.
         """
         self.cfg_file = cfg_file
-        self.project_id = str(project_id)
-        self.project_api_key = str(project_api_key)
+        self.project_id = project_id
+        self.project_api_key = project_api_key
 
         try:
             self.env: str = kwargs["env"]

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -11,8 +11,8 @@ from tenacity import (
     retry_if_exception_type,
 )
 
-from .tools import Tools
-from .utils import get_logger
+from up42.tools import Tools
+from up42.utils import get_logger
 
 logger = get_logger(__name__)
 

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -8,9 +8,9 @@ from geojson import Feature, FeatureCollection
 from requests.exceptions import HTTPError
 from tqdm import tqdm
 
-from .auth import Auth
-from .tools import Tools
-from .utils import get_logger, any_vector_to_fc, fc_to_query_geometry
+from up42.auth import Auth
+from up42.tools import Tools
+from up42.utils import get_logger, any_vector_to_fc, fc_to_query_geometry
 
 logger = get_logger(__name__)
 

--- a/up42/cli.py
+++ b/up42/cli.py
@@ -4,13 +4,13 @@ from pathlib import Path
 from datetime import datetime, timedelta
 import click
 
-from .auth import Auth
-from .tools import Tools
-from .project import Project
-from .workflow import Workflow
-from .job import Job
-from .catalog import Catalog
-from .utils import get_logger
+from up42.auth import Auth
+from up42.tools import Tools
+from up42.project import Project
+from up42.workflow import Workflow
+from up42.job import Job
+from up42.catalog import Catalog
+from up42.utils import get_logger
 
 logger = get_logger(__name__)
 

--- a/up42/job.py
+++ b/up42/job.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 from time import sleep
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 
 import folium
 from geopandas import GeoDataFrame
@@ -349,7 +349,7 @@ class Job(Tools):
             )
             return m
 
-    def get_logs(self, as_print: bool = True, as_return: bool = False):
+    def get_logs(self, as_print: bool = True, as_return: bool = False) -> Optional[Dict]:
         """
         Convenience function to print or return the logs of all job tasks.
 

--- a/up42/job.py
+++ b/up42/job.py
@@ -13,10 +13,10 @@ from shapely.geometry import box
 from rasterio.vrt import WarpedVRT
 import rasterio
 
-from .auth import Auth
-from .jobtask import JobTask
-from .tools import Tools
-from .utils import (
+from up42.auth import Auth
+from up42.jobtask import JobTask
+from up42.tools import Tools
+from up42.utils import (
     get_logger,
     folium_base_map,
     download_results_from_gcs,

--- a/up42/job.py
+++ b/up42/job.py
@@ -387,8 +387,10 @@ class Job(Tools):
                 print("----------------------------------------------------------")
                 print(f"JobTask {idx+1} with jobtask_id {jobtask_id}:\n")
                 print(response_json)
-            if as_return:
-                return job_logs
+        if as_return:
+            return job_logs
+        else:
+            return None
 
     def get_jobtasks(
         self, return_json: bool = False

--- a/up42/job.py
+++ b/up42/job.py
@@ -349,7 +349,9 @@ class Job(Tools):
             )
             return m
 
-    def get_logs(self, as_print: bool = True, as_return: bool = False) -> Optional[Dict]:
+    def get_logs(
+        self, as_print: bool = True, as_return: bool = False
+    ) -> Optional[Dict]:
         """
         Convenience function to print or return the logs of all job tasks.
 

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -4,11 +4,11 @@ from pathlib import Path
 import geojson
 from geojson import FeatureCollection
 
-from .auth import Auth
-from .job import Job
-from .tools import Tools
+from auth import Auth
+from job import Job
+from tools import Tools
 
-from .utils import get_logger
+from up42.utils import get_logger
 
 logger = get_logger(__name__)
 

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -4,9 +4,9 @@ from pathlib import Path
 import geojson
 from geojson import FeatureCollection
 
-from auth import Auth
-from job import Job
-from tools import Tools
+from up42.auth import Auth
+from up42.job import Job
+from up42.tools import Tools
 
 from up42.utils import get_logger
 

--- a/up42/jobtask.py
+++ b/up42/jobtask.py
@@ -4,9 +4,9 @@ from typing import Dict, Union, List
 from geopandas import GeoDataFrame
 from tqdm import tqdm
 
-from .auth import Auth
-from .tools import Tools
-from .utils import get_logger, download_results_from_gcs
+from up42.auth import Auth
+from up42.tools import Tools
+from up42.utils import get_logger, download_results_from_gcs
 
 logger = get_logger(__name__)
 

--- a/up42/project.py
+++ b/up42/project.py
@@ -149,6 +149,7 @@ class Project(Tools):
 
     @property
     def max_concurrent_jobs(self) -> int:
+        """Gets the maximum number of concurrent jobs allowed by the project settings."""
         project_settings = self.get_project_settings()
         project_settings_dict = {d["name"]: int(d["value"]) for d in project_settings}
         return project_settings_dict["MAX_CONCURRENT_JOBS"]

--- a/up42/project.py
+++ b/up42/project.py
@@ -3,12 +3,12 @@ from typing import Dict, List, Union
 
 from tqdm import tqdm
 
-from .auth import Auth
-from .job import Job
-from .jobcollection import JobCollection
-from .tools import Tools
-from .utils import get_logger
-from .workflow import Workflow
+from up42.auth import Auth
+from up42.job import Job
+from up42.jobcollection import JobCollection
+from up42.tools import Tools
+from up42.utils import get_logger
+from up42.workflow import Workflow
 
 logger = get_logger(__name__)
 

--- a/up42/project.py
+++ b/up42/project.py
@@ -135,7 +135,7 @@ class Project(Tools):
             )
             return jobcollection
 
-    def get_project_settings(self) -> List:
+    def get_project_settings(self) -> List[Dict[str, str]]:
         """
         Gets the project settings.
 
@@ -150,9 +150,8 @@ class Project(Tools):
     @property
     def max_concurrent_jobs(self) -> int:
         project_settings = self.get_project_settings()
-        print(project_settings)
-        project_settings = {d["name"]: int(d["value"]) for d in project_settings}
-        return project_settings["MAX_CONCURRENT_JOBS"]
+        project_settings_dict = {d["name"]: int(d["value"]) for d in project_settings}
+        return project_settings_dict["MAX_CONCURRENT_JOBS"]
 
     def update_project_settings(
         self,

--- a/up42/project.py
+++ b/up42/project.py
@@ -147,6 +147,13 @@ class Project(Tools):
         project_settings = response_json["data"]
         return project_settings
 
+    @property
+    def max_concurrent_jobs(self) -> int:
+        project_settings = self.get_project_settings()
+        print(project_settings)
+        project_settings = {d["name"]: int(d["value"]) for d in project_settings}
+        return project_settings["MAX_CONCURRENT_JOBS"]
+
     def update_project_settings(
         self,
         max_aoi_size: int = None,

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -10,7 +10,7 @@ import pandas as pd
 import shapely
 import rasterio
 
-from .utils import get_logger, folium_base_map, DrawFoliumOverride, _plot_images
+from up42.utils import get_logger, folium_base_map, DrawFoliumOverride, _plot_images
 
 try:
     from IPython.display import display

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -500,6 +500,19 @@ class Workflow(Tools):
 
         jobs_list = []
         job_nr = 0
+
+        p = Project(self.auth, self.project_id)
+
+        if max_concurrent_jobs > p.max_concurrent_jobs:
+            logger.error(
+                "Maximum concurrent jobs %d greater"
+                "than project settings %d."
+                "Use project.update_project_settings to change this value.",
+                max_concurrent_jobs,
+                p.max_concurrent_jobs,
+            )
+            raise ValueError("Too many concurrent jobs!")
+
         # Run all jobs in parallel batches of the max_concurrent_jobs (max. 10.)
         batches = [
             input_parameters_list[pos : pos + max_concurrent_jobs]

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -501,7 +501,10 @@ class Workflow(Tools):
         jobs_list = []
         job_nr = 0
 
-        p = Project(self.auth, self.project_id)
+        # Avoids circular dependencies
+        import project  # pylint: disable=import-outside-toplevel
+
+        p = project.Project(self.auth, self.project_id)
 
         if max_concurrent_jobs > p.max_concurrent_jobs:
             logger.error(

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -478,6 +478,9 @@ class Workflow(Tools):
             test_job: If set, runs a test query (search for available imagery based on your data parameters).
             name: The job name. Optional, by default the workflow name is assigned.
 
+        Raises:
+            ValueError: When max_concurrent_jobs is greater than max_concurrent_jobs set in project settings.
+
         Returns:
             The spawned real or test job object.
         """
@@ -587,7 +590,10 @@ class Workflow(Tools):
         )
 
     def test_jobs_parallel(
-        self, input_parameters_list: List[Dict] = None, name: str = None,
+        self,
+        input_parameters_list: List[Dict] = None,
+        name: str = None,
+        max_concurrent_jobs: int = 10,
     ) -> "JobCollection":
         """
         Create and run test jobs (Test Query) in parallel. With this test query you will not be
@@ -596,13 +602,15 @@ class Workflow(Tools):
         Args:
             input_parameters_list: List of dictionary of input parameters
             name: The job name. Optional, by default the workflow name is assigned.
+            max_concurrent_jobs: The maximum number of jobs to run in parallel.
+                This is defined in the project settings.
 
         Returns:
             The spawned test jobcollection object.
         """
         return self._helper_run_parallel_jobs(
             input_parameters_list=input_parameters_list,
-            max_concurrent_jobs=10,
+            max_concurrent_jobs=max_concurrent_jobs,
             test_job=True,
             name=name,
         )
@@ -630,7 +638,10 @@ class Workflow(Tools):
         )
 
     def run_jobs_parallel(
-        self, input_parameters_list: List[Dict] = None, name: str = None,
+        self,
+        input_parameters_list: List[Dict] = None,
+        name: str = None,
+        max_concurrent_jobs: int = 10,
     ) -> "JobCollection":
         """
         Create and run jobs in parallel.
@@ -638,13 +649,14 @@ class Workflow(Tools):
         Args:
             input_parameters_list: List of dictionary of input parameters
             name: The job name. Optional, by default the workflow name is assigned.
+            max_concurrent_jobs: The maximum number of jobs to run in parallel. This is defined in the project settings.
 
         Returns:
             The spawned test jobcollection object.
         """
         jobcollection = self._helper_run_parallel_jobs(
             input_parameters_list=input_parameters_list,
-            max_concurrent_jobs=10,
+            max_concurrent_jobs=max_concurrent_jobs,
             name=name,
         )
         return jobcollection

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -478,11 +478,11 @@ class Workflow(Tools):
             test_job: If set, runs a test query (search for available imagery based on your data parameters).
             name: The job name. Optional, by default the workflow name is assigned.
 
-        Raises:
-            ValueError: When max_concurrent_jobs is greater than max_concurrent_jobs set in project settings.
-
         Returns:
             The spawned real or test job object.
+
+        Raises:
+            ValueError: When max_concurrent_jobs is greater than max_concurrent_jobs set in project settings.
         """
         if input_parameters_list is None:
             raise ValueError(
@@ -606,7 +606,10 @@ class Workflow(Tools):
                 This is defined in the project settings.
 
         Returns:
-            The spawned test jobcollection object.
+            The spawned test JobCollection object.
+
+        Raises:
+            ValueError: When max_concurrent_jobs is greater than max_concurrent_jobs set in project settings.
         """
         return self._helper_run_parallel_jobs(
             input_parameters_list=input_parameters_list,
@@ -652,7 +655,10 @@ class Workflow(Tools):
             max_concurrent_jobs: The maximum number of jobs to run in parallel. This is defined in the project settings.
 
         Returns:
-            The spawned test jobcollection object.
+            The spawned JobCollection object.
+
+        Raises:
+            ValueError: When max_concurrent_jobs is greater than max_concurrent_jobs set in project settings.
         """
         jobcollection = self._helper_run_parallel_jobs(
             input_parameters_list=input_parameters_list,

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -11,11 +11,11 @@ from geojson import Feature, FeatureCollection
 from geojson import Polygon as geojson_Polygon
 from tqdm import tqdm
 
-from .auth import Auth
-from .job import Job
-from .jobcollection import JobCollection
-from .tools import Tools
-from .utils import get_logger, any_vector_to_fc, fc_to_query_geometry
+from up42.auth import Auth
+from up42.job import Job
+from up42.jobcollection import JobCollection
+from up42.tools import Tools
+from up42.utils import get_logger, any_vector_to_fc, fc_to_query_geometry
 
 logger = get_logger(__name__)
 

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -511,11 +511,9 @@ class Workflow(Tools):
 
         if max_concurrent_jobs > p.max_concurrent_jobs:
             logger.error(
-                "Maximum concurrent jobs %d greater"
-                "than project settings %d."
-                "Use project.update_project_settings to change this value.",
-                max_concurrent_jobs,
-                p.max_concurrent_jobs,
+                f"Maximum concurrent jobs {max_concurrent_jobs} greater"
+                f"than project settings {p.max_concurrent_jobs}."
+                "Use project.update_project_settings to change this value."
             )
             raise ValueError("Too many concurrent jobs!")
 

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -504,15 +504,10 @@ class Workflow(Tools):
         jobs_list = []
         job_nr = 0
 
-        # Avoids circular dependencies
-        import project  # pylint: disable=import-outside-toplevel
-
-        p = project.Project(self.auth, self.project_id)
-
-        if max_concurrent_jobs > p.max_concurrent_jobs:
+        if max_concurrent_jobs > self.max_concurrent_jobs:
             logger.error(
-                f"Maximum concurrent jobs {max_concurrent_jobs} greater"
-                f"than project settings {p.max_concurrent_jobs}."
+                f"Maximum concurrent jobs {max_concurrent_jobs} greater "
+                f"than project settings {self.max_concurrent_jobs}. "
                 "Use project.update_project_settings to change this value."
             )
             raise ValueError("Too many concurrent jobs!")
@@ -726,3 +721,12 @@ class Workflow(Tools):
         self.auth._request(request_type="DELETE", url=url, return_text=False)
         logger.info(f"Successfully deleted workflow: {self.workflow_id}")
         del self
+
+    @property
+    def max_concurrent_jobs(self) -> int:
+        """Gets the maximum number of concurrent jobs allowed by the project settings."""
+        url = f"{self.auth._endpoint()}/projects/{self.project_id}/settings"
+        response_json = self.auth._request(request_type="GET", url=url)
+        project_settings = response_json["data"]
+        project_settings_dict = {d["name"]: int(d["value"]) for d in project_settings}
+        return project_settings_dict["MAX_CONCURRENT_JOBS"]


### PR DESCRIPTION
Currently the maximum number of concurrent jobs is a project setting in UP42. This PR makes necessary changes that check the maximum number of concurrent jobs in settings and raises a ValueError when users select a higher number in the run_parallel_job method. This avoids unhandled API errors when the number of concurrent jobs is exceeded.

In addition:

- [x] Removed relative imports from modules to avoid ImportError
- [x] Added max_concurrent_jobs property to Project
- [x] Small fixes in docs and docstrings