### PR TITLE
Deprecate tools inheritance

### DIFF
--- a/docs/macros.py
+++ b/docs/macros.py
@@ -40,7 +40,6 @@ def define_env(env):
     def get_methods(
         c: Callable,
         exclude: List[str] = None,
-        exclude_tools=True,
         exclude_viztools=False,
     ) -> List[str]:
         """
@@ -49,7 +48,6 @@ def define_env(env):
         Args:
                 c: The class object.
                 exclude: Exclude specific methods.
-                exclude_tools: Exclude inherited functions from Tools.
                 exclude_viztools: Exclude inherited functions from VizTools.
         """
         property_methods = [
@@ -67,8 +65,6 @@ def define_env(env):
         # TODO: Could also return separatly for separated formatting.
         function_methods = function_methods + property_methods
 
-        if exclude_tools:
-            function_methods = [f for f in function_methods if f not in dir(up42.Tools)]
         if exclude_viztools:
             function_methods = [
                 f for f in function_methods if f not in dir(up42.VizTools)
@@ -106,9 +102,7 @@ def define_env(env):
     env.variables.docstring_asset = indent(up42.Asset.__doc__)
 
     # Class functions for reference and structure chapter
-    env.variables.funcs_up42 = get_methods(
-        up42, exclude_tools=False, exclude_viztools=True
-    )
+    env.variables.funcs_up42 = get_methods(up42, exclude_viztools=True)
     env.variables.funcs_project = get_methods(up42.Project)
     env.variables.funcs_workflow = get_methods(up42.Workflow)
     env.variables.funcs_job = get_methods(up42.Job)

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -12,10 +12,9 @@
 
 import warnings
 from pathlib import Path
-from typing import Union, Tuple, List, Optional
+from typing import Union, Tuple, List, Optional, Dict
 import logging
 
-from geojson import FeatureCollection
 from geopandas import GeoDataFrame
 
 # pylint: disable=wrong-import-position

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -37,7 +37,7 @@ logger = get_logger(__name__, level=logging.INFO)
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
 
-_auth = None
+_auth: Union[Auth, None] = None
 
 
 def authenticate(
@@ -203,13 +203,13 @@ def validate_manifest(path_or_json: Union[str, Path, Dict]) -> Dict:
 
 def read_vector_file(
     filename: str = "aoi.geojson", as_dataframe: bool = False
-) -> FeatureCollection:
+) -> Union[Dict, GeoDataFrame]:
     return Tools().read_vector_file(filename, as_dataframe)
 
 
 def get_example_aoi(
     location: str = "Berlin", as_dataframe: bool = False
-) -> FeatureCollection:
+) -> Union[Dict, GeoDataFrame]:
     return Tools().get_example_aoi(location, as_dataframe)
 
 

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -31,7 +31,7 @@ class Asset:
         self.auth = auth
         self.workspace_id = auth.workspace_id
         self.asset_id = asset_id
-        self.results = None
+        self.results: Union[List[str], None] = None
 
     def __repr__(self):
         info = self.info

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Dict, List, Union
 
 from up42.auth import Auth
-from up42.tools import Tools
 from up42.utils import (
     get_logger,
     download_results_from_gcs,
@@ -13,7 +12,7 @@ from up42.utils import (
 logger = get_logger(__name__)
 
 
-class Asset(Tools):
+class Asset:
     """
     The Asset class enables access to the UP42 assets in the storage. Assets are results
     of orders or results of jobs with download blocks.

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -219,7 +219,7 @@ class Auth:
         data: Union[dict, list] = {},
         querystring: dict = {},
         return_text: bool = True,
-    ) -> Union[str, dict, requests.Response]:
+    ):  # Union[str, dict, requests.Response]:
         """
         Handles retrying the request and automatically retries and gets a new token if
         the old is invalid.

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -13,7 +13,6 @@ from geojson import Feature, FeatureCollection
 from tqdm import tqdm
 
 from up42.auth import Auth
-from up42.tools import Tools
 from up42.viztools import VizTools
 from up42.order import Order
 from up42.utils import get_logger, any_vector_to_fc, fc_to_query_geometry
@@ -63,7 +62,7 @@ supported_sensors = {
 }
 
 # pylint: disable=duplicate-code
-class Catalog(VizTools, Tools):
+class Catalog(VizTools):
     """
     The Catalog class enables access to the UP42 catalog search. You can search
     for satellite image scenes (for different sensors and criteria like cloud cover),

--- a/up42/estimation.py
+++ b/up42/estimation.py
@@ -2,14 +2,13 @@ from typing import Dict, Union, List
 from pathlib import Path
 
 from up42.auth import Auth
-from up42.tools import Tools
 
 from up42.utils import get_logger
 
 logger = get_logger(__name__)
 
 
-class Estimation(Tools):
+class Estimation:
     def __init__(
         self,
         auth: Auth,

--- a/up42/job.py
+++ b/up42/job.py
@@ -9,7 +9,6 @@ import requests.exceptions
 
 from up42.auth import Auth
 from up42.jobtask import JobTask
-from up42.tools import Tools
 from up42.viztools import VizTools
 from up42.utils import (
     get_logger,
@@ -21,7 +20,7 @@ logger = get_logger(__name__)
 
 
 # pylint: disable=duplicate-code
-class Job(VizTools, Tools):
+class Job(VizTools):
     """
     The Job class is the result of running a workflow. It lets you download, visualize and
         manipulate the results of the job, and keep track of the status or cancel a job while

--- a/up42/jobcollection.py
+++ b/up42/jobcollection.py
@@ -7,14 +7,13 @@ from geojson import FeatureCollection
 from up42.auth import Auth
 from up42.job import Job
 from up42.viztools import VizTools
-from up42.tools import Tools
 
 from up42.utils import get_logger
 
 logger = get_logger(__name__)
 
 
-class JobCollection(VizTools, Tools):
+class JobCollection(VizTools):
     """
     The JobCollection class provides facilities for handling and downloading
     multiple jobs results as one object.

--- a/up42/jobtask.py
+++ b/up42/jobtask.py
@@ -5,7 +5,6 @@ from geopandas import GeoDataFrame
 from tqdm import tqdm
 
 from up42.auth import Auth
-from up42.tools import Tools
 from up42.viztools import VizTools
 from up42.utils import get_logger, download_results_from_gcs
 
@@ -13,7 +12,7 @@ logger = get_logger(__name__)
 
 
 # pylint: disable=duplicate-code
-class JobTask(VizTools, Tools):
+class JobTask(VizTools):
     """
     The JobTask class provides access to the result of a specific block in the workflow.
     Each job contains one or multiple JobTasks, one for each block.

--- a/up42/order.py
+++ b/up42/order.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Optional
 
 from up42.auth import Auth
 from up42.asset import Asset
-from up42.tools import Tools
 from up42.utils import (
     get_logger,
 )
@@ -13,7 +12,7 @@ logger = get_logger(__name__)
 DATA_PROVIDERS = ["oneatlas"]
 
 
-class Order(Tools):
+class Order:
     """
     The Order class enables you to place, inspect and get information on orders.
 

--- a/up42/project.py
+++ b/up42/project.py
@@ -8,12 +8,11 @@ from up42.job import Job
 from up42.jobcollection import JobCollection
 from up42.utils import get_logger, filter_jobs_on_mode
 from up42.workflow import Workflow
-from up42.tools import Tools
 
 logger = get_logger(__name__)
 
 
-class Project(Tools):
+class Project:
     """
     The Project is the top-level class of the UP42 hierarchy. With it you can create
     new workflows, query already existing workflows & jobs in the project and manage

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -6,12 +6,11 @@ from up42.auth import Auth
 from up42.order import Order
 from up42.asset import Asset
 from up42.utils import get_logger
-from up42.tools import Tools
 
 logger = get_logger(__name__)
 
 
-class Storage(Tools):
+class Storage:
     """
     The Storage class enables access to the UP42 storage. You can list
     your assets and orders within an UP42 workspace.

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -1,11 +1,11 @@
 """
-Base functionality that is not bound to a specific higher level UP42 object.
+Base functionality that is made available on the up42 import object (in the init) and
+not bound to a specific higher level UP42 object.
 """
 
 import json
 from pathlib import Path
 from typing import List, Union, Dict
-import warnings
 
 from geopandas import GeoDataFrame
 import geopandas as gpd
@@ -40,26 +40,6 @@ class Tools:
         self.quicklooks = None
         self.results = None
 
-    def _deprecate_tools(self, function_name: str):
-        # TODO: When finally deprecating this, move the functions that don't require
-        # TODO: the class out of it and import directly in init. Don't need to be
-        # TODO: instatiated via Tools in __init__.
-
-        object_name = self.__class__.__name__
-        if object_name in [
-            "Project",
-            "Workflow",
-            "Job",
-            "JobTask",
-            "JobCollection",
-            "Catalog",
-        ]:
-            message = (
-                f"Use of {object_name}.{function_name} will be deprecated in "
-                f"version 0.14.0, use up42.{function_name} instead!"
-            )
-            warnings.warn(message, DeprecationWarning, stacklevel=3)
-
     # pylint: disable=no-self-use
     def read_vector_file(
         self, filename: str = "aoi.geojson", as_dataframe: bool = False
@@ -78,8 +58,6 @@ class Tools:
         Returns:
             Feature Collection
         """
-        self._deprecate_tools("read_vector_file")
-
         suffix = Path(filename).suffix
 
         if suffix == ".kml":
@@ -117,8 +95,6 @@ class Tools:
         Returns:
             Feature collection json with the selected aoi.
         """
-        self._deprecate_tools("get_example_aoi")
-
         logger.info(f"Getting small example aoi in location '{location}'.")
         if location == "Berlin":
             example_aoi = self.read_vector_file(
@@ -148,7 +124,6 @@ class Tools:
         Export the drawn aoi via the export button, then read the geometries via
         read_aoi_file().
         """
-        self._deprecate_tools("draw_aoi")
         m = folium_base_map(layer_control=True)
         DrawFoliumOverride(
             export=True,
@@ -184,8 +159,6 @@ class Tools:
             A list of the public blocks and their metadata. Optional a simpler version
             dict.
         """
-        self._deprecate_tools("get_blocks")
-
         try:
             block_type = block_type.lower()
         except AttributeError:
@@ -239,8 +212,6 @@ class Tools:
         Returns:
             A dict of the block details metadata for the specific block.
         """
-        self._deprecate_tools("get_block_details")
-
         if not hasattr(self, "auth"):
             raise Exception(
                 "Requires authentication with UP42, use up42.authenticate()!"
@@ -269,8 +240,6 @@ class Tools:
         Returns:
             A dictionary with the validation results and potential validation errors.
         """
-        self._deprecate_tools("validate_manifest")
-
         if isinstance(path_or_json, (str, Path)):
             with open(path_or_json) as src:
                 manifest_json = json.load(src)

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -552,7 +552,7 @@ class Workflow:
             f"workflows/{self.workflow_id}/jobs?name={name}"
         )
         response_json = self.auth._request(
-            request_type="POST", url=url, data=input_parameters
+            request_type="POST", url=url, data=input_parameters  # type: ignore
         )
         job_json = response_json["data"]
         logger.info(f"Created and running new job: {job_json['id']}.")

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -27,7 +27,7 @@ from up42.utils import (
 logger = get_logger(__name__)
 
 
-class Workflow(Tools):
+class Workflow:
     """
     The Workflow class lets you configure & run jobs and query existing jobs related
     to this workflow.
@@ -158,7 +158,7 @@ class Workflow(Tools):
 
         # Get public + custom blocks.
         logging.getLogger("up42.tools").setLevel(logging.CRITICAL)
-        blocks: Dict = self.get_blocks(basic=False)  # type: ignore
+        blocks: Dict = Tools(auth=self.auth).get_blocks(basic=False)  # type: ignore
         logging.getLogger("up42.tools").setLevel(logging.INFO)
 
         # Get ids of the input tasks, regardless of the specified format.


### PR DESCRIPTION
Fully deprecates the Tools module inheritance  in the other classes (after deprecation process). The tools functions will only be available from the `up42` import object.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
