### PR TITLE
Update pin mypy

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ pytest
 pytest-pylint
 pytest-sugar
 mypy==0.902
+types-requests
 mypy-extensions
 pytest-cov
 pytest-mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 nbconvert
 black
 requests-mock
-pylint
+pylint==2.8.3
 pytest
 pytest-pylint
 pytest-sugar
-mypy
+mypy==0.902
 mypy-extensions
 pytest-cov
 pytest-mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ pytest-pylint
 pytest-sugar
 mypy==0.902
 types-requests
+types-mock
 mypy-extensions
 pytest-cov
 pytest-mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ pytest-sugar
 mypy==0.902
 types-requests
 types-mock
+types-click
 mypy-extensions
 pytest-cov
 pytest-mypy


### PR DESCRIPTION
Adds type-stubs packages (which are used with mypy) as requirements. Mypy automatically installs [typeshed](https://github.com/python/typeshed/blob/master/README.md), but apparently type-stubs for third packages are external now or weren't required before.

Also pinning mypy&pylint to require less changes. We can update intentionally from time to time.

Items:
* [X] Ran tests
* [ ] Ran live-tests (failing due to cli issues, separate PR)
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
