### PR TITLE
limit to <3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,5 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
     ],
+    python_requires=">=3.6, <3.9",
 )


### PR DESCRIPTION
After feedback & testing found that there is an issue when installing the package dependencies (geopandas) with Python 3.9. Investigating further soon.

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
