### PR TITLE
disable pylint no-member in ci - up5330

### DIFF
--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -255,7 +255,7 @@ def settings(log=True):
     else:
         logger.info("Logging disabled - use up42.settings(log=True) to reactivate.")
 
-    # pylint: disable=expression-not-assigned
+    # pylint: disable=expression-not-assigned,no-member
     [
         setattr(logging.getLogger(name), "disabled", not log)
         for name in logging.root.manager.loggerDict


### PR DESCRIPTION
Disables pylint error in ci livetest run. Could not reproduce locally (with updated mypy), functions works as expected, guess just mypy not understanding the full function.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
