### PR TITLE
remove geometry filtering for catalog search results

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">85%</text>
-        <text x="80" y="14">85%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">84%</text>
+        <text x="80" y="14">84%</text>
     </g>
 </svg>

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -7,7 +7,6 @@ from typing import Union, List, Tuple
 
 from pandas import Series
 from geopandas import GeoDataFrame
-from shapely.geometry import shape
 from shapely.geometry import Point, Polygon
 from geojson import Feature, FeatureCollection
 from tqdm import tqdm

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -202,21 +202,6 @@ class Catalog(VizTools):
         logger.info(f"{len(response_json['features'])} results returned.")
         dst_crs = "EPSG:4326"
         df = GeoDataFrame.from_features(response_json, crs=dst_crs)
-        if df.empty:
-            if as_dataframe:
-                return df
-            else:
-                return df.__geo_interface__
-
-        # Filter to actual geometries intersecting the aoi (Sobloo search uses a rectangular
-        # bounds geometry, can contain scenes that touch the aoi bbox, but not the aoi.
-        # So number returned images not consistent with set limit.
-        # TODO: Resolve on backend
-        geometry = search_parameters["intersects"]
-        poly = shape(geometry)
-        df = df[df.intersects(poly)]
-        df = df.reset_index(drop=True)
-        df.crs = dst_crs  # apply resets the crs
 
         if as_dataframe:
             return df


### PR DESCRIPTION
SDK used an additional geometry filtering for catalog search results, to filter results out that were not actually touching the search geomety. Instead will be ticketed with backend and removed, since it is also interfering with the catalog pagination testing.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
