### PR TITLE
remove exclude-search plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,10 +121,6 @@ plugins:
         - "*examples/guides/*"
         - "*swagger*"
         - PULL_REQUEST_TEMPLATE.md
-  - exclude-search:
-      exclude:
-        - cli.md
-        - cli-reference.md
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -5,7 +5,6 @@ pymdown-extensions
 mkdocs-autolinks-plugin
 mkdocs-jupyter
 mkdocs-exclude
-mkdocs-exclude-search
 mkdocs-macros-plugin
 mkdocs-click
 mkdocstrings


### PR DESCRIPTION
Removes mkdocs-exclude-search plugin, which was required for excluding specific CLI chapters (CLI was removed).

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
