### PR TITLE
Download jobtasks to subfolder - up4865

### DIFF
--- a/tests/test_jobtask.py
+++ b/tests/test_jobtask.py
@@ -74,7 +74,12 @@ def test_jobtask_download_result(jobtask_mock):
             assert len(out_files) == 2
 
         # With default outdir
-        default_outdir = Path.cwd() / f"project_{jobtask_mock.auth.project_id}/job_{jobtask_mock.job_id}/jobtask_{jobtask_mock.jobtask_id}"
+        default_outdir = (
+            Path.cwd()
+            / f"project_{jobtask_mock.auth.project_id}/job_{jobtask_mock.job_id}/jobtask_{jobtask_mock.jobtask_id}"
+        )
+        if default_outdir.exists():
+            shutil.rmtree(default_outdir)
         out_files = jobtask_mock.download_results()
         assert default_outdir.exists()
         assert default_outdir.is_dir()

--- a/tests/test_jobtask.py
+++ b/tests/test_jobtask.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import tempfile
+import shutil
 
 import requests_mock
 import pytest
@@ -65,11 +66,23 @@ def test_jobtask_download_result(jobtask_mock):
             headers={"x-goog-stored-content-length": "221"},
         )
 
+        # With specified outdir
         with tempfile.TemporaryDirectory() as tempdir:
             out_files = jobtask_mock.download_results(output_directory=tempdir)
             for file in out_files:
                 assert Path(file).exists()
             assert len(out_files) == 2
+
+        # With default outdir
+        default_outdir = Path.cwd() / f"project_{jobtask_mock.auth.project_id}/job_{jobtask_mock.job_id}/jobtask_{jobtask_mock.jobtask_id}"
+        out_files = jobtask_mock.download_results()
+        assert default_outdir.exists()
+        assert default_outdir.is_dir()
+        for file in out_files:
+            assert Path(file).exists()
+        assert len(out_files) == 2
+        assert str(default_outdir) in str(out_files[0])
+        shutil.rmtree(default_outdir)
 
 
 @pytest.mark.live

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -249,9 +249,7 @@ class Catalog(Tools):
         )
 
         if output_directory is None:
-            output_directory = (
-                Path.cwd() / f"project_{self.auth.project_id}" / "catalog"
-            )
+            output_directory = Path.cwd() / f"project_{self.auth.project_id}/catalog"
         else:
             output_directory = Path(output_directory)
         output_directory.mkdir(parents=True, exist_ok=True)

--- a/up42/job.py
+++ b/up42/job.py
@@ -191,7 +191,7 @@ class Job(Tools):
 
         if output_directory is None:
             output_directory = (
-                Path.cwd() / f"project_{self.auth.project_id}" / f"job_{self.job_id}"
+                Path.cwd() / f"project_{self.auth.project_id}/job_{self.job_id}"
             )
         else:
             output_directory = Path(output_directory)

--- a/up42/jobtask.py
+++ b/up42/jobtask.py
@@ -99,7 +99,8 @@ class JobTask(Tools):
 
         if output_directory is None:
             output_directory = (
-                Path.cwd() / f"project_{self.auth.project_id}" / f"job_{self.job_id}"
+                Path.cwd()
+                / f"project_{self.auth.project_id}/job_{self.job_id}/jobtask_{self.jobtask_id}"
             )
         else:
             output_directory = Path(output_directory)

--- a/up42/jobtask.py
+++ b/up42/jobtask.py
@@ -133,6 +133,9 @@ class JobTask(Tools):
             The quicklooks filepaths.
         """
         if output_directory is None:
+            # On purpose downloading the quicklooks to the jobs folder and not the
+            # jobtasks folder,since only relevant for data block task. And clearer
+            # for job.download_quicklooks.
             output_directory = (
                 Path.cwd() / f"project_{self.auth.project_id}" / f"job_{self.job_id}"
             )


### PR DESCRIPTION
When using the default output dir, Jobtasks were downloaded to the jobs folder. When downloading multiple jobtasks this lead to overwritten files. Now downloading to cwd/project_id/job_id/jobtask_id.