### PR TITLE
Main to up42 name in CLI

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,11 +1,10 @@
 # Command Line Interface (CLI)
 
-The CLI tool allows you to use the UP42 functionality from the command line. 
+The CLI tool allows you to use the UP42 functionality from the command line.
 It is installed automatically with and based on the Python SDK.
 
 
 ::: mkdocs-click
     :module: up42.cli
-    :command: main
+    :command: up42
     :depth: 1
-    

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ mkdocs-jupyter
 mkdocs-exclude
 mkdocs-click
 mkdocstrings
+nbconvert==5.6.1
 black
 requests-mock
 pylint==2.5.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=parent_dir.joinpath("requirements.txt").read_text().splitlines(),
     entry_points="""
         [console_scripts]
-        up42=up42.cli:main
+        up42=up42.cli:up42
     """,
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,15 +43,15 @@ JOB_ENVS = mock.patch.dict(
 
 @PROJECT_ENVS
 @pytest.mark.live()
-def test_main_live(cli_runner):
-    result = cli_runner.invoke(cli.main)
+def test_up42_live(cli_runner):
+    result = cli_runner.invoke(cli.up42)
     assert result.exit_code == 0
 
 
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_auth_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["auth"])
+    result = cli_runner.invoke(cli.up42, ["auth"])
     assert result.exit_code == 0
 
 
@@ -59,56 +59,56 @@ def test_auth_live(cli_runner):
 @pytest.mark.live()
 def test_config_live(cli_runner):
     with cli_runner.isolated_filesystem():
-        result = cli_runner.invoke(cli.main, ["config"])
+        result = cli_runner.invoke(cli.up42, ["config"])
         assert result.exit_code == 0
 
 
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_get_blocks_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["get-blocks"])
+    result = cli_runner.invoke(cli.up42, ["get-blocks"])
     assert result.exit_code == 0
 
 
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_get_block_details_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["get-block-details", "-h"])
+    result = cli_runner.invoke(cli.up42, ["get-block-details", "-h"])
     assert result.exit_code == 0
 
-    result = cli_runner.invoke(cli.main, ["get-block-details", "-n", "tiling"])
+    result = cli_runner.invoke(cli.up42, ["get-block-details", "-n", "tiling"])
     assert result.exit_code == 0
 
-    result = cli_runner.invoke(cli.main, ["get-block-details", "-n", "never_a_block"])
+    result = cli_runner.invoke(cli.up42, ["get-block-details", "-n", "never_a_block"])
     assert result.exit_code == 2
 
 
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_validate_manifest_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["validate-manifest", "-h"])
+    result = cli_runner.invoke(cli.up42, ["validate-manifest", "-h"])
     assert result.exit_code == 0
 
     mock_manifest = Path(__file__).resolve().parent / "mock_data/manifest.json"
-    result = cli_runner.invoke(cli.main, ["validate-manifest", str(mock_manifest)])
+    result = cli_runner.invoke(cli.up42, ["validate-manifest", str(mock_manifest)])
     assert result.exit_code == 0
 
 
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_project_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["project"])
+    result = cli_runner.invoke(cli.up42, ["project"])
     assert result.exit_code == 0
 
 
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_create_workflow_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["project", "create-workflow", "-h"])
+    result = cli_runner.invoke(cli.up42, ["project", "create-workflow", "-h"])
     assert result.exit_code == 0
 
     # result = cli_runner.invoke(
-    #    cli.main, ["project", "create-workflow", "a_cli_workflow"]
+    #    cli.up42, ["project", "create-workflow", "a_cli_workflow"]
     # )
     # assert result.exit_code == 0
 
@@ -116,37 +116,37 @@ def test_create_workflow_live(cli_runner):
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_get_project_settings_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["project", "get-project-settings"])
+    result = cli_runner.invoke(cli.up42, ["project", "get-project-settings"])
     assert result.exit_code == 0
 
 
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_get_workflows_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["project", "get-workflows"])
+    result = cli_runner.invoke(cli.up42, ["project", "get-workflows"])
     assert result.exit_code == 0
 
 
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_update_project_settings_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["project", "update-project-settings", "-h"])
+    result = cli_runner.invoke(cli.up42, ["project", "update-project-settings", "-h"])
     assert result.exit_code == 0
 
 
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_workflow_from_name_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["project", "workflow-from-name", "-h"])
+    result = cli_runner.invoke(cli.up42, ["project", "workflow-from-name", "-h"])
     assert result.exit_code == 0
 
     result = cli_runner.invoke(
-        cli.main, ["project", "workflow-from-name", "-n", "test_cli"]
+        cli.up42, ["project", "workflow-from-name", "-n", "test_cli"]
     )
     assert result.exit_code == 0
 
     result = cli_runner.invoke(
-        cli.main, ["project", "workflow-from-name", "-n", "never_a_workflow"]
+        cli.up42, ["project", "workflow-from-name", "-n", "never_a_workflow"]
     )
     assert result.exit_code == 2
 
@@ -154,10 +154,10 @@ def test_workflow_from_name_live(cli_runner):
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_workflow_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["workflow", "-h"])
+    result = cli_runner.invoke(cli.up42, ["workflow", "-h"])
     assert result.exit_code == 0
 
-    result = cli_runner.invoke(cli.main, ["workflow"])
+    result = cli_runner.invoke(cli.up42, ["workflow"])
     assert result.exit_code == 0
 
 
@@ -165,7 +165,7 @@ def test_workflow_live(cli_runner):
 @WORKFLOW_ENVS
 @pytest.mark.live()
 def test_workflow_get_info_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["workflow", "get-info"])
+    result = cli_runner.invoke(cli.up42, ["workflow", "get-info"])
     assert result.exit_code == 0
 
 
@@ -173,7 +173,7 @@ def test_workflow_get_info_live(cli_runner):
 @WORKFLOW_ENVS
 @pytest.mark.live()
 def test_workflow_update_name_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["workflow", "update-name", "-h"])
+    result = cli_runner.invoke(cli.up42, ["workflow", "update-name", "-h"])
     assert result.exit_code == 0
 
 
@@ -181,7 +181,7 @@ def test_workflow_update_name_live(cli_runner):
 @WORKFLOW_ENVS
 @pytest.mark.live()
 def test_workflow_delete_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["workflow", "delete", "-h"])
+    result = cli_runner.invoke(cli.up42, ["workflow", "delete", "-h"])
     assert result.exit_code == 0
 
 
@@ -189,7 +189,7 @@ def test_workflow_delete_live(cli_runner):
 @WORKFLOW_ENVS
 @pytest.mark.live()
 def test_get_jobs_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["workflow", "get-jobs"])
+    result = cli_runner.invoke(cli.up42, ["workflow", "get-jobs"])
     assert result.exit_code == 0
 
 
@@ -197,7 +197,7 @@ def test_get_jobs_live(cli_runner):
 @WORKFLOW_ENVS
 @pytest.mark.live()
 def test_get_workflow_tasks_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["workflow", "get-workflow-tasks"])
+    result = cli_runner.invoke(cli.up42, ["workflow", "get-workflow-tasks"])
     assert result.exit_code == 0
 
 
@@ -205,7 +205,7 @@ def test_get_workflow_tasks_live(cli_runner):
 @WORKFLOW_ENVS
 @pytest.mark.live()
 def test_get_parameters_info_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["workflow", "get-parameters-info"])
+    result = cli_runner.invoke(cli.up42, ["workflow", "get-parameters-info"])
     assert result.exit_code == 0
 
 
@@ -213,7 +213,7 @@ def test_get_parameters_info_live(cli_runner):
 @WORKFLOW_ENVS
 @pytest.mark.live()
 def test_get_compatible_blocks_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["workflow", "get-compatible-blocks"])
+    result = cli_runner.invoke(cli.up42, ["workflow", "get-compatible-blocks"])
     assert result.exit_code == 0
 
 
@@ -221,14 +221,14 @@ def test_get_compatible_blocks_live(cli_runner):
 @WORKFLOW_ENVS
 @pytest.mark.live()
 def test_add_workflow_tasks_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["workflow", "add-workflow-tasks", "-h"])
+    result = cli_runner.invoke(cli.up42, ["workflow", "add-workflow-tasks", "-h"])
     assert result.exit_code == 0
 
     input_tasks_json = (
         Path(__file__).resolve().parent / "mock_data/input_tasks_simple.json"
     )
     result = cli_runner.invoke(
-        cli.main, ["workflow", "add-workflow-tasks", str(input_tasks_json)]
+        cli.up42, ["workflow", "add-workflow-tasks", str(input_tasks_json)]
     )
     assert result.exit_code == 0
 
@@ -237,14 +237,14 @@ def test_add_workflow_tasks_live(cli_runner):
 @WORKFLOW_ENVS
 @pytest.mark.live()
 def test_test_job_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["workflow", "test-job", "-h"])
+    result = cli_runner.invoke(cli.up42, ["workflow", "test-job", "-h"])
     assert result.exit_code == 0
 
     input_parameters_json = (
         Path(__file__).resolve().parent / "mock_data/input_params_simple.json"
     )
     result = cli_runner.invoke(
-        cli.main,
+        cli.up42,
         [
             "workflow",
             "test-job",
@@ -259,14 +259,14 @@ def test_test_job_live(cli_runner):
 @WORKFLOW_ENVS
 @pytest.mark.live()
 def test_run_job_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["workflow", "run-job", "-h"])
+    result = cli_runner.invoke(cli.up42, ["workflow", "run-job", "-h"])
     assert result.exit_code == 0
 
     input_parameters_json = (
         Path(__file__).resolve().parent / "mock_data/input_params_simple.json"
     )
     result = cli_runner.invoke(
-        cli.main,
+        cli.up42,
         [
             "workflow",
             "run-job",
@@ -281,10 +281,10 @@ def test_run_job_live(cli_runner):
 @JOB_ENVS
 @pytest.mark.live()
 def test_job_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["job", "-h"])
+    result = cli_runner.invoke(cli.up42, ["job", "-h"])
     assert result.exit_code == 0
 
-    result = cli_runner.invoke(cli.main, ["job"])
+    result = cli_runner.invoke(cli.up42, ["job"])
     assert result.exit_code == 0
 
 
@@ -292,7 +292,7 @@ def test_job_live(cli_runner):
 @JOB_ENVS
 @pytest.mark.live()
 def test_job_get_info_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["job", "get-info"])
+    result = cli_runner.invoke(cli.up42, ["job", "get-info"])
     assert result.exit_code == 0
 
 
@@ -300,7 +300,7 @@ def test_job_get_info_live(cli_runner):
 @JOB_ENVS
 @pytest.mark.live()
 def test_cancel_job_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["job", "cancel-job", "-h"])
+    result = cli_runner.invoke(cli.up42, ["job", "cancel-job", "-h"])
     assert result.exit_code == 0
 
 
@@ -308,7 +308,7 @@ def test_cancel_job_live(cli_runner):
 @JOB_ENVS
 @pytest.mark.live()
 def test_download_quicklooks_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["job", "download-quicklooks", "-h"])
+    result = cli_runner.invoke(cli.up42, ["job", "download-quicklooks", "-h"])
     assert result.exit_code == 0
 
 
@@ -316,7 +316,7 @@ def test_download_quicklooks_live(cli_runner):
 @JOB_ENVS
 @pytest.mark.live()
 def test_download_results_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["job", "download-results", "-h"])
+    result = cli_runner.invoke(cli.up42, ["job", "download-results", "-h"])
     assert result.exit_code == 0
 
 
@@ -324,7 +324,7 @@ def test_download_results_live(cli_runner):
 @JOB_ENVS
 @pytest.mark.live()
 def test_get_jobtasks_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["job", "get-jobtasks"])
+    result = cli_runner.invoke(cli.up42, ["job", "get-jobtasks"])
     assert result.exit_code == 0
 
 
@@ -332,7 +332,7 @@ def test_get_jobtasks_live(cli_runner):
 @JOB_ENVS
 @pytest.mark.live()
 def test_jobtasks_results_json_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["job", "get-jobtasks-results-json"])
+    result = cli_runner.invoke(cli.up42, ["job", "get-jobtasks-results-json"])
     assert result.exit_code == 0
 
 
@@ -340,7 +340,7 @@ def test_jobtasks_results_json_live(cli_runner):
 @JOB_ENVS
 @pytest.mark.live()
 def test_get_logs_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["job", "get-logs"])
+    result = cli_runner.invoke(cli.up42, ["job", "get-logs"])
     assert result.exit_code == 0
 
 
@@ -348,7 +348,7 @@ def test_get_logs_live(cli_runner):
 @JOB_ENVS
 @pytest.mark.live()
 def test_get_results_json_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["job", "get-results-json"])
+    result = cli_runner.invoke(cli.up42, ["job", "get-results-json"])
     assert result.exit_code == 0
 
 
@@ -356,7 +356,7 @@ def test_get_results_json_live(cli_runner):
 @JOB_ENVS
 @pytest.mark.live()
 def test_get_status_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["job", "get-status"])
+    result = cli_runner.invoke(cli.up42, ["job", "get-status"])
     assert result.exit_code == 0
 
 
@@ -364,26 +364,26 @@ def test_get_status_live(cli_runner):
 @JOB_ENVS
 @pytest.mark.live()
 def test_track_status_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["job", "track-status"])
+    result = cli_runner.invoke(cli.up42, ["job", "track-status"])
     assert result.exit_code == 0
 
 
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_catalog_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["catalog", "-h"])
+    result = cli_runner.invoke(cli.up42, ["catalog", "-h"])
     assert result.exit_code == 0
 
 
 @PROJECT_ENVS
 @pytest.mark.live()
 def test_construct_parameters_live(cli_runner):
-    result = cli_runner.invoke(cli.main, ["catalog", "construct-parameters", "-h"])
+    result = cli_runner.invoke(cli.up42, ["catalog", "construct-parameters", "-h"])
     assert result.exit_code == 0
 
     aoi_geojson = Path(__file__).resolve().parent / "mock_data/aoi_berlin.geojson"
     result = cli_runner.invoke(
-        cli.main, ["catalog", "construct-parameters", str(aoi_geojson)]
+        cli.up42, ["catalog", "construct-parameters", str(aoi_geojson)]
     )
     assert result.exit_code == 0
 
@@ -395,6 +395,6 @@ def test_catalog_search_live(cli_runner):
         Path(__file__).resolve().parent / "mock_data/search_params_simple.json"
     )
     result = cli_runner.invoke(
-        cli.main, ["catalog", "search", str(search_parameters_json)]
+        cli.up42, ["catalog", "search", str(search_parameters_json)]
     )
     assert result.exit_code == 0

--- a/up42/cli.py
+++ b/up42/cli.py
@@ -57,7 +57,7 @@ def cfg_default(defult_path="./config.json"):
 )
 @click.option("--env", default="com")
 @click.pass_context
-def main(ctx, project_id, project_api_key, cfg_file, env):
+def up42(ctx, project_id, project_api_key, cfg_file, env):
     ctx.ensure_object(dict)
     if project_id and project_api_key:
         ctx.obj = Auth(project_id=project_id, project_api_key=project_api_key, env=env)
@@ -65,7 +65,7 @@ def main(ctx, project_id, project_api_key, cfg_file, env):
         ctx.obj = Auth(cfg_file=cfg_file, env=env)
 
 
-COMMAND = main.command(context_settings=CONTEXT_SETTINGS)
+COMMAND = up42.command(context_settings=CONTEXT_SETTINGS)
 
 
 @COMMAND
@@ -190,7 +190,7 @@ def validate_manifest(auth, manifest_json):
 
 
 # Project
-@main.group()
+@up42.group()
 @click.pass_context
 def project(ctx):
     """
@@ -297,7 +297,7 @@ def workflow_from_name(project, workflow_name):
 
 
 # Workflows
-@main.group()
+@up42.group()
 @click.pass_context
 @click.option(
     "-wid",
@@ -467,7 +467,7 @@ def run_job(workflow, input_parameters_json, track):
 
 
 # Jobs
-@main.group()
+@up42.group()
 @click.pass_context
 @click.option(
     "-jid",
@@ -602,7 +602,7 @@ def track_status(job, interval):
 # Catalog
 
 
-@main.group()
+@up42.group()
 @click.pass_context
 def catalog(ctx):
     """


### PR DESCRIPTION
Updates the main module of the CLI to be called up42. This allows mkdocs-click to properly display the commands in the reference. Consequence of issue answer from mkdocs-click package https://github.com/DataDog/mkdocs-click/issues/6.