### PR TITLE
Pylint disable for livetests up5530

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,9 @@ jobs:
             pip install -r requirements-dev.txt
       - run:
           name: Runnning tests
-          command: make test[live]
+          command: |
+            rm -r .pytest_cache
+            python -m pytest --runlive --durations=5
   deploy:
     docker:
       - image: circleci/python:3.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,7 @@ jobs:
             pip install -r requirements-dev.txt
       - run:
           name: Runnning tests
-          command: |
-            rm -r .pytest_cache
-            python -m pytest --runlive --durations=5
+          command: python -m pytest --runlive --durations=5
   deploy:
     docker:
       - image: circleci/python:3.7

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -56,10 +56,11 @@ def test_asset_get_download_url_live(asset_live):
 
 def test_asset_download(asset_mock, requests_mock):
     out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
-    out_tgz_file = open(out_tgz, "rb")
+    with open(out_tgz, "rb") as src_tgz:
+        out_tgz_file = src_tgz.read()
     requests_mock.get(
         url=DOWNLOAD_URL,
-        content=out_tgz_file.read(),
+        content=out_tgz_file,
         headers={"x-goog-stored-content-length": "163"},
     )
 
@@ -85,10 +86,11 @@ def test_asset_download(asset_mock, requests_mock):
 def test_asset_download_nounpacking(asset_mock, requests_mock):
 
     out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
-    out_tgz_file = open(out_tgz, "rb")
+    with open(out_tgz, "rb") as src_tgz:
+        out_tgz_file = src_tgz.read()
     requests_mock.get(
         url=DOWNLOAD_URL,
-        content=out_tgz_file.read(),
+        content=out_tgz_file,
         headers={"x-goog-stored-content-length": "163"},
     )
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -141,10 +141,11 @@ def test_get_jobtasks_result_json(job_mock):
 
 def test_job_download_result(job_mock, requests_mock):
     out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
-    out_tgz_file = open(out_tgz, "rb")
+    with open(out_tgz, "rb") as src_tgz:
+        out_tgz_file = src_tgz.read()
     requests_mock.get(
         url=DOWNLOAD_URL,
-        content=out_tgz_file.read(),
+        content=out_tgz_file,
         headers={"x-goog-stored-content-length": "163"},
     )
 
@@ -170,10 +171,11 @@ def test_job_download_result(job_mock, requests_mock):
 def test_job_download_result_nounpacking(job_mock, requests_mock):
 
     out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
-    out_tgz_file = open(out_tgz, "rb")
+    with open(out_tgz, "rb") as src_tgz:
+        out_tgz_file = src_tgz.read()
     requests_mock.get(
         url=DOWNLOAD_URL,
-        content=out_tgz_file.read(),
+        content=out_tgz_file,
         headers={"x-goog-stored-content-length": "163"},
     )
 

--- a/tests/test_jobtask.py
+++ b/tests/test_jobtask.py
@@ -31,10 +31,11 @@ def test_get_result_json_live(jobtask_live):
 
 def test_jobtask_download_result(jobtask_mock, requests_mock):
     out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
-    out_tgz_file = open(out_tgz, "rb")
+    with open(out_tgz, "rb") as src_tgz:
+        out_tgz_file = src_tgz.read()
     requests_mock.get(
         url=DOWNLOAD_URL,
-        content=out_tgz_file.read(),
+        content=out_tgz_file,
         headers={"x-goog-stored-content-length": "221"},
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -259,10 +259,11 @@ def test_download_result_from_gcs(requests_mock):
     cloud_storage_url = "http://clouddownload.api.com/abcdef"
 
     out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
-    out_tgz_file = open(out_tgz, "rb")
+    with open(out_tgz, "rb") as src_tgz:
+        out_tgz_file = src_tgz.read()
     requests_mock.get(
         url=cloud_storage_url,
-        content=out_tgz_file.read(),
+        content=out_tgz_file,
     )
     with tempfile.TemporaryDirectory() as tempdir:
         with open(Path(tempdir) / "dummy.txt", "w") as fp:
@@ -282,10 +283,12 @@ def test_download_result_from_gcs_zip(requests_mock):
     cloud_storage_url = "http://clouddownload.api.com/abcdef"
 
     out_zip = Path(__file__).resolve().parent / "mock_data/result_tif.zip"
-    out_zip_file = open(out_zip, "rb")
+    with open(out_zip, "rb") as src_zip:
+        out_zip_file = src_zip.read()
+
     requests_mock.get(
         url=cloud_storage_url,
-        content=out_zip_file.read(),
+        content=out_zip_file,
     )
     with tempfile.TemporaryDirectory() as tempdir:
         with open(Path(tempdir) / "dummy.txt", "w") as fp:
@@ -305,10 +308,12 @@ def test_download_result_from_gcs_not_compressed(requests_mock):
     cloud_storage_url = "http://clouddownload.api.com/abcdef"
 
     out_zip = Path(__file__).resolve().parent / "mock_data/aoi_berlin.geojson"
-    out_zip_file = open(out_zip, "rb")
+    with open(out_zip, "rb") as src_zip:
+        out_zip_file = src_zip.read()
+
     requests_mock.get(
         url=cloud_storage_url,
-        content=out_zip_file.read(),
+        content=out_zip_file,
     )
     with tempfile.TemporaryDirectory() as tempdir:
         with open(Path(tempdir) / "dummy.txt", "w") as fp:


### PR DESCRIPTION
- Fixes pylint errors due to new version
- Disables pylint/mypy for daily ci livetests

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
