### PR TITLE
remove deprecated jobcollection.get_job_info & get_job_status

### DIFF
--- a/docs/macros.py
+++ b/docs/macros.py
@@ -118,7 +118,6 @@ def define_env(env):
     env.variables.funcs_jobcollection = get_methods(
         up42.JobCollection,
         exclude=[
-            "get_jobs_status",
             "plot_quicklooks",
             "map_quicklooks",
             "plot_coverage",

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -118,7 +118,6 @@ def define_env(env):
     env.variables.funcs_jobcollection = get_methods(
         up42.JobCollection,
         exclude=[
-            "get_jobs_info",
             "get_jobs_status",
             "plot_quicklooks",
             "map_quicklooks",

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -82,9 +82,7 @@ def test_jobcollection_info(jobcollection_single_mock, requests_mock):
 
 
 @pytest.mark.parametrize("status", ["NOT STARTED", "PENDING", "RUNNING"])
-def test_jobcollection_get_jobs_status(
-    jobcollection_single_mock, status, requests_mock
-):
+def test_jobcollection_jobs_status(jobcollection_single_mock, status, requests_mock):
     url_job_info = (
         f"{jobcollection_single_mock.auth._endpoint()}/projects/"
         f"{jobcollection_single_mock.project_id}/jobs/{jobcollection_single_mock[0].job_id}"

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -9,7 +9,7 @@ from up42.job import Job
 from up42.viztools import VizTools
 from up42.tools import Tools
 
-from up42.utils import get_logger, deprecation
+from up42.utils import get_logger
 
 logger = get_logger(__name__)
 

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -65,14 +65,6 @@ class JobCollection(VizTools, Tools):
         """
         return self.apply(lambda job: job.status, only_succeeded=False)
 
-    @deprecation("get_jobs_status", "jobcollection.status")
-    def get_jobs_status(self) -> Dict[str, str]:
-        """
-        `get_jobs_status` will be deprecated in release 0.13, use
-        [status attribute](jobcollection-reference.md#up42.jobcollection.JobCollection.status) instead.
-        """
-        return self.status
-
     def apply(
         self, worker: Callable, only_succeeded: bool = True, **kwargs
     ) -> Dict[str, Any]:

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -57,14 +57,6 @@ class JobCollection(VizTools, Tools):
         """
         return self.apply(lambda job: job.info, only_succeeded=False)
 
-    @deprecation("get_jobs_info", "jobcollection.info")
-    def get_jobs_info(self) -> Dict[str, Dict]:
-        """
-        `get_jobs_info` will be deprecated in release 0.13, use
-        [info attribute](jobcollection-reference.md#up42.jobcollection.JobCollection.info) instead.
-        """
-        return self.info
-
     @property
     def status(self) -> Dict[str, str]:
         """


### PR DESCRIPTION
remove deprecated jobcollection.get_job_info & get_job_status

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
