### PR TITLE
fix livetests - project settings lengths is fixed

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -99,7 +99,7 @@ def test_get_project_settings(project_mock):
 def test_get_project_settings_live(project_live):
     project_settings = project_live.get_project_settings()
     assert isinstance(project_settings, list)
-    assert len(project_settings) == MAX_CONCURRENT_JOBS
+    assert len(project_settings) == 3
     assert project_settings[0]["name"] in [
         "JOB_QUERY_MAX_AOI_SIZE",
         "MAX_CONCURRENT_JOBS",


### PR DESCRIPTION
fix livetests - project settings lengths is fixed

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
