### PR TITLE
Speed up create workflow existing up5736

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">85%</text>
-        <text x="80" y="14">85%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">89%</text>
+        <text x="80" y="14">89%</text>
     </g>
 </svg>

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -277,7 +277,7 @@ def project_mock(auth_mock, requests_mock):
 
     # create_workflow.
     url_create_workflow = (
-        f"{project.auth._endpoint()}/projects/" f"{project.project_id}/workflows/"
+        f"{project.auth._endpoint()}/projects/{project.project_id}/workflows/"
     )
     json_create_workflow = {
         "error": {},
@@ -304,13 +304,23 @@ def project_mock(auth_mock, requests_mock):
         f"{project.auth._endpoint()}/projects/" f"{project.project_id}/workflows"
     )
     json_get_workflows = {
-        "data": [{"id": WORKFLOW_ID}, {"id": WORKFLOW_ID}],
+        "data": [
+            {
+                "id": WORKFLOW_ID,
+                "name": WORKFLOW_NAME,
+                "description": WORKFLOW_DESCRIPTION,
+            },
+            {
+                "id": WORKFLOW_ID,
+                "name": WORKFLOW_NAME,
+                "description": WORKFLOW_DESCRIPTION,
+            },
+        ],
         "error": {},
     }  # Same workflow_id to not have to get multiple .info
     requests_mock.get(url=url_get_workflows, json=json_get_workflows)
 
     # get_jobs. Requires job_info mock.
-
     url_get_jobs = f"{project.auth._endpoint()}/projects/{project.project_id}/jobs"
     json_get_jobs = {
         "data": [

--- a/up42/project.py
+++ b/up42/project.py
@@ -96,15 +96,17 @@ class Project:
         )
         return workflow
 
-    def get_workflows(self, return_json: bool = False) -> Union[List["Workflow"], dict]:
+    def get_workflows(
+        self, return_json: bool = False
+    ) -> Union[List["Workflow"], List[dict]]:
         """
         Gets all workflows in a project as workflow objects or json.
 
         Args:
-            return_json: True returns Workflow Objects.
+            return_json: True returns infos of workflows as json instead of workflow objects.
 
         Returns:
-            Workflow objects in the project or alternatively json info of the workflows.
+            List of Workflow objects in the project or alternatively json info of the workflows.
         """
         url = f"{self.auth._endpoint()}/projects/{self.project_id}/workflows"
         response_json = self.auth._request(request_type="GET", url=url)

--- a/up42/project.py
+++ b/up42/project.py
@@ -70,17 +70,20 @@ class Project:
         if use_existing:
             logger.info("Getting existing workflows in project ...")
             logging.getLogger("up42.workflow").setLevel(logging.CRITICAL)
-            existing_workflows = self.get_workflows()
+            existing_workflows: list = self.get_workflows(return_json=True)
             logging.getLogger("up42.workflow").setLevel(logging.INFO)
 
-            matching_workflows = [
+            matching_workflows: list = [
                 workflow
                 for workflow in existing_workflows
-                if workflow._info["name"] == name
-                and workflow._info["description"] == description
+                if workflow["name"] == name and workflow["description"] == description
             ]
             if matching_workflows:
-                existing_workflow = matching_workflows[0]
+                existing_workflow = Workflow(
+                    self.auth,
+                    project_id=self.project_id,
+                    workflow_id=matching_workflows[0]["id"],
+                )
                 logger.info(
                     f"Using existing workflow: {name} - {existing_workflow.workflow_id}"
                 )


### PR DESCRIPTION
Speed up project.create_workflow(..., use_existing=True) by using the json return of all workflows in the project to compare with the workflow that is supposed to be created. Previously the workflow object of each workflow was used for the comparison which takes much longer due to each additional workflow.info call.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
