### PR TITLE
skip test_cancel_job_live

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,3 @@
-# pylint: disable=no-member
-
 import os
 from unittest import mock
 from pathlib import Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+# pylint: disable=no-member
+
 import os
 from unittest import mock
 from pathlib import Path

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -186,9 +186,7 @@ def test_job_download_result_nounpacking(job_mock, requests_mock):
         assert len(out_files) == 1
 
 
-@pytest.mark.skip(
-    reason="Sometimes takes quite long to cancel the job on the server."
-)
+@pytest.mark.skip(reason="Sometimes takes quite long to cancel the job on the server.")
 @pytest.mark.live
 def test_cancel_job_live(workflow_live):
     input_parameters_json = (

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -186,6 +186,9 @@ def test_job_download_result_nounpacking(job_mock, requests_mock):
         assert len(out_files) == 1
 
 
+@pytest.mark.skip(
+    reason="Sometimes takes quite long to cancel the job on the server."
+)
 @pytest.mark.live
 def test_cancel_job_live(workflow_live):
     input_parameters_json = (

--- a/up42/cli.py
+++ b/up42/cli.py
@@ -159,7 +159,7 @@ def blocks_from_context():
     class OptionChoiceFromContext(click.Option):
         def full_process_value(self, ctx, value):
             self.type = click.Choice(Tools(ctx.obj).get_blocks().keys())
-            return super().full_process_value(ctx, value)
+            return super().full_process_value(ctx, value)  # pylint: disable=no-member
 
     return OptionChoiceFromContext
 
@@ -274,7 +274,7 @@ def workflows_from_context():
         def full_process_value(self, ctx, value):
             workflow_names = [wkf._info["name"] for wkf in ctx.obj.get_workflows()]
             self.type = click.Choice(workflow_names)
-            return super().full_process_value(ctx, value)
+            return super().full_process_value(ctx, value)  # pylint: disable=no-member
 
     return OptionChoiceFromContext
 


### PR DESCRIPTION
Skip test_cancel_job_live due to server flakiness, to avoid ci livetests failing.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
