### PR TITLE
Add exponential backoff up4980

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">81%</text>
-        <text x="80" y="14">81%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">80%</text>
+        <text x="80" y="14">80%</text>
     </g>
 </svg>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -123,3 +123,23 @@ def test_request_with_retry(auth_mock, requests_mock):
 
     response_json = auth_mock._request(request_type="GET", url="http://test.com")
     assert response_json == {"data": {"xyz": 789}, "error": {}}
+
+
+def test_request_rate_limited(auth_mock, requests_mock):
+    a = requests_mock.get(
+        "http://test.com",
+        [
+            {
+                "status_code": 429,
+                "json": {
+                    "data": {},
+                    "error": {"code": 429, "message": "rate limited"},
+                },
+            },
+            {"json": {"data": {"xyz": 789}, "error": {}}},
+        ],
+    )
+
+    response_json = auth_mock._request(request_type="GET", url="http://test.com")
+    assert response_json == {"data": {"xyz": 789}, "error": {}}
+    assert a.call_count == 2


### PR DESCRIPTION
With newly introduced rate limiting in the UP42 API, this PR handles retrying in cases where the rate limit is exceed by using a exponential backoff strategy with jitter (see [tenacity docs](https://tenacity.readthedocs.io/en/latest/api.html#tenacity.wait.wait_random_exponential)).