### PR TITLE
Use oauth2 for token up 5571

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">84%</text>
-        <text x="80" y="14">84%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">85%</text>
+        <text x="80" y="14">85%</text>
     </g>
 </svg>

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -211,12 +211,13 @@ JSON_ORDERS = {"data": {"orders": [JSON_ORDER["data"]]}, "error": None}
 @pytest.fixture()
 def auth_mock(requests_mock):
     # token for initial authentication
-    url_get_token = f"https://{PROJECT_ID}:{PROJECT_APIKEY}@api.up42.com/oauth/token"
-    json_get_token = {"data": {"accessToken": TOKEN}}
-    requests_mock.post(
-        url=url_get_token,
-        json=json_get_token,
-    )
+    url_get_token = "https://api.up42.com/oauth/token"
+    json_get_token = {
+        "data": {"accessToken": TOKEN},
+        "access_token": TOKEN,
+        "token_type": "bearer",
+    }
+    requests_mock.post(url_get_token, json=json_get_token)
 
     url_get_workspace = f"https://api.up42.com/projects/{PROJECT_ID}"
     json_get_workspace = {"data": {"workspaceId": WORKSPACE_ID}}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -54,13 +54,23 @@ def test_endpoint(auth_mock):
     assert auth_mock._endpoint() == "https://api.up42.abc"
 
 
-def test_get_token_project(auth_mock):
-    auth_mock._get_token_project()
+def test_get_token(auth_mock):
+    auth_mock._get_token()
     assert auth_mock.token == TOKEN
 
 
+def test_get_token_raises_wrong_credentials_live(auth_live):
+    auth_live.project_id = "123"
+    with pytest.raises(ValueError) as e:
+        auth_live._get_token()
+    assert (
+        "Authentication was not successful, check the provided project credentials."
+        in str(e.value)
+    )
+
+
 @pytest.mark.live
-def test_get_token_project_live(auth_live):
+def test_get_token_live(auth_live):
     assert hasattr(auth_live, "token")
 
 


### PR DESCRIPTION
Use Oauth for the token session. This currently only handles getting the token, using the oauth2 session all throughout the SDK for requests is a separate task.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
