### PR TITLE
Bug cancel job up5307

### DIFF
--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -82,7 +82,7 @@ def test_track_status_fail(job_mock, status, requests_mock):
 
 
 def test_cancel_job(job_mock, requests_mock):
-    url = f"{job_mock.auth._endpoint()}/jobs/{job_mock.job_id}/cancel/"
+    url = f"{job_mock.auth._endpoint()}/projects/{job_mock.project_id}/jobs/{job_mock.job_id}/cancel/"
     requests_mock.post(url, status_code=200)
     job_mock.cancel_job()
 
@@ -173,6 +173,9 @@ def test_job_download_result_nounpacking(job_mock, requests_mock):
             assert Path(file).exists()
         assert len(out_files) == 1
 
+# @pytest.mark.live
+def test_cancel_job_live(job_live):
+    job_live.cancel_job()
 
 @pytest.mark.live
 def test_job_download_result_live(job_live):
@@ -181,7 +184,6 @@ def test_job_download_result_live(job_live):
         for file in out_files:
             assert Path(file).exists()
         assert len(out_files) == 2
-
 
 @pytest.mark.live
 def test_job_download_result_no_tiff_live(auth_live):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,9 +1,9 @@
 import os
 from pathlib import Path
+import json
 import tempfile
 
 import pytest
-import json
 import time
 
 # pylint: disable=unused-import

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,10 +1,11 @@
 import os
 from pathlib import Path
 import json
+import time
 import tempfile
 
 import pytest
-import time
+
 
 # pylint: disable=unused-import
 from .context import Job, JobTask

--- a/up42/job.py
+++ b/up42/job.py
@@ -146,7 +146,7 @@ class Job(VizTools, Tools):
 
     def cancel_job(self) -> None:
         """Cancels a pending or running job."""
-        url = f"{self.auth._endpoint()}/jobs/{self.job_id}/cancel/"
+        url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs/{self.job_id}/cancel/"
         self.auth._request(request_type="POST", url=url)
         logger.info(f"Job canceled: {self.job_id}")
 


### PR DESCRIPTION
This PR addresses and solves the following ticket https://up42.atlassian.net/browse/UP-5307?atlOrigin=eyJpIjoiMzA4NmZlODMyYTEyNDEwM2E2OGE3N2QwNDllNDg4NzMiLCJwIjoiaiJ9. The cancel_job functions was failing, apparently because the endpoint has changed (see here https://docs.up42.dev/openapi/swagger-ui/?urls.primaryName=backend-core#/jobs-controller/cancelJob).
A live test was added to ensure that the status from the job changes from RUNNING to CANCELLED.
 
Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
