### PR TITLE
Add CircleCI and GitHub action up4621

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   notify-slack: interstellar/notify-slack@0.2.0
 
 jobs:
-  build_and_test:
+  test:
     docker:
       - image: circleci/python:3.7
     steps:
@@ -16,9 +16,28 @@ jobs:
       - run:
           name: Runnning tests
           command: make test
+  test_live:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Install requirements
+          command: |
+            pip install -r requirements.txt
+            pip install -r requirements-dev.txt
+      - run:
+          name: Runnning tests
+          command: make test[live]
+
 
 workflows:
   version: 2
-  build-and-deploy:
+  test:
     jobs:
-      - build_and_test
+      - test
+  test_live:
+    jobs:
+      - test_live:
+          context: up42-py-live-testing
+    

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ workflows:
   test:
     jobs:
       - test
+
   test_live:
     jobs:
       - test_live:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,13 @@ workflows:
       - test
 
   test_live:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - test_live:
           context: up42-py-live-testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ workflows:
           filters:
             branches:
               only: master
-      - deploy
+      - deploy:
           requires:
             - hold_before_deploy
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Installing build utils
+          name: Installing packaging utils
           command: python -m pip install --user packaging twine
       - run:
           name: Build package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,41 @@ jobs:
       - run:
           name: Runnning tests
           command: make test[live]
+  deploy:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Installing build utils
+          command: python -m pip install --user packaging twine
+      - run:
+          name: Build package
+          command: make package
+      - run:
+          name: Upload to PyPi
+          command: make upload
 
 
 workflows:
   version: 2
-  test:
+  test_and_deploy:
     jobs:
       - test
+      - hold_before_deploy:
+          type: approval
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
+      - deploy
+          requires:
+            - hold_before_deploy
+          filters:
+            branches:
+              only: master
+
 
   test_live:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  notify-slack: interstellar/notify-slack@0.2.0
 
 jobs:
   test:
@@ -63,8 +61,6 @@ workflows:
           filters:
             branches:
               only: master
-
-
   test_live:
     jobs:
       - test_live:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,13 +66,6 @@ workflows:
 
 
   test_live:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
     jobs:
       - test_live:
           context: up42-py-live-testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,13 @@ workflows:
             branches:
               only: master
   test_live:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - test_live:
           context: up42-py-live-testing

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -1,14 +1,17 @@
 name: Publish docs via GitHub Pages
+
 on:
   push:
     branches:
       - master
     paths:
       # Only rebuild website when docs have changed
+      # Comment out when testing locally via act!
       - 'docs/**'
       - 'examples/**'
       - 'CHANGELOG.md'
       - 'mkdocs.yml'
+
 
 jobs:
   build:
@@ -18,21 +21,21 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
           python -m pip install -r requirements-docs.txt
+          python -m pip install -e .
 
       - name: Create symlinks for examples and changelog
         run: |
-             ln -s examples docs
-             ln -s CHANGELOG.md docs
+              ln -sfn /github/workspace/examples /github/workspace/docs
+              ln -sfn /github/workspace/examples/guides /github/workspace/docs
+              ln -sfn /github/workspace/CHANGELOG.md /github/workspace/docs
 
       - name: Deploy docs
-        run: mkdocs gh-deploy -m "update gh-pages [ci skip]" --force
+        run: mkdocs gh-deploy --force -m "update gh-pages [ci skip]"

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -11,10 +11,12 @@ jobs:
       
       - name: Fix paths for examples and changelog
         run: |
-          ls
+          unlink docs/examples; ln -s examples docs
+	        unlink docs/CHANGELOG.md; ln -s CHANGELOG.md docs
+        shell: bash
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXTRA_PACKAGES: build-base
+          REQUIREMENTS: requirements-dev.txt

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -14,8 +14,6 @@ jobs:
           ls
           unlink up42-py/docs/examples
           ln -s up42-py/examples up42-py/docs
-	        unlink up42-py/docs/CHANGELOG.md
-          ln -s up42-py/CHANGELOG.md up42-py/docs
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -10,8 +10,11 @@ jobs:
         uses: actions/checkout@v2
       
       - run: |
-        unlink up42-py/docs/examples; ln -s up42-py/examples docs
-	      unlink up42-py/docs/CHANGELOG.md; ln -s up42-py/CHANGELOG.md docs
+        unlink up42-py/docs/examples
+        ln -s up42-py/examples docs
+      - run: |
+	      unlink up42-py/docs/CHANGELOG.md
+        ln -s up42-py/CHANGELOG.md docs
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -9,14 +9,14 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@v2
       
-      - name: Fix paths for examples and changelog
+      - name: Create symlinks for examples and changelog
         run: |
-          unlink docs/examples; ln -s examples docs
-	        unlink docs/CHANGELOG.md; ln -s CHANGELOG.md docs
-        shell: bash
+             ln -s examples docs
+             ln -s CHANGELOG.md docs
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REQUIREMENTS: requirements-dev.txt
+          REQUIREMENTS: requirements-docs.txt
+          EXTRA_PACKAGES: build-base libzmq musl-dev python3 python3-dev zeromq-dev py3-rasterio

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -2,14 +2,16 @@ name: Publish docs via GitHub Pages
 on: push
 
 jobs:
-  build:
+  deployDocs:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
         uses: actions/checkout@v2
       
-      - run: |
+      - name: Fix paths for examples and changelog
+        run: |
+          ls
           unlink up42-py/docs/examples
           ln -s up42-py/examples up42-py/docs
 	        unlink up42-py/docs/CHANGELOG.md

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -12,7 +12,6 @@ jobs:
       - run: |
           unlink up42-py/docs/examples
           ln -s up42-py/examples up42-py/docs
-      - run: |
 	        unlink up42-py/docs/CHANGELOG.md
           ln -s up42-py/CHANGELOG.md up42-py/docs
 

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -12,8 +12,6 @@ jobs:
       - name: Fix paths for examples and changelog
         run: |
           ls
-          unlink up42-py/docs/examples
-          ln -s up42-py/examples up42-py/docs
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -22,9 +22,10 @@ jobs:
 
       - name: Create symlinks for examples and changelog
         run: |
-              ln -sfn /github/workspace/examples /github/workspace/docs
-              ln -sfn /github/workspace/examples/guides /github/workspace/docs
-              ln -sfn /github/workspace/CHANGELOG.md /github/workspace/docs
+              ls
+              ln -sfn examples docs
+              ln -sfn examples/guides docs
+              ln -sfn CHANGELOG.md docs
 
       - name: Deploy docs
         run: mkdocs gh-deploy --force -m "update gh-pages [ci skip]"

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -1,0 +1,20 @@
+name: Publish docs via GitHub Pages
+on: push
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+      
+      - run: |
+        unlink up42-py/docs/examples; ln -s up42-py/examples docs
+	      unlink up42-py/docs/CHANGELOG.md; ln -s up42-py/CHANGELOG.md docs
+
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXTRA_PACKAGES: build-base

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -1,6 +1,17 @@
 name: Publish docs via GitHub Pages
 
-on: push
+on:
+  push:
+    branches:
+      - master
+    paths:
+      # Only rebuild website when docs have changed
+      # Comment out when testing locally via act!
+      - 'docs/**'
+      - 'examples/**'
+      - 'CHANGELOG.md'
+      - 'mkdocs.yml'
+
 
 jobs:
   build:

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Create symlinks for examples and changelog
         run: |
               ls
-              ln -sfn examples docs
-              ln -sfn examples/guides docs
-              ln -sfn CHANGELOG.md docs
+              mv examples/guides/* docs/guides
+              mv examples/* docs/examples
+              mv CHANGELOG.md docs
 
       - name: Deploy docs
         run: mkdocs gh-deploy --force -m "update gh-pages [ci skip]"

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -1,22 +1,38 @@
 name: Publish docs via GitHub Pages
-on: push
+on:
+  push:
+    branches:
+      - master
+    paths:
+      # Only rebuild website when docs have changed
+      - 'docs/**'
+      - 'examples/**'
+      - 'CHANGELOG.md'
+      - 'mkdocs.yml'
 
 jobs:
-  deployDocs:
+  build:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
         uses: actions/checkout@v2
-      
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install -r requirements-docs.txt
+
       - name: Create symlinks for examples and changelog
         run: |
              ln -s examples docs
              ln -s CHANGELOG.md docs
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REQUIREMENTS: requirements-docs.txt
-          EXTRA_PACKAGES: build-base libzmq musl-dev python3 python3-dev zeromq-dev py3-rasterio
+        run: mkdocs gh-deploy -m "update gh-pages [ci skip]" --force

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -11,10 +11,10 @@ jobs:
       
       - run: |
         unlink up42-py/docs/examples
-        ln -s up42-py/examples docs
+        ln -s up42-py/examples up42-py/docs
       - run: |
 	      unlink up42-py/docs/CHANGELOG.md
-        ln -s up42-py/CHANGELOG.md docs
+        ln -s up42-py/CHANGELOG.md up42-py/docs
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Create symlinks for examples and changelog
         run: |
               ls
+              mkdir docs/guides
+              mkdir docs/examples
               mv examples/guides/* docs/guides
               mv examples/* docs/examples
               mv CHANGELOG.md docs

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -10,11 +10,11 @@ jobs:
         uses: actions/checkout@v2
       
       - run: |
-        unlink up42-py/docs/examples
-        ln -s up42-py/examples up42-py/docs
+          unlink up42-py/docs/examples
+          ln -s up42-py/examples up42-py/docs
       - run: |
-	      unlink up42-py/docs/CHANGELOG.md
-        ln -s up42-py/CHANGELOG.md up42-py/docs
+	        unlink up42-py/docs/CHANGELOG.md
+          ln -s up42-py/CHANGELOG.md up42-py/docs
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master

--- a/.github/workflows/mkdocsdeploy.yml
+++ b/.github/workflows/mkdocsdeploy.yml
@@ -1,17 +1,6 @@
 name: Publish docs via GitHub Pages
 
-on:
-  push:
-    branches:
-      - master
-    paths:
-      # Only rebuild website when docs have changed
-      # Comment out when testing locally via act!
-      - 'docs/**'
-      - 'examples/**'
-      - 'CHANGELOG.md'
-      - 'mkdocs.yml'
-
+on: push
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,15 @@ e2e:
 	python $(SRC)/tests/e2e.py
 
 serve:
-	unlink $(PWD)/docs/examples; ln -s $(PWD)/examples docs
-	unlink $(PWD)/docs/CHANGELOG.md; ln -s $(PWD)/CHANGELOG.md docs
+	ln -sfn $(PWD)/examples docs
+	ln -sfn $(PWD)/docs/examples/guides docs
+	ln -sfn $(PWD)/CHANGELOG.md docs
 	mkdocs serve
 
 gh-pages:
-	unlink $(PWD)/docs/examples; ln -s $(PWD)/examples docs
-	unlink $(PWD)/docs/CHANGELOG.md; ln -s $(PWD)/CHANGELOG.md docs
+	ln -sfn $(PWD)/examples docs
+	ln -sfn $(PWD)/docs/examples/guides docs
+	ln -sfn $(PWD)/CHANGELOG.md docs
 	mkdocs gh-deploy -m "update gh-pages [ci skip]"
 
 package:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ install[dev]:
 	pip install -r $(SRC)/requirements.txt
 	pip install -e .
 	pip install -r $(SRC)/requirements-dev.txt
+	pip install -r $(SRC)/requirements-docs.txt
 	unlink $(PWD)/docs/examples; ln -s $(PWD)/examples docs
 
 test:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,3 @@
-mkdocs
-mkdocs-material
-pygments
-pymdown-extensions
-mkdocs-autolinks-plugin
-mkdocs-jupyter
-mkdocs-exclude
-mkdocs-exclude-search
-mkdocs-macros-plugin
-mkdocs-click
-mkdocstrings
 nbconvert
 black
 requests-mock

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,12 @@
+-e .
+mkdocs
+mkdocs-material
+pygments
+pymdown-extensions
+mkdocs-autolinks-plugin
+mkdocs-jupyter
+mkdocs-exclude
+mkdocs-exclude-search
+mkdocs-macros-plugin
+mkdocs-click
+mkdocstrings

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,3 @@
--e .
 mkdocs
 mkdocs-material
 pygments

--- a/tests/test_e2e_30sec.py
+++ b/tests/test_e2e_30sec.py
@@ -6,11 +6,12 @@ import up42
 
 @pytest.mark.live()
 def test_e2e_30sec():
-    up42.authenticate(
+    _auth = up42.Auth(
         project_id=os.getenv("TEST_UP42_PROJECT_ID"),
         project_api_key=os.getenv("TEST_UP42_PROJECT_API_KEY"),
     )
-    project = up42.initialize_project()
+
+    project = up42.Project(_auth, project_id=_auth.project_id)
 
     # Construct workflow
     workflow = project.create_workflow(name="30-seconds-workflow", use_existing=True)

--- a/tests/test_e2e_catalog.py
+++ b/tests/test_e2e_catalog.py
@@ -6,12 +6,12 @@ import up42
 
 @pytest.mark.live()
 def test_e2e_catalog():
-    up42.authenticate(
+    _auth = up42.Auth(
         project_id=os.getenv("TEST_UP42_PROJECT_ID"),
         project_api_key=os.getenv("TEST_UP42_PROJECT_API_KEY"),
     )
 
-    catalog = up42.initialize_catalog()
+    catalog = up42.Catalog(_auth)
 
     ## Search scenes in aoi
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -212,7 +212,7 @@ def test_job_download_result_dimap_live(auth_live):
         assert Path(out_files[0]).exists()
         assert Path(out_files[20]).exists()
         assert Path(out_files[-1]).exists()
-        assert Path(out_files[-1]).name == "data.json"
+        assert "data.json" in [Path(of).name for of in out_files]
         assert len(out_files) == 54
 
 

--- a/tests/test_jobtask.py
+++ b/tests/test_jobtask.py
@@ -69,8 +69,8 @@ def test_jobtask_download_result_live(jobtask_live):
         for file in out_files:
             assert Path(file).exists()
         assert len(out_files) == 2
-        assert Path(out_files[1]).suffix == ".tif"
-        assert Path(out_files[0]).name == "data.json"
+        assert ".tif" in [Path(of).suffix for of in out_files]
+        assert "data.json" in [Path(of).name for of in out_files]
 
 
 def test_download_quicklook(jobtask_mock, requests_mock):


### PR DESCRIPTION
Add Circle CI config to enable live testing and deployment in CI. Fix a couple of issues in tests. 

In addition add Github Actions to deploy docs in master.

**What changes from now on:**
- Any deployment of a new package version should be done via CircleCI with the new approve to deploy in master
- Live tests will be run every night at 12AM.
- Any merge into master that changes the documentation will trigger a deployment of the docs

Items:
* [x] Ran test & live-tests
* [x] Implemented (new) unit tests
* [na] Removed credentials
* [na] Removed argument pointing to staging
* [na] Updated [documentation](sdk.up42.com)
