### PR TITLE
Plotting bands

### DIFF
--- a/up42/viztools.py
+++ b/up42/viztools.py
@@ -53,7 +53,9 @@ class VizTools:
         titles: List[str] = None,
         filepaths: Union[List[Union[str, Path]], Dict] = None,
         plot_file_format: List[str] = [".tif"],
+        **kwargs,
     ) -> None:
+        # pylint: disable=line-too-long
         """
         Plots image data (quicklooks or results)
 
@@ -64,6 +66,9 @@ class VizTools:
             filepaths: Paths to images to plot. Optional, by default picks up the last
                 downloaded results.
             plot_file_format: List of accepted image file formats e.g. [".tif"]
+            kwargs: Accepts any additional args and kwargs of
+                [rasterio.plot.show](https://rasterio.readthedocs.io/en/latest/api/rasterio.plot.html#rasterio.plot.show),
+                 e.g. matplotlib cmap etc.
         """
         if filepaths is None:
             if self.results is None:
@@ -105,7 +110,8 @@ class VizTools:
 
         if len(bands) != 3:
             if len(bands) == 1:
-                bands = bands * 3  # plot as grayband
+                if "cmap" not in kwargs:
+                    kwargs["cmap"] = "gray"
             else:
                 raise ValueError("Parameter bands can only contain one or three bands.")
         for idx, (fp, title) in enumerate(zip(imagepaths, titles)):
@@ -117,6 +123,7 @@ class VizTools:
                     title=title,
                     ax=axs[idx],
                     aspect="auto",
+                    **kwargs,
                 )
             axs[idx].set_axis_off()
         plt.axis("off")

--- a/up42/viztools.py
+++ b/up42/viztools.py
@@ -2,6 +2,8 @@
 Visualization tools available in various objects
 """
 
+# pylint: disable=dangerous-default-value
+
 from typing import Tuple, List, Union, Dict
 import math
 from pathlib import Path
@@ -50,7 +52,6 @@ class VizTools:
         bands: List[int] = [1, 2, 3],
         titles: List[str] = None,
         filepaths: Union[List[Union[str, Path]], Dict] = None,
-        # pylint: disable=dangerous-default-value
         plot_file_format: List[str] = [".tif"],
     ) -> None:
         """
@@ -120,8 +121,8 @@ class VizTools:
     def plot_quicklooks(
         self,
         figsize: Tuple[int, int] = (8, 8),
-        filepaths: List = None,
         titles: List[str] = None,
+        filepaths: List = None,
     ) -> None:
         """
         Plots the downloaded quicklooks (filepaths saved to self.quicklooks of the
@@ -154,6 +155,7 @@ class VizTools:
         plot_file_format: List[str],
         result_df: GeoDataFrame,
         filepaths: List[Union[str, Path]],
+        bands: List[int] = [1, 2, 3],
         aoi: GeoDataFrame = None,
         show_images=True,
         show_features=False,
@@ -231,12 +233,12 @@ class VizTools:
             ):
                 with rasterio.open(raster_fp) as src:
                     if src.meta["crs"] is None:
-                        dst_array = src.read()[:3, :, :]
+                        dst_array = src.read(bands)
                         minx, miny, maxx, maxy = list_bounds[idx]
                     else:
                         # Folium requires 4326, streaming blocks are 3857
                         with WarpedVRT(src, crs="EPSG:4326") as vrt:
-                            dst_array = vrt.read()[:3, :, :]
+                            dst_array = vrt.read(bands)
                             minx, miny, maxx, maxy = vrt.bounds
 
                 m.add_child(
@@ -262,6 +264,7 @@ class VizTools:
 
     def map_results(
         self,
+        bands=[1, 2, 3],
         aoi: GeoDataFrame = None,
         show_images: bool = True,
         show_features: bool = True,
@@ -272,7 +275,8 @@ class VizTools:
         Displays data.json, and if available, one or multiple results geotiffs.
 
         Args:
-            aoi: GeoDataFrame of aoi.
+            bands: Image bands and order to plot, default [1,2,3]. First band is 1.
+            aoi: Optional visualization of aoi boundaries when given GeoDataFrame of aoi.
             show_images: Shows images if True (default).
             show_features: Shows features if True (default).
             name_column: Name of the feature property that provides the Feature/Layer name.
@@ -297,6 +301,7 @@ class VizTools:
 
         # Add image to map.
         m = self._map_images(
+            bands=bands,
             plot_file_format=[".tif"],
             result_df=df,
             filepaths=self.results,

--- a/up42/viztools.py
+++ b/up42/viztools.py
@@ -47,8 +47,9 @@ class VizTools:
     def plot_results(
         self,
         figsize: Tuple[int, int] = (14, 8),
-        filepaths: Union[List[Union[str, Path]], Dict] = None,
+        bands: List[int] = [1, 2, 3],
         titles: List[str] = None,
+        filepaths: Union[List[Union[str, Path]], Dict] = None,
         # pylint: disable=dangerous-default-value
         plot_file_format: List[str] = [".tif"],
     ) -> None:
@@ -56,12 +57,12 @@ class VizTools:
         Plots image data (quicklooks or results)
 
         Args:
-            plot_file_format: List of accepted image file formats e.g. [".tif"]
             figsize: matplotlib figure size.
+            bands: Image bands and order to plot, default [1,2,3]. First band is 1.
+            titles: Optional list of titles for the subplots.
             filepaths: Paths to images to plot. Optional, by default picks up the last
                 downloaded results.
-            titles: Optional list of titles for the subplots.
-
+            plot_file_format: List of accepted image file formats e.g. [".tif"]
         """
         if filepaths is None:
             if self.results is None:
@@ -103,9 +104,7 @@ class VizTools:
 
         for idx, (fp, title) in enumerate(zip(imagepaths, titles)):
             with rasterio.open(fp) as src:
-                img_array = src.read()[:3, :, :]
-                # TODO: Handle more band configurations.
-                # TODO: add histogram equalization?
+                img_array = src.read(bands)
                 show(
                     img_array,
                     transform=src.transform,

--- a/up42/viztools.py
+++ b/up42/viztools.py
@@ -103,6 +103,11 @@ class VizTools:
         else:
             axs = [axs]
 
+        if len(bands) != 3:
+            if len(bands) == 1:
+                bands = bands * 3  # plot as grayband
+            else:
+                raise ValueError("Parameter bands can only contain one or three bands.")
         for idx, (fp, title) in enumerate(zip(imagepaths, titles)):
             with rasterio.open(fp) as src:
                 img_array = src.read(bands)
@@ -228,6 +233,14 @@ class VizTools:
                 f.add_to(m)
 
         if show_images and raster_filepaths:
+            if len(bands) != 3:
+                if len(bands) == 1:
+                    bands = bands * 3  # plot as grayband
+                else:
+                    raise ValueError(
+                        "Parameter bands can only contain one or three bands."
+                    )
+
             for idx, (raster_fp, feature_name) in enumerate(
                 zip(raster_filepaths, feature_names)
             ):


### PR DESCRIPTION
Enables band selection in `plot_results` and `map_results`. Also required for new default examples.

x           |  y |  z
:-------------------------:|:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/12833517/101093925-dc882b00-35bb-11eb-830d-e005060b7639.png) |  ![image](https://user-images.githubusercontent.com/12833517/101093954-e7db5680-35bb-11eb-9cb5-8b83559dfc8f.png) | ![image](https://user-images.githubusercontent.com/12833517/101094485-c333ae80-35bc-11eb-95ed-ebd23cb090c9.png) 








