### PR TITLE
Iso time for catalog and workflow up5631

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../u
 from up42.tools import Tools
 from up42.viztools import folium_base_map, VizTools
 from up42.utils import (
+    format_time_period,
     any_vector_to_fc,
     fc_to_query_geometry,
     download_results_from_gcs,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import json
 import copy
-from dateutil.parser import parse
 
 import pytest
 import shapely
@@ -181,97 +180,6 @@ def test_get_default_parameters(workflow_mock):
         "bbox": "None",
         "time": "2018-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
     }
-
-
-@pytest.mark.parametrize(
-    "start_date,end_date,result_time",
-    [
-        ("2014-01-01", "2016-12-31", "2014-01-01T00:00:00Z/2016-12-31T23:59:59Z"),
-        (
-            "2014-01-01T00:00:00",
-            "2016-12-31T10:11:12",
-            "2014-01-01T00:00:00Z/2016-12-31T10:11:12Z",
-        ),
-        (
-            "2014-01-01T00:00:00",
-            "2016-12-31",
-            "2014-01-01T00:00:00Z/2016-12-31T23:59:59Z",
-        ),
-        (
-            parse("2014-01-01"),
-            parse("2016-12-31T10:11:12"),
-            "2014-01-01T00:00:00Z/2016-12-31T10:11:12Z",
-        ),
-        (
-            parse("2014-01-01"),
-            "2016-12-31",
-            "2014-01-01T00:00:00Z/2016-12-31T23:59:59Z",
-        ),
-        (
-            parse("2014-01-01"),
-            "2016-12-31T10:11:12",
-            "2014-01-01T00:00:00Z/2016-12-31T10:11:12Z",
-        ),
-    ],
-)
-def test_construct_parameters_dates(workflow_mock, start_date, end_date, result_time):
-    parameters = workflow_mock.construct_parameters(
-        geometry=shapely.geometry.point.Point(1, 3),
-        geometry_operation="bbox",
-        start_date=start_date,
-        end_date=end_date,
-        limit=1,
-    )
-    assert isinstance(parameters, dict)
-    assert parameters == {
-        "esa-s2-l2a-gtiff-visual:1": {
-            "ids": "None",
-            "bbox": [0.99999, 2.99999, 1.00001, 3.00001],
-            "time": result_time,
-            "limit": 1,
-        },
-        "tiling:1": {"nodata": "None", "tile_width": 768},
-    }
-
-
-@pytest.mark.parametrize(
-    "start_date,end_date",
-    [(None, "2014-01-01"), ("2014-01-01", None)],
-)
-def test_construct_parameters_raises_with_missing_dates(
-    workflow_mock, start_date, end_date
-):
-    with pytest.raises(ValueError) as e:
-        workflow_mock.construct_parameters(
-            geometry=shapely.geometry.point.Point(1, 3),
-            geometry_operation="bbox",
-            start_date=start_date,
-            end_date=end_date,
-            limit=1,
-        )
-
-        assert (
-            "When using dates, both start_date and end_date need to be provided."
-            in str(e.value)
-        )
-
-
-@pytest.mark.parametrize(
-    "start_date,end_date",
-    [(None, "2016-01-01"), ("2014-01-01", None)],
-)
-def test_construct_parameters_raises_with_mixed_up_dates(
-    workflow_mock, start_date, end_date
-):
-    with pytest.raises(ValueError) as e:
-        workflow_mock.construct_parameters(
-            geometry=shapely.geometry.point.Point(1, 3),
-            geometry_operation="bbox",
-            start_date=start_date,
-            end_date=end_date,
-            limit=1,
-        )
-        assert "The start_date needs to be earlier than the end_date!" in str(e.value)
 
 
 def test_construct_parameters_scene_ids(workflow_mock):

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -15,7 +15,12 @@ from tqdm import tqdm
 from up42.auth import Auth
 from up42.viztools import VizTools
 from up42.order import Order
-from up42.utils import get_logger, any_vector_to_fc, fc_to_query_geometry
+from up42.utils import (
+    get_logger,
+    any_vector_to_fc,
+    fc_to_query_geometry,
+    format_time_period,
+)
 
 logger = get_logger(__name__)
 
@@ -129,7 +134,8 @@ class Catalog(VizTools):
         Returns:
             The constructed parameters dictionary.
         """
-        datetime = f"{start_date}T00:00:00Z/{end_date}T23:59:59Z"
+        time_period = format_time_period(start_date=start_date, end_date=end_date)
+
         block_filters: List[str] = []
         for sensor in sensors:
             if sensor not in list(supported_sensors.keys()):
@@ -154,7 +160,7 @@ class Catalog(VizTools):
             query_filters["cloudCoverage"] = {"lte": max_cloudcover}  # type: ignore
 
         search_parameters = {
-            "datetime": datetime,
+            "datetime": time_period,
             "intersects": aoi_geometry,
             "limit": limit,
             "query": query_filters,

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from typing import List, Union
+from typing import List, Union, Optional
 from pathlib import Path
 import shutil
 import tempfile
@@ -8,6 +8,8 @@ import tarfile
 import zipfile
 import warnings
 import functools
+from datetime import datetime
+from datetime import time as datetime_time
 
 from geopandas import GeoDataFrame
 import shapely
@@ -172,6 +174,53 @@ def download_results_from_gcs_without_unpacking(
         f" '{output_directory}': {[Path(p).name for p in out_filepaths]}"
     )
     return out_filepaths
+
+
+def format_time_period(
+    start_date: Optional[Union[str, datetime]], end_date: Optional[Union[str, datetime]]
+):
+    """
+    Formats a time period string from start date and end date.
+
+    Args:
+        start_date: Query period starting day as iso-format string or datetime object,
+            e.g. "YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS".
+        end_date: Query period ending day as iso-format or datetime object,
+            e.g. "YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS".
+
+    Returns:
+        Time period string in the format "2014-01-01T00:00:00Z/2016-12-31T10:11:12Z"
+    """
+    if start_date is None or end_date is None:
+        raise ValueError(
+            "When using dates, both start_date and end_date need to be provided."
+        )
+    # Start and end date can be any combination of str ("YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS")
+    # or datetime objects.
+    if not isinstance(start_date, datetime):
+        start_dt: datetime = datetime.fromisoformat(start_date)
+    else:
+        start_dt = start_date
+
+    if not isinstance(end_date, datetime):
+        end_dt: datetime = datetime.fromisoformat(end_date)
+        try:
+            # For "YYYY-MM-DD" string the default datetime conversion sets to
+            # start of day, but image archive query requires end of day.
+            datetime.strptime(end_date, "%Y-%m-%d")  # format validation
+            end_dt = datetime.combine(end_dt.date(), datetime_time(23, 59, 59, 999999))
+        except ValueError:
+            pass
+    else:
+        end_dt = end_date
+
+    if start_dt > end_dt:
+        raise ValueError("The start_date can not be later than the end_date!")
+
+    formatting = "%Y-%m-%dT%H:%M:%S"
+    time_period = f"{start_dt.strftime(formatting)}Z/{end_dt.strftime(formatting)}Z"
+
+    return time_period
 
 
 def any_vector_to_fc(


### PR DESCRIPTION
- Use the new time formatting options (iso, datetime) from https://github.com/up42/up42-py/pull/244 also in catalog search
- Move time formatting logic to utils module to simplify code structure

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
