### PR TITLE
Add skip existing to makefile dist upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ package:
 	twine check dist/*
 
 upload:
-	twine upload dist/*
+	twine upload --skip-existing dist/*
 
 clean:
 	find . -name "__pycache__" -exec rm -rf {} +


### PR DESCRIPTION
Latest changes are not passing circleci test (when going to prod), see here https://app.circleci.com/pipelines/github/up42/up42-py/1163/workflows/1b069335-94b1-405c-9407-a0b7143cdbf3/jobs/1179/steps. Changes only entail a new jupyter notebook example.

The error is related to an existing file with the same name. I got solution from here https://stackoverflow.com/questions/52016336/how-to-upload-new-versions-of-project-to-pypi-with-twine/52130985.
