### PR TITLE
Code reference improvements

### DIFF
--- a/docs/reference/job.md
+++ b/docs/reference/job.md
@@ -1,7 +1,20 @@
-# Job class
+# Job
 
-The Job class provides access to the results, parameters and tasks of UP42
-Jobs (Workflows that have been run as Jobs).
+The Job object is the result of running a workflow. It lets you download, visualize and 
+manipulate the results of the job, and keep track of the status or cancel a job while
+still running.
 
+Initialize an existing job:
+
+```python
+job = up42.initialize_job(job_id="12345")
+```
+
+Run a new job:
+```python
+job = workflow.run_job(name="new_job", input_parameters={...})
+```
+
+<br>
 
 ::: up42.job.Job

--- a/docs/reference/jobcollection.md
+++ b/docs/reference/jobcollection.md
@@ -1,6 +1,6 @@
-# JobCollection class
+# JobCollection
 
-The JobCollection class provides facilities for downloading and merging
+The JobCollection object provides facilities for downloading and merging
 multiple jobs results.
 
 

--- a/docs/reference/jobtask.md
+++ b/docs/reference/jobtask.md
@@ -1,8 +1,14 @@
-# JobTask class
+# JobTask
 
-The JobTask class provides access to the results and parameters of single
-Tasks of UP42 Jobs (each Job contains one or multiple Jobtasks, one for each
-block in the workflow).
+The JobTask object provides access to a specific intermediate result of a block in the 
+workflow. Each job contains one or multiple JobTasks, one for each block.
 
+Initialize an existing jobtask:
+
+```python
+jobtask = up42.initialize_jobtask(jobtask_id="12345", job_id="12345")
+```
+
+<br>
 
 ::: up42.jobtask.JobTask

--- a/docs/reference/project.md
+++ b/docs/reference/project.md
@@ -1,7 +1,19 @@
-# Project class
+# Project
 
-The Project class can query all available workflows and spawn new workflows within an 
-UP42 project. Also handles project user settings.
+The Project is the top level object of the UP42 hierachy. With it you can create 
+new workflows, query already existing workflows & jobs in the project and 
+manage the project settings.
 
+To initialize an existing project, first [authenticate](authentication.md#authenticate)
+with UP42, then use:
+
+```python
+project = up42.initialize_project()
+```
+
+To create a new project use the [UP42 website interface](authentication.md#authenticate). 
+This functionality will soon also be available via the UP42 API & Python SDK.
+
+<br>
 
 ::: up42.project.Project

--- a/docs/reference/up42.md
+++ b/docs/reference/up42.md
@@ -1,0 +1,20 @@
+# up42
+
+up42 is the base object imported to Python. It provides the elementary functionality 
+that is not bound to a specific object of the UP42 structure (Project > Workflow > Job etc.).
+
+From it you can initialize these other objects, get information about UP42 
+data & processing blocks, read or draw vector data, and adjust the SDK settings.
+
+To import the UP42 library:
+
+```python
+import up42
+```
+
+<br>
+
+::: up42.__init__
+    rendering:
+      show_source: no
+      show_if_no_docstring: no

--- a/docs/reference/workflow.md
+++ b/docs/reference/workflow.md
@@ -1,7 +1,19 @@
-# Workflow class
+# Workflow
 
-The Workflow class can query all available and spawn new jobs for an UP42
-Workflow and helps to find and set the the workflow tasks, parameters and aoi.
+With whe workflow object you can configure & run jobs and query exisiting jobs of this 
+workflow.
 
+Initialize an existing workflow:
+
+```python
+workflow = up42.initialize_workflow(workflow_id="12345")
+```
+
+Create a new workflow:
+```python
+workflow = project.create_workflow(name="new_workflow")
+```
+
+<br>
 
 ::: up42.workflow.Workflow

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
         - Command Line Interface (CLI): cli.md
         - Command Reference: reference/cli.md
     - Code Reference:
+        - up42: reference/up42.md
         - Project: reference/project.md
         - Workflow: reference/workflow.md
         - Job: reference/job.md

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -83,8 +83,9 @@ def initialize_job(job_id: str) -> "Job":
     """
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
+    job = Job(auth=_auth, job_id=job_id, project_id=str(_auth.project_id))
     logger.info(f"Initialized {job}")
-    return Job(auth=_auth, job_id=job_id, project_id=str(_auth.project_id))
+    return job
 
 
 def initialize_jobtask(jobtask_id, job_id) -> "JobTask":

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -80,9 +80,7 @@ def initialize_job(job_id: str) -> "Job":
     """
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
-    return Job(
-        auth=_auth, job_id=job_id, project_id=str(_auth.project_id)
-    )
+    return Job(auth=_auth, job_id=job_id, project_id=str(_auth.project_id))
 
 
 def initialize_jobtask(jobtask_id, job_id) -> "JobTask":
@@ -166,7 +164,7 @@ def plot_results(
     tools.plot_results(figsize, filepaths, titles)
 
 
-def settings(log: bool=True):
+def settings(log=True):
     """
     Configures settings about logging etc. when using the up42-py package.
 

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -67,7 +67,7 @@ def initialize_job(job_id, order_ids: List[str] = None) -> "Job":
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
     return Job(
-        auth=_auth, job_id=job_id, project_id=str(_auth.project_id), order_ids=order_ids
+        auth=_auth, job_id=job_id, project_id=str(_auth.project_id)
     )
 
 

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -39,7 +39,9 @@ def authenticate(
 
 
 def initialize_project() -> "Project":
-    """Directly returns the correct Project object (has to exist on UP42)."""
+    """
+    Returns the correct Project object (has to exist on UP42).
+    """
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
     logger.info(f"Working on Project with project_id {_auth.project_id}")
@@ -47,14 +49,21 @@ def initialize_project() -> "Project":
 
 
 def initialize_catalog() -> "Catalog":
-    """Directly returns a Catalog object."""
+    """
+    Returns a Catalog object for using the catalog search.
+    """
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
     return Catalog(auth=_auth)
 
 
-def initialize_workflow(workflow_id) -> "Workflow":
-    """Directly returns a Workflow object (has to exist on UP42)."""
+def initialize_workflow(workflow_id: str) -> "Workflow":
+    """
+    Returns a Workflow object (has to exist on UP42).
+
+    Args:
+        workflow_id: The UP42 workflow_id
+    """
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
     return Workflow(
@@ -62,8 +71,13 @@ def initialize_workflow(workflow_id) -> "Workflow":
     )
 
 
-def initialize_job(job_id, order_ids: List[str] = None) -> "Job":
-    """Directly returns a Job object (has to exist on UP42)."""
+def initialize_job(job_id: str) -> "Job":
+    """
+    Returns a Job object (has to exist on UP42).
+
+    Args:
+        job_id: The UP42 job_id
+    """
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
     return Job(
@@ -72,7 +86,13 @@ def initialize_job(job_id, order_ids: List[str] = None) -> "Job":
 
 
 def initialize_jobtask(jobtask_id, job_id) -> "JobTask":
-    """Directly returns a JobTask object (has to exist on UP42)."""
+    """
+    Returns a JobTask object (has to exist on UP42).
+
+    Args:
+        jobtask_id: The UP42 jobtask_id
+        job_id: The UP42 job_id
+    """
     if _auth is None:
         raise RuntimeError("Not authenticated, call up42.authenticate() first")
     return JobTask(
@@ -146,7 +166,13 @@ def plot_results(
     tools.plot_results(figsize, filepaths, titles)
 
 
-def settings(log=True):
+def settings(log: bool=True):
+    """
+    Configures settings about logging etc. when using the up42-py package.
+
+    Args:
+        log: Activates/deactivates logging, default True is activated logging.
+    """
     if log:
         logger.info(
             "Logging enabled (default) - use up42.settings(log=False) to disable."


### PR DESCRIPTION
Last PR before new version.

- Add object initialization at top of page for each object to code reference
- Add up42 base import chapter to code reference (currenty only contains the object initializations, to be extended with get_blocks() etc when inheritance is clearer).
- Remove `order_ids` from `up42.initialize_job`, makes no sense, only at Job creation.