### PR TITLE
Fix reference docs for CLI

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -3,8 +3,9 @@
 The CLI tool allows you to use the UP42 functionality from the command line.
 It is installed automatically with and based on the Python SDK.
 
-
+{% raw %}
 ::: mkdocs-click
     :module: up42.cli
     :command: up42
     :depth: 1
+{% endraw %}


### PR DESCRIPTION
Plugin mkdocs-macros was "disappearing" the CLI reference. This seems like it's due to [Jinja like statements ](https://mkdocs-macros-plugin.readthedocs.io/en/latest/advanced/#how-to-prevent-interpretation-of-jinja-like-statements) in the output HTML. Adding a raw enclosure in the call to mkdocs-click plugin fixes the issue.

Items:
* [na] Ran test & live-tests
* [na] Implemented (new) unit tests
* [na] Removed credentials
* [na] Removed argument pointing to staging
* [x] Updated [documentation](sdk.up42.com)
