### PR TITLE
New project settings post and payload up5366

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -335,13 +335,33 @@ def project_mock(auth_mock, requests_mock):
     )
     json_project_settings = {
         "data": [
-            {"name": "MAX_CONCURRENT_JOBS"},
-            {"name": "MAX_AOI_SIZE"},
-            {"name": "JOB_QUERY_LIMIT_PARAMETER_MAX_VALUE"},
+            {"name": "MAX_CONCURRENT_JOBS", "value": "10"},
+            {"name": "MAX_AOI_SIZE", "value": "5000"},
+            {"name": "JOB_QUERY_LIMIT_PARAMETER_MAX_VALUE", "value": "20"},
         ],
         "error": {},
     }
     requests_mock.get(url=url_project_settings, json=json_project_settings)
+
+    # project settings update
+    url_projects_settings_update = (
+        f"{project.auth._endpoint()}/projects/project_id_123/settings"
+    )
+    json_desired_project_settings = {
+        "data": [
+            {"name": "MAX_CONCURRENT_JOBS", "value": "500"},
+            {"name": "MAX_AOI_SIZE", "value": "5"},
+            {"name": "JOB_QUERY_LIMIT_PARAMETER_MAX_VALUE", "value": "20"},
+        ],
+        "error": {},
+    }
+    requests_mock.post(
+        url_projects_settings_update,
+        [
+            {"status_code": 404, "json": json_desired_project_settings},
+            {"status_code": 201, "json": json_desired_project_settings},
+        ],
+    )
 
     return project
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -9,7 +9,14 @@ import pytest
 
 # pylint: disable=unused-import
 from .context import Job, JobTask
-from .fixtures import auth_mock, auth_live, job_mock, job_live, jobtask_mock, workflow_live
+from .fixtures import (
+    auth_mock,
+    auth_live,
+    job_mock,
+    job_live,
+    jobtask_mock,
+    workflow_live,
+)
 from .fixtures import DOWNLOAD_URL, JOBTASK_ID
 
 
@@ -176,6 +183,7 @@ def test_job_download_result_nounpacking(job_mock, requests_mock):
             assert Path(file).exists()
         assert len(out_files) == 1
 
+
 @pytest.mark.live
 def test_cancel_job_live(workflow_live):
     input_parameters_json = (
@@ -204,6 +212,7 @@ def test_job_download_result_live(job_live):
         for file in out_files:
             assert Path(file).exists()
         assert len(out_files) == 2
+
 
 @pytest.mark.live
 def test_job_download_result_no_tiff_live(auth_live):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 from .context import Project, Workflow, Job
 
 # pylint: disable=unused-import
@@ -111,8 +112,28 @@ def test_get_project_settings_live(project_live):
     project_settings = project_live.get_project_settings()
     assert isinstance(project_settings, list)
     assert len(project_settings) == 3
-    project_settings_dict = {item["name"]: item for item in project_settings}
-    assert "MAX_CONCURRENT_JOBS" in project_settings_dict.keys()
+    assert project_settings[0]["name"] == "MAX_CONCURRENT_JOBS"
+
+
+def test_update_project_settings(project_mock):
+    # 2 responses of post request in fixture, 404 and 201
+    with pytest.raises(requests.exceptions.RequestException):
+        project_mock.update_project_settings(max_aoi_size=5, max_concurrent_jobs=500)
+
+    project_mock.update_project_settings(max_aoi_size=5, max_concurrent_jobs=500)
+
+
+@pytest.mark.live
+def test_update_project_settings_live(project_live):
+    project_live.update_project_settings(max_concurrent_jobs=8)
+    project_settings = project_live.get_project_settings()
+    assert isinstance(project_settings, list)
+    for setting in project_settings:
+        if setting["name"] == "MAX_CONCURRENT_JOBS":
+            assert setting["value"] == "8"
+
+    # Reset to default value
+    project_live.update_project_settings(max_concurrent_jobs=3)
 
 
 def test_max_concurrent_jobs(project_mock, project_mock_max_concurrent_jobs):

--- a/up42/project.py
+++ b/up42/project.py
@@ -192,20 +192,23 @@ class Project(Tools):
             max_concurrent_jobs: The maximum number of concurrent jobs, from 1-10, default 1.
             number_of_images: The maximum number of images returned with each job, from 1-20, default 10.
         """
+        # The ranges and default values of the project settings can potentially get
+        # increased, so need to be dynamically queried from the server.
+        current_settings = {d["name"]: d for d in self.get_project_settings()}
+
         url = f"{self.auth._endpoint()}/projects/{self.project_id}/settings"
-        payload = [
-            {
-                "name": "JOB_QUERY_MAX_AOI_SIZE",
-                "value": f"{100 if max_aoi_size is None else max_aoi_size}",
-            },
-            {
-                "name": "MAX_CONCURRENT_JOBS",
-                "value": f"{10 if max_concurrent_jobs is None else max_concurrent_jobs}",
-            },
-            {
-                "name": "JOB_QUERY_LIMIT_PARAMETER_MAX_VALUE",
-                "value": f"{10 if number_of_images is None else number_of_images}",
-            },
-        ]
-        self.auth._request(request_type="PUT", url=url, data=payload)
+        payload = {"settings": {}}
+        desired_settings = {
+            "JOB_QUERY_MAX_AOI_SIZE": max_aoi_size,
+            "MAX_CONCURRENT_JOBS": max_concurrent_jobs,
+            "JOB_QUERY_LIMIT_PARAMETER_MAX_VALUE": number_of_images,
+        }
+
+        for name, desired_setting in desired_settings.items():
+            if desired_setting is None:
+                payload["settings"][name] = str(current_settings[name]["value"])
+            else:
+                payload["settings"][name] = str(desired_setting)
+
+        self.auth._request(request_type="POST", url=url, data=payload)
         logger.info(f"Updated project settings: {payload}")

--- a/up42/project.py
+++ b/up42/project.py
@@ -197,7 +197,7 @@ class Project(Tools):
         current_settings = {d["name"]: d for d in self.get_project_settings()}
 
         url = f"{self.auth._endpoint()}/projects/{self.project_id}/settings"
-        payload = {"settings": {}}
+        payload: Dict = {"settings": {}}
         desired_settings = {
             "JOB_QUERY_MAX_AOI_SIZE": max_aoi_size,
             "MAX_CONCURRENT_JOBS": max_concurrent_jobs,


### PR DESCRIPTION
Integrate new payload structure to new post request for updating the projecting settings. Replace hardcoding of value ranges with project setting request.

Items:
* [x] Ran test & live-tests
* [x] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
