### PR TITLE
Remove get info from fixtures up4296

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -270,7 +270,7 @@ def project_mock(auth_mock, requests_mock):
 
     project = Project(auth=auth_mock, project_id=auth_mock.project_id)
 
-    # create_workflow. If with use_existing=True, requires workflow info mock.
+    # create_workflow.
     url_create_workflow = (
         f"{project.auth._endpoint()}/projects/" f"{project.project_id}/workflows/"
     )
@@ -279,6 +279,20 @@ def project_mock(auth_mock, requests_mock):
         "data": {"id": WORKFLOW_ID, "displayId": "workflow_displayId_123"},
     }
     requests_mock.post(url=url_create_workflow, json=json_create_workflow)
+
+    # workflow.info (for create_workflow)
+    url_workflow_info = (
+        f"{project.auth._endpoint()}/projects/"
+        f"{project.project_id}/workflows/{WORKFLOW_ID}"
+    )
+    json_workflow_info = {
+        "data": {
+            "name": WORKFLOW_NAME,
+            "description": WORKFLOW_DESCRIPTION,
+        },
+        "error": {},
+    }
+    requests_mock.get(url=url_workflow_info, json=json_workflow_info)
 
     # get_workflows
     url_get_workflows = (

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -208,30 +208,6 @@ JSON_ORDER = {
 JSON_ORDERS = {"data": {"orders": [JSON_ORDER["data"]]}, "error": None}
 
 
-# TODO: Use patch.dict instead of 2 fictures?
-@pytest.fixture()
-def auth_mock_no_request(requests_mock):
-    auth = Auth(
-        project_id=PROJECT_ID,
-        project_api_key=PROJECT_APIKEY,
-        authenticate=False,
-        retry=False,
-        get_info=False,
-    )
-
-    url_get_token = (
-        f"https://{auth.project_id}:{auth.project_api_key}@api.up42."
-        f"{auth.env}/oauth/token"
-    )
-    json_get_token = {"data": {"accessToken": TOKEN}}
-    requests_mock.post(
-        url=url_get_token,
-        json=json_get_token,
-    )
-
-    return auth
-
-
 @pytest.fixture()
 def auth_mock(requests_mock):
     # token for initial authentication
@@ -253,7 +229,6 @@ def auth_mock(requests_mock):
         project_api_key=PROJECT_APIKEY,
         authenticate=True,
         retry=False,
-        get_info=True,
     )
 
     # get_blocks

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,7 +9,6 @@ from .context import Auth
 
 # pylint: disable=unused-import
 from .fixtures import (
-    auth_mock_no_request,
     auth_mock,
     auth_live,
 )
@@ -23,43 +22,41 @@ def test_auth_kwargs():
         env="abc",
         authenticate=False,
         retry=False,
-        get_info=False,
     )
     assert auth.env == "abc"
     assert not auth.authenticate
     assert not auth.retry
-    assert not auth.get_info
 
 
-def test_no_credentials_raises(auth_mock_no_request):
-    auth_mock_no_request.project_id = None
-    auth_mock_no_request.project_api_key = None
+def test_no_credentials_raises(auth_mock):
+    auth_mock.project_id = None
+    auth_mock.project_api_key = None
     with pytest.raises(ValueError):
-        auth_mock_no_request._find_credentials()
+        auth_mock._find_credentials()
 
 
-def test_find_credentials_cfg_file(auth_mock_no_request):
-    auth_mock_no_request.project_id = None
-    auth_mock_no_request.project_api_key = None
+def test_find_credentials_cfg_file(auth_mock):
+    auth_mock.project_id = None
+    auth_mock.project_api_key = None
 
     fp = Path(__file__).resolve().parent / "mock_data" / "test_config.json"
-    auth_mock_no_request.cfg_file = fp
+    auth_mock.cfg_file = fp
 
-    auth_mock_no_request._find_credentials()
-    assert auth_mock_no_request.project_id is not None
-    assert auth_mock_no_request.project_api_key is not None
-
-
-def test_endpoint(auth_mock_no_request):
-    assert auth_mock_no_request._endpoint() == "https://api.up42.com"
-
-    auth_mock_no_request.env = "abc"
-    assert auth_mock_no_request._endpoint() == "https://api.up42.abc"
+    auth_mock._find_credentials()
+    assert auth_mock.project_id is not None
+    assert auth_mock.project_api_key is not None
 
 
-def test_get_token_project(auth_mock_no_request):
-    auth_mock_no_request._get_token_project()
-    assert auth_mock_no_request.token == TOKEN
+def test_endpoint(auth_mock):
+    assert auth_mock._endpoint() == "https://api.up42.com"
+
+    auth_mock.env = "abc"
+    assert auth_mock._endpoint() == "https://api.up42.abc"
+
+
+def test_get_token_project(auth_mock):
+    auth_mock._get_token_project()
+    assert auth_mock.token == TOKEN
 
 
 @pytest.mark.live
@@ -77,7 +74,7 @@ def test_get_workspace_live(auth_live):
     assert hasattr(auth_live, "workspace_id")
 
 
-def test_generate_headers(auth_mock_no_request):
+def test_generate_headers(auth_mock):
     version = io.open(
         Path(__file__).resolve().parents[1] / "up42/_version.txt", encoding="utf-8"
     ).read()
@@ -87,9 +84,7 @@ def test_generate_headers(auth_mock_no_request):
         "cache-control": "no-cache",
         "X-UP42-info": f"python/{version}",
     }
-    assert (
-        auth_mock_no_request._generate_headers(token="token_1011") == expected_headers
-    )
+    assert auth_mock._generate_headers(token="token_1011") == expected_headers
 
 
 def test_request_helper(auth_mock, requests_mock):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -26,35 +26,21 @@ def test_project_info(project_mock):
 
 
 def test_create_workflow(project_mock):
-    project_mock.auth.get_info = False
-
     workflow = project_mock.create_workflow(
         name=WORKFLOW_NAME, description=WORKFLOW_DESCRIPTION
     )
     assert isinstance(workflow, Workflow)
-    assert not hasattr(workflow, "_info")
+    assert hasattr(workflow, "_info")
 
 
-def test_create_workflow_use_existing(project_mock, requests_mock):
-    url_workflow_info = (
-        f"{project_mock.auth._endpoint()}/projects/"
-        f"{project_mock.project_id}/workflows/{WORKFLOW_ID}"
-    )
-    json_workflow_info = {
-        "data": {
-            "name": WORKFLOW_NAME,
-            "description": WORKFLOW_DESCRIPTION,
-        },
-        "error": {},
-    }
-    requests_mock.get(url=url_workflow_info, json=json_workflow_info)
-
+def test_create_workflow_use_existing(project_mock):
     workflow = project_mock.create_workflow(
         name=WORKFLOW_NAME,
         description=WORKFLOW_DESCRIPTION,
         use_existing=True,
     )
     assert isinstance(workflow, Workflow)
+    assert hasattr(workflow, "_info")
 
 
 def test_get_workflows(project_mock):

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -33,8 +33,6 @@ class Asset(Tools):
         self.workspace_id = auth.workspace_id
         self.asset_id = asset_id
         self.results = None
-        if self.auth.get_info:
-            self._info = self.info
 
     def __repr__(self):
         info = self.info
@@ -51,7 +49,6 @@ class Asset(Tools):
         """
         url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/assets/{self.asset_id}"
         response_json = self.auth._request(request_type="GET", url=url)
-        self._info = response_json["data"]
         return response_json["data"]
 
     @property

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -77,10 +77,6 @@ class Auth:
             self.retry: bool = kwargs["retry"]
         except KeyError:
             self.retry = True
-        try:
-            self.get_info: bool = kwargs["get_info"]
-        except KeyError:
-            self.get_info = True
 
         if self.authenticate:
             self._find_credentials()

--- a/up42/job.py
+++ b/up42/job.py
@@ -52,8 +52,7 @@ class Job(VizTools, Tools):
         self.quicklooks = None
         self.results = None
         self.order_ids = order_ids
-        if self.auth.get_info:
-            self._info = self.info
+        self._info = self.info
 
     def __repr__(self):
         order_ids = (

--- a/up42/jobtask.py
+++ b/up42/jobtask.py
@@ -38,8 +38,7 @@ class JobTask(VizTools, Tools):
         self.jobtask_id = jobtask_id
         self.quicklooks = None
         self.results = None
-        if self.auth.get_info:
-            self._info = self.info
+        self._info = self.info
 
     def __repr__(self):
         info = self.info[0]

--- a/up42/order.py
+++ b/up42/order.py
@@ -28,8 +28,7 @@ class Order(Tools):
         self.workspace_id = auth.workspace_id
         self.order_id = order_id
         self.payload = payload
-        if self.auth.get_info:
-            self._info = self.info
+        self._info = self.info
 
     def __repr__(self):
         info = self.info

--- a/up42/project.py
+++ b/up42/project.py
@@ -32,8 +32,7 @@ class Project(Tools):
     def __init__(self, auth: Auth, project_id: str):
         self.auth = auth
         self.project_id = project_id
-        if self.auth.get_info:
-            self._info = self.info
+        self._info = self.info
 
     def __repr__(self):
         info = self.info

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -47,8 +47,7 @@ class Workflow(Tools):
         self.auth = auth
         self.project_id = project_id
         self.workflow_id = workflow_id
-        if self.auth.get_info:
-            self._info = self.info
+        self._info = self.info
 
     def __repr__(self):
         info = self.info


### PR DESCRIPTION
Simplifies class instantiation with auth-mock by removing the additional "auth-mock-without-info-call" mechanism. Not relevant anymore, was mainly for avoiding code duplication of the additional info mock request in every test (mock now in the fixtures anyway) and to be explicit about some single requests (not actually important).

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
