### PR TITLE
Fix catalog data blocks up4982

### DIFF
--- a/tests/mock_data/search_params_simple.json
+++ b/tests/mock_data/search_params_simple.json
@@ -18,7 +18,7 @@
         "dataBlock": {
             "in": ["oneatlas-pleiades-fullscene", "oneatlas-pleiades-aoiclipped",
                    "oneatlas-spot-fullscene", "oneatlas-spot-aoiclipped",
-                   "sobloo-sentinel1-l1c-grd-full", "sobloo-sentinel1-l1c-grd-aoiclipped", "sobloo-sentinel1-l1c-slc-full"]
+                   "sobloo-s1-grd-fullscene", "sobloo-s1-grd-aoiclipped", "sobloo-s1-slc-fullscene"]
         }
     },
     "sortby": [{"field": "properties.cloudCoverage", "direction": "desc"}]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -90,7 +90,7 @@ def test_search(catalog_mock, requests_mock):
 def test_search_live(catalog_live):
     search_results = catalog_live.search(mock_search_parameters)
     assert isinstance(search_results, gpd.GeoDataFrame)
-    assert search_results.shape == (4, 9)
+    assert search_results.shape == (4, 10)
     assert list(search_results.columns) == [
         "geometry",
         "id",
@@ -99,6 +99,7 @@ def test_search_live(catalog_live):
         "providerName",
         "blockNames",
         "cloudCoverage",
+        "up42:usageType",
         "providerProperties",
         "scene_id",
     ]

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -36,23 +36,23 @@ supported_sensors = {
     },
     "sentinel1": {
         "blocks": [
-            "sobloo-sentinel1-l1c-grd-full",
-            "sobloo-sentinel1-l1c-grd-aoiclipped",
-            "sobloo-sentinel1-l1c-slc-full",
+            "sobloo-s1-grd-fullscene",
+            "sobloo-s1-grd-aoiclipped",
+            "sobloo-s1-slc-fullscene",
         ],
         "provider": "sobloo-image",
     },
     "sentinel2": {
         "blocks": [
-            "sobloo-sentinel2-lic-msi-full",
-            "sobloo-sentinel2-lic-msi-aoiclipped",
+            "sobloo-s2-l1c-fullscene",
+            "sobloo-s2-l1c-aoiclipped",
         ],
         "provider": "sobloo-image",
     },
-    "sentinel3": {"blocks": ["sobloo-sentinel3-full"], "provider": "sobloo-image"},
+    "sentinel3": {"blocks": ["sobloo-s3"], "provider": "sobloo-image"},
     "sentinel5p": {
         "blocks": [
-            "sobloo-sentinel5-preview-full",
+            "sobloo-s5p",
         ],
         "provider": "sobloo-image",
     },


### PR DESCRIPTION
Catalog search sobloo provider data block names were changed on backend, broke the catalog search for sobloo sensors. This fixes it, users need to update though, no backwards compatability.

Longer term data-api team will implement api endpoint to query the provider:data_blocks mappings, then the mapping in the SDK can be removed.