### PR TITLE
Add display blocks reference in Catalog

### DIFF
--- a/tests/mock_data/search_params_simple.json
+++ b/tests/mock_data/search_params_simple.json
@@ -16,8 +16,8 @@
     "query": {
         "cloudCoverage": {"lte": 20},
         "dataBlock": {
-            "in": ["oneatlas-pleiades-fullscene", "oneatlas-pleiades-aoiclipped",
-                   "oneatlas-spot-fullscene", "oneatlas-spot-aoiclipped",
+            "in": ["oneatlas-pleiades-fullscene", "oneatlas-pleiades-display", "oneatlas-pleiades-aoiclipped",
+                   "oneatlas-spot-fullscene", "oneatlas-spot-display", "oneatlas-spot-aoiclipped",
                    "sobloo-s1-grd-fullscene", "sobloo-s1-grd-aoiclipped", "sobloo-s1-slc-fullscene"]
         }
     },

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -25,6 +25,7 @@ supported_sensors = {
     "pleiades": {
         "blocks": [
             "oneatlas-pleiades-fullscene",
+            "oneatlas-pleiades-display",
             "oneatlas-pleiades-aoiclipped",
         ],
         "provider": "oneatlas",
@@ -32,6 +33,7 @@ supported_sensors = {
     "spot": {
         "blocks": [
             "oneatlas-spot-fullscene",
+            "oneatlas-spot-display",
             "oneatlas-spot-aoiclipped",
         ],
         "provider": "oneatlas",


### PR DESCRIPTION
While working on https://github.com/up42/mosaicking I noticed the display blocks were not placed in the catalog search parameters. This PR addresses that.

Items:
* [x] Ran test & live-tests
* [na] Implemented (new) unit tests
* [x] Removed credentials
* [x] Removed argument pointing to staging
* [na] Updated [documentation](sdk.up42.com)