### PR TITLE
fix cli livetest

### DIFF
--- a/up42/cli.py
+++ b/up42/cli.py
@@ -675,7 +675,7 @@ def construct_parameters(
     Follows STAC principles and property names to create a filter for
     catalog search.
     """
-    geometry = catalog.read_vector_file(geom_file)
+    geometry = Tools(catalog.auth).read_vector_file(geom_file)
     start_date_str = start_date.strftime("%Y-%m-%d")
     end_date_str = end_date.strftime("%Y-%m-%d")
     logger.info(


### PR DESCRIPTION
Don't use deprecated tools access via catalog in cli livetest

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
