### PR TITLE
Fix download results up4867

### DIFF
--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -234,7 +234,8 @@ def test_job_download_result(job_mock):
             for path in out_paths:
                 assert path.exists()
             assert len(out_paths) == 2
-            assert out_paths[0].name == "data.json"
+            assert out_paths[0].name == "7e17f023-a8e3-43bd-aaac-5bbef749c7f4_0-0.tif"
+            assert out_paths[1].name == "data.json"
             assert out_paths[1].parent.exists()
             assert out_paths[1].parent.is_dir()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -277,10 +277,13 @@ def test_download_result_from_gcs():
             content=out_tgz_file.read(),
         )
         with tempfile.TemporaryDirectory() as tempdir:
+            with open(Path(tempdir) / "dummy.txt", "w") as fp:
+                fp.write("dummy")
             out_files = download_results_from_gcs(
                 download_url=cloud_storage_url,
                 output_directory=tempdir,
             )
+
             for file in out_files:
                 assert Path(file).exists()
             assert len(out_files) == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -284,6 +284,7 @@ def test_download_result_from_gcs():
             for file in out_files:
                 assert Path(file).exists()
             assert len(out_files) == 2
+            assert not (Path(tempdir) / "output").exists()
 
 
 def test_map_images_2_scenes():

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -81,6 +81,7 @@ def download_results_from_gcs(
         for src_path in output_folder_path.glob("**/*"):
             dst_path = output_directory / src_path.relative_to(output_folder_path)
             shutil.move(str(src_path), str(dst_path))
+        output_folder_path.rmdir()
         out_filepaths = [str(x) for x in output_directory.glob("**/*") if x.is_file()]
 
     logger.info(

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -78,11 +78,15 @@ def download_results_from_gcs(
     with tarfile.open(tgz_file) as tar:
         tar.extractall(path=output_directory)
         output_folder_path = output_directory / "output"
+        out_filepaths = []
         for src_path in output_folder_path.glob("**/*"):
             dst_path = output_directory / src_path.relative_to(output_folder_path)
             shutil.move(str(src_path), str(dst_path))
+            if dst_path.is_dir():
+                out_filepaths += [str(x) for x in dst_path.glob("**/*")]
+            elif dst_path.is_file():
+                out_filepaths.append(str(dst_path))
         output_folder_path.rmdir()
-        out_filepaths = [str(x) for x in output_directory.glob("**/*") if x.is_file()]
 
     logger.info(
         f"Download successful of {len(out_filepaths)} files to output_directory "


### PR DESCRIPTION
- [x] Makes sure no empty `output` folder is left behind
- [x] Output list of download_results includes only downloaded files (not other files in the same directory).
