### PR TITLE
Renamed example blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ project = up42.initialize_project()
 # Construct workflow
 workflow = project.create_workflow(name="30-seconds-workflow", use_existing=True)
 #print(up42.get_blocks(basic=True))
-input_tasks = ["Sentinel-2 Level 2 (BOA) AOI clipped", 
+input_tasks = ["Sentinel-2 Level 2 (GeoTIFF)",
                "Land Surface Temperature Estimation"]
 workflow.add_workflow_tasks(input_tasks)
 

--- a/docs/30-second-example.md
+++ b/docs/30-second-example.md
@@ -21,7 +21,7 @@ project = up42.initialize_project()
 # Construct workflow
 workflow = project.create_workflow(name="30-seconds-workflow", use_existing=True)
 #print(up42.get_blocks(basic=True))
-input_tasks = ["Sentinel-2 Level 2 (BOA) AOI clipped", 
+input_tasks = ["Sentinel-2 Level 2 (GeoTIFF)",
                "Land Surface Temperature Estimation"]
 workflow.add_workflow_tasks(input_tasks)
 

--- a/examples/guides/30-seconds-example.ipynb
+++ b/examples/guides/30-seconds-example.ipynb
@@ -41,7 +41,7 @@
     "# Construct workflow\n",
     "workflow = project.create_workflow(name=\"30-seconds-workflow\", use_existing=True)\n",
     "#print(up42.get_blocks(basic=True))\n",
-    "input_tasks = [\"Sentinel-2 Level 2 (BOA) AOI clipped\", \"Land Surface Temperature Estimation\"]\n",
+    "input_tasks = [\"Sentinel-2 Level 2 (GeoTIFF)\", \"Land Surface Temperature Estimation\"]\n",
     "workflow.add_workflow_tasks(input_tasks)"
    ]
   },

--- a/examples/guides/detailed-example.ipynb
+++ b/examples/guides/detailed-example.ipynb
@@ -84,7 +84,7 @@
    "source": [
     "# Add workflow tasks\n",
     "\n",
-    "input_tasks = [\"Sentinel-2 Level 2 (BOA) AOI clipped\", \"Land Surface Temperature Estimation\"]\n",
+    "input_tasks = [\"Sentinel-2 Level 2 (GeoTIFF)\", \"Land Surface Temperature Estimation\"]\n",
     "workflow.add_workflow_tasks(input_tasks=input_tasks)\n",
     "\n",
     "# Check the added tasks.\n",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,13 +99,12 @@ plugins:
         - "*examples/project*"
         - "*examples/guides/*"
         - "*swagger*"
+        - PULL_REQUEST_TEMPLATE.md
   - exclude-search:
       exclude:
         - cli-reference.md
       ignore:
         - cli-reference.md#command-line-interface-cli
-  #- minify:
-  #    minify_html: false
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,7 +89,6 @@ theme:
 plugins:
   - search
   - autolinks
-  - table-reader
   - mkdocs-jupyter:
       include_source: False
   - exclude:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ mkdocs-material
 pygments
 pymdown-extensions
 mkdocs-autolinks-plugin
-mkdocs-table-reader-plugin
 mkdocs-jupyter
 mkdocs-exclude
 mkdocs-exclude-search


### PR DESCRIPTION
- Fixes SDK examples, sentinelhub block display name were renamed. sdk.up42.com already adjusted.
- Removes unneccessary docs plugin.

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [x] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
