### PR TITLE
Simpler workflow creation - up4765

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,11 @@ up42.authenticate(project_id="12345", project_api_key="12345")
 # up42.authenticate(cfg_file="config.json")
 
 project = up42.initialize_project()
-workflow = project.create_workflow(name="30-seconds-workflow", use_existing=True)
 
-# Add data and processing blocks to the workflow.
 print(up42.get_blocks(basic=True))
-input_tasks = ['sobloo-s2-l1c-aoiclipped', 'sharpening']
-workflow.add_workflow_tasks(input_tasks=input_tasks)
+workflow = project.create_workflow(name="30-seconds-workflow", 
+                                   blocks=['sobloo-s2-l1c-aoiclipped', 'sharpening'], 
+                                   use_existing=True)
 
 # Define the aoi and input parameters of the workflow.
 aoi = workflow.get_example_aoi(as_dataframe=True)

--- a/docs/30-second-example.md
+++ b/docs/30-second-example.md
@@ -19,13 +19,11 @@ up42.authenticate(project_id="123", project_api_key="456")
 # up42.authenticate(cfg_file="config.json")
 
 project = up42.initialize_project()
-workflow = project.create_workflow(name="30-seconds-workflow", 
-                                   use_existing=True)
 
-# Add data and processing blocks to the workflow.
 print(up42.get_blocks(basic=True))
-input_tasks = ['sobloo-s2-l1c-aoiclipped', 'sharpening']
-workflow.add_workflow_tasks(input_tasks=input_tasks)
+workflow = project.create_workflow(name="30-seconds-workflow",
+                                   blocks=['sobloo-s2-l1c-aoiclipped', 'sharpening'],
+                                   use_existing=True)
 
 # Define the aoi and input parameters of the workflow.
 aoi = workflow.get_example_aoi(as_dataframe=True)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Live on github pages:
 ## Installation for doc development:
 ```
 cd docs
-pip install -r requirements_docs.txt
+pip install -r requirements_dev.txt
 ```
 
 ## HTML Preview Server
@@ -22,11 +22,13 @@ Reinstall Python package via
 pip install -e .
 ```
 
+## Build site (Not really neccessary due to preview function):
+```
+mkdocs build
+```
+
 ## Publish
 ```
 mkdocs gh-deploy
 ```
 Pushes to the `gh-deploy` branch and republishes as github pages.
-
-For more infos see readme here:
-https://github.com/up42/docs_mkdocs

--- a/docs/detailed-example.md
+++ b/docs/detailed-example.md
@@ -32,38 +32,23 @@ You can either create a new workflow, use project.get_workflows() to get all exi
 
 
 ```python
-# Create a new, empty workflow.
-workflow = project.create_workflow(name="30-seconds-workflow", 
+# Either create a workflow directly filled with tasks
+workflow = project.create_workflow(name="30-seconds-workflow",
+                                   blocks=['sobloo-s2-l1c-aoiclipped', 'sharpening'],
                                    use_existing=True)
 workflow
 ```
 
 
 ```python
-# Add workflow tasks - simple version. See above .get_blocks() result.
-input_tasks= ['sobloo-s2-l1c-aoiclipped', 'sharpening']
-workflow.add_workflow_tasks(input_tasks=input_tasks)
-```
+# Or Create a new, empty workflow an fill/edit the tasks manually
+workflow = project.create_workflow(name="30-seconds-workflow", use_existing=False)
+workflow
 
+workflow.add_workflow_tasks(input_tasks=['sobloo-s2-l1c-aoiclipped', 'sharpening'])
 
-```python
-# Alternative: Add workflow tasks - complex version, gives you more control 
-# about the block connections.
-
-input_tasks = [
-    {
-        "name": "sobloo-s2-l1c-aoiclipped:1",
-        "parentName": None,
-        "blockId": "a2daaab4-196d-4226-a018-a810444dcad1"
-    },
-    {
-        "name": "sharpening:1",
-        "parentName": "sobloo-s2-l1c-aoiclipped:1",
-        "blockId": "4ed70368-d4e1-4462-bef6-14e768049471"
-    }
-]
-
-workflow.add_workflow_tasks(input_tasks=input_tasks)
+# Instead of the block names you can also use the block ids, which point to a specific block version.
+# ["a2daaab4-196d-4226-a018-a810444dcad1", "4ed70368-d4e1-4462-bef6-14e768049471"]
 ```
 
 

--- a/examples/airports-parallel.ipynb
+++ b/examples/airports-parallel.ipynb
@@ -286,41 +286,9 @@
     }
    ],
    "source": [
-    "workflow = project.create_workflow(\"workflow_airports\", use_existing=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2020-08-07 10:04:42,249 - up42.workflow - INFO - Added tasks to workflow: [{'name': 'sobloo-s2-l1c-aoiclipped:1', 'parentName': None, 'blockId': 'a2daaab4-196d-4226-a018-a810444dcad1'}]\n",
-      "2020-08-07 10:04:42,697 - up42.workflow - INFO - Got 1 tasks/blocks in workflow 4022cf7c-fa26-4dd4-a2c6-b37583cacc27.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'sobloo-s2-l1c-aoiclipped:1': '10b80b0d-9b99-4a2d-b5a4-2cbd8331cc0d'}"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Fill the workflow with tasks\n",
-    "\n",
-    "#blocks = up42.get_blocks(basic=True)\n",
-    "selected_block = \"sobloo-s2-l1c-aoiclipped\"\n",
-    "workflow.add_workflow_tasks([selected_block])\n",
-    "\n",
-    "workflow.get_workflow_tasks(basic=True)"
+    "workflow = project.create_workflow(\"workflow_airports\", \n",
+    "                                   blocks=[\"sobloo-s2-l1c-aoiclipped\"], \n",
+    "                                   use_existing=True)"
    ]
   },
   {

--- a/examples/flood_mapping.ipynb
+++ b/examples/flood_mapping.ipynb
@@ -140,7 +140,8 @@
     "project = up42.initialize_project()\n",
     "    \n",
     "# init workflow\n",
-    "workflow = project.create_workflow(name=\"flooding_sentinel\")"
+    "workflow = project.create_workflow(name=\"flooding_sentinel\",\n",
+    "                                   blocks=['sentinelhub-s2-aoiclipped'])"
    ]
   },
   {
@@ -175,11 +176,6 @@
     }
    ],
    "source": [
-    "input_tasks = ['sentinelhub-s2-aoiclipped']\n",
-    "\n",
-    "# Update workflow object with our desired data block as input_task(s)\n",
-    "workflow.add_workflow_tasks(input_tasks=input_tasks)\n",
-    "\n",
     "# read aoi\n",
     "aoi = workflow.read_vector_file(\"data/aoi_bellevue_US.geojson\", as_dataframe=True)\n",
     "\n",

--- a/examples/guides/30-seconds-example.ipynb
+++ b/examples/guides/30-seconds-example.ipynb
@@ -31,12 +31,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add blocks/tasks to the workflow.\n",
-    "workflow = project.create_workflow(name=\"30-seconds-workflow\", \n",
-    "                                   use_existing=True)\n",
-    "print(up42.get_blocks(basic=True))\n",
-    "input_tasks= ['sobloo-s2-l1c-aoiclipped', 'sharpening']\n",
-    "workflow.add_workflow_tasks(input_tasks=input_tasks)"
+    "up42.get_blocks(basic=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workflow = project.create_workflow(name=\"30-seconds-workflow\",\n",
+    "                                   blocks=['sobloo-s2-l1c-aoiclipped', 'sharpening'],\n",
+    "                                   use_existing=True)"
    ]
   },
   {
@@ -113,7 +119,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/examples/guides/catalog.ipynb
+++ b/examples/guides/catalog.ipynb
@@ -116,7 +116,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/examples/guides/detailed-example.ipynb
+++ b/examples/guides/detailed-example.ipynb
@@ -76,46 +76,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create a new, empty workflow.\n",
-    "\n",
+    "# Either create a workflow directly filled with tasks\n",
+    "workflow = project.create_workflow(name=\"30-seconds-workflow\",\n",
+    "                                   blocks=['sobloo-s2-l1c-aoiclipped', 'sharpening'],\n",
+    "                                   use_existing=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Or Create a new, empty workflow an fill/edit the tasks manually\n",
     "workflow = project.create_workflow(name=\"30-seconds-workflow\", use_existing=False)\n",
-    "workflow"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Add workflow tasks - simple version. See above .get_blocks() result.\n",
+    "workflow\n",
     "\n",
-    "input_tasks= [\"a2daaab4-196d-4226-a018-a810444dcad1\", \"4ed70368-d4e1-4462-bef6-14e768049471\"]\n",
-    "workflow.add_workflow_tasks(input_tasks=input_tasks)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Alternative: Add workflow tasks - complex version, gives you more control about the block connections.\n",
+    "workflow.add_workflow_tasks(input_tasks=['sobloo-s2-l1c-aoiclipped', 'sharpening'])\n",
     "\n",
-    "input_tasks = [\n",
-    "    {\n",
-    "        \"name\": \"sobloo-s2-l1c-aoiclipped:1\",\n",
-    "        \"parentName\": None,\n",
-    "        \"blockId\": \"a2daaab4-196d-4226-a018-a810444dcad1\"\n",
-    "    },\n",
-    "    {\n",
-    "        \"name\": \"sharpening:1\",\n",
-    "        \"parentName\": \"sobloo-s2-l1c-aoiclipped:1\",\n",
-    "        \"blockId\": \"4ed70368-d4e1-4462-bef6-14e768049471\"\n",
-    "    }\n",
-    "]\n",
-    "\n",
-    "workflow.add_workflow_tasks(input_tasks=input_tasks)"
+    "# Instead of the block names you can also use the block ids, which point to a specific block version.\n",
+    "# [\"a2daaab4-196d-4226-a018-a810444dcad1\", \"4ed70368-d4e1-4462-bef6-14e768049471\"]"
    ]
   },
   {
@@ -125,17 +105,7 @@
    "outputs": [],
    "source": [
     "# Check the added tasks.\n",
-    "\n",
     "workflow.get_workflow_tasks(basic=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#workflow.get_jobs()"
    ]
   },
   {
@@ -377,7 +347,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/examples/radar_processing_1.ipynb
+++ b/examples/radar_processing_1.ipynb
@@ -78,7 +78,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create workflow and check available blocks and data"
+    "Check available blocks and create workflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "up42.get_blocks(basic=True)"
    ]
   },
   {
@@ -107,8 +116,19 @@
    ],
    "source": [
     "workflow = S1_SNAP_project.create_workflow(name=\"S1-GRD_SNAP\", \n",
-    "                                   use_existing=True)\n",
-    "print(up42.get_blocks(basic=True))"
+    "                                           blocks=['sobloo-s1-grd-fullscene', 'snap-polarimetric'],\n",
+    "                                           use_existing=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define aoi and input parameters\n",
+    "\n",
+    "The S1 GRD block always delivers the complete images as they are delivered in SAFE format which cannot be clipped.\n",
+    "The image can be clipped though by the SNAP polarimetric processing blocks. For this it is necessary to supply the same geometry (in this case a bbox) to that block as well. \n",
+    "\n"
    ]
   },
   {
@@ -161,21 +181,7 @@
     }
    ],
    "source": [
-    "# Fill the workflow with tasks\n",
-    "input_tasks= ['sobloo-s1-grd-fullscene', 'snap-polarimetric']\n",
-    "workflow.add_workflow_tasks(input_tasks=input_tasks)\n",
     "workflow.get_parameters_info()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Define aoi and input parameters\n",
-    "\n",
-    "The S1 GRD block always delivers the complete images as they are delivered in SAFE format which cannot be clipped.\n",
-    "The image can be clipped though by the SNAP polarimetric processing blocks. For this it is necessary to supply the same geometry (in this case a bbox) to that block as well. \n",
-    "\n"
    ]
   },
   {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,8 +94,6 @@ plugins:
         - ".ipynb_checkpoints"
         - "*examples/project*"
         - "*examples/guides/*"
-  #- minify:
-  #    minify_html: false
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/up42/project.py
+++ b/up42/project.py
@@ -40,7 +40,7 @@ class Project(Tools):
         self,
         name: str,
         description: str = "",
-        workflow_tasks: List = None,
+        blocks: List = None,
         use_existing: bool = False,
     ) -> "Workflow":
         """
@@ -49,8 +49,8 @@ class Project(Tools):
         Args:
             name: Name of the new workflow.
             description: Description of the new workflow.
-            workflow_tasks: List of workflow tasks (blocks) that the workflow should
-                consist of. Can be a list of block names, block ods or block display names.
+            blocks: List of blocks/tasks that the workflow should consist of.
+                Can be a list of block names, block ids or block display names.
                 If not provided, an empty workflow will be created and you
                 can use `workflow.add_workflow_tasks()` to add/edit them.
             use_existing: If True, instead of creating a new workflow, uses the
@@ -86,8 +86,8 @@ class Project(Tools):
         workflow = Workflow(
             self.auth, project_id=self.project_id, workflow_id=workflow_id
         )
-        if workflow_tasks:
-            workflow.add_workflow_tasks(input_tasks=workflow_tasks)
+        if blocks:
+            workflow.add_workflow_tasks(input_tasks=blocks)
         return workflow
 
     def get_workflows(self, return_json: bool = False) -> Union[List["Workflow"], Dict]:

--- a/up42/project.py
+++ b/up42/project.py
@@ -37,7 +37,11 @@ class Project(Tools):
         return self.info
 
     def create_workflow(
-        self, name: str, description: str = "", use_existing: bool = False
+        self,
+        name: str,
+        description: str = "",
+        workflow_tasks: List = None,
+        use_existing: bool = False,
     ) -> "Workflow":
         """
         Creates a new workflow and returns a workflow object.
@@ -45,6 +49,10 @@ class Project(Tools):
         Args:
             name: Name of the new workflow.
             description: Description of the new workflow.
+            workflow_tasks: List of workflow tasks (blocks) that the workflow should
+                consist of. Can be a list of block names, block ods or block display names.
+                If not provided, an empty workflow will be created and you
+                can use `workflow.add_workflow_tasks()` to add/edit them.
             use_existing: If True, instead of creating a new workflow, uses the
                 most recent workflow with the same name & description.
 
@@ -78,6 +86,8 @@ class Project(Tools):
         workflow = Workflow(
             self.auth, project_id=self.project_id, workflow_id=workflow_id
         )
+        if workflow_tasks:
+            workflow.add_workflow_tasks(input_tasks=workflow_tasks)
         return workflow
 
     def get_workflows(self, return_json: bool = False) -> Union[List["Workflow"], Dict]:


### PR DESCRIPTION
Adds the option to define blocks to be added to the workflow right in `project.create_workflow`. A suggestion by @jngo, this would be the new default, simpler way to define a workflow. Removes a bit of clutter from all examples and imho makes the process easier. Also prepares for the simple usage of recipes/shortcuts/templates.

Think it's really neat but indeed a draft PR, open for discussion!

```
workflow = project.create_workflow(name="30-seconds-workflow", 
                                   blocks=['sobloo-s2-l1c-aoiclipped', 'sharpening'])
```
instead of

```
workflow = project.create_workflow(name="30-seconds-workflow")
workflow.add_workflow_tasks(input_tasks=input_tasks)
```

`workflow.add_workflow_tasks()` would be less important and essentially only used under the hood or to alter an existing workflow object.

Function/argument naming should be overhauled at some point (with save deprecation), e.g. add_workflow_tasks is unneccessarily long.