### PR TITLE
Function return examples up5486 - WIP

### DIFF
--- a/up42/project.py
+++ b/up42/project.py
@@ -192,6 +192,7 @@ class Project:
                   'value': '15000',
                   'range': {'min': 1, 'max': 180000}}
                 ]
+            ```
         """
         url = f"{self.auth._endpoint()}/projects/{self.project_id}/settings"
         response_json = self.auth._request(request_type="GET", url=url)

--- a/up42/project.py
+++ b/up42/project.py
@@ -46,6 +46,19 @@ class Project:
     def info(self) -> dict:
         """
         Gets the project metadata information.
+
+        ??? Example "Example Return (Click to extend)"
+            ```python
+                {'id': 'ce8793d0-b3ac-4b21-8040-54ad790db431',
+                 'displayId': 'ce8793d0',
+                 'createdAt': '2021-10-28T16:21:11.737831Z',
+                 'createdBy': {'id': '01ae36f8-9e58-4606-b6de-846cf8748a8c', 'type': 'USER'},
+                 'name': 'some project',
+                 'description': '',
+                 'workspaceId': '01ae36f3-9e58-4206-bassw-846cf8748a8c',
+                 ...
+                }
+            ```
         """
         url = f"{self.auth._endpoint()}/projects/{self.project_id}"
         response_json = self.auth._request(request_type="GET", url=url)
@@ -166,6 +179,19 @@ class Project:
 
         Returns:
             The project settings.
+
+        ??? Example "Example Return (Click to extend)"
+            ```python
+                [{'name': 'MAX_CONCURRENT_JOBS',
+                  'value': '10',
+                  'range': {'min': 1, 'max': 1000}},
+                 {'name': 'JOB_QUERY_LIMIT_PARAMETER_MAX_VALUE',
+                  'value': '20',
+                  'range': {'min': 1, 'max': 5000}},
+                 {'name': 'JOB_QUERY_MAX_AOI_SIZE',
+                  'value': '15000',
+                  'range': {'min': 1, 'max': 180000}}
+                ]
         """
         url = f"{self.auth._endpoint()}/projects/{self.project_id}/settings"
         response_json = self.auth._request(request_type="GET", url=url)

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -159,12 +159,13 @@ class Tools:
             A list of the public blocks and their metadata. Optional a simpler version
             dict.
 
-        Examples:
+        ??? Example "Example Return (Click to extend)"
             ```python
-             {
-              'tiling': 'd350aa0b-ac31-4021-bbe6-fd8da366740a',
-              'oneatlas-spot-fullscene': '0f15e07f-efcc-4598-939b-18aade349c57'
-             }
+                {
+                    'tiling': 'd350aa0b-ac31-4021-bbe6-fd8da366740a',
+                    'oneatlas-spot-fullscene': '0f15e07f-efcc-4598-939b-18aade349c57',
+                    ...
+                }
             ```
         """
         try:
@@ -220,6 +221,25 @@ class Tools:
 
         Returns:
             A dict of the block details metadata for the specific block.
+
+        ??? Example "Example Return (Click to extend)"
+            ```python
+                {
+                 'id': 'd350aa0b-ac31-4021-bbe6-fd8da366740a',
+                 'createdAt': '2019-02-12T12:19:20.470Z',
+                 'name': 'tiling',
+                 'displayName': 'Raster Tiling',
+                 'description': 'Clips rasters into tiles for machine learning algorithms.',
+                 'inputCapabilities': [],
+                 'outputCapabilities': [],
+                 'parameters': {
+                  'tile_width': {'type': 'number',
+                   'default': 768,
+                   'required': True,
+                   'description': 'Width of a tile in pixels'}},
+                ...
+               }
+            ```
         """
         if not hasattr(self, "auth"):
             raise Exception(
@@ -248,6 +268,13 @@ class Tools:
 
         Returns:
             A dictionary with the validation results and potential validation errors.
+
+        ??? Example "Example Return (Click to extend)"
+            ```python
+                {
+                 'valid': True, 'errors': []
+                }
+            ```
         """
         if isinstance(path_or_json, (str, Path)):
             with open(path_or_json) as src:

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -158,6 +158,14 @@ class Tools:
         Returns:
             A list of the public blocks and their metadata. Optional a simpler version
             dict.
+
+        Examples:
+            ```python
+             {
+              'tiling': 'd350aa0b-ac31-4021-bbe6-fd8da366740a',
+              'oneatlas-spot-fullscene': '0f15e07f-efcc-4598-939b-18aade349c57'
+             }
+            ```
         """
         try:
             block_type = block_type.lower()  # type: ignore

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -161,10 +161,9 @@ class Tools:
 
         ??? Example "Example Return (Click to extend)"
             ```python
-                {
-                    'tiling': 'd350aa0b-ac31-4021-bbe6-fd8da366740a',
-                    'oneatlas-spot-fullscene': '0f15e07f-efcc-4598-939b-18aade349c57',
-                    ...
+                {'tiling': 'd350aa0b-ac31-4021-bbe6-fd8da366740a',
+                 'oneatlas-spot-fullscene': '0f15e07f-efcc-4598-939b-18aade349c57',
+                 ...
                 }
             ```
         """
@@ -224,8 +223,7 @@ class Tools:
 
         ??? Example "Example Return (Click to extend)"
             ```python
-                {
-                 'id': 'd350aa0b-ac31-4021-bbe6-fd8da366740a',
+                {'id': 'd350aa0b-ac31-4021-bbe6-fd8da366740a',
                  'createdAt': '2019-02-12T12:19:20.470Z',
                  'name': 'tiling',
                  'displayName': 'Raster Tiling',
@@ -237,8 +235,8 @@ class Tools:
                    'default': 768,
                    'required': True,
                    'description': 'Width of a tile in pixels'}},
-                ...
-               }
+                 ...
+                }
             ```
         """
         if not hasattr(self, "auth"):
@@ -271,9 +269,7 @@ class Tools:
 
         ??? Example "Example Return (Click to extend)"
             ```python
-                {
-                 'valid': True, 'errors': []
-                }
+                {'valid': True, 'errors': []}
             ```
         """
         if isinstance(path_or_json, (str, Path)):

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -64,6 +64,19 @@ class Workflow:
     def info(self) -> dict:
         """
         Gets the workflow metadata information.
+
+        ??? Example "Example Return (Click to extend)"
+            ```python
+                {'id': '58a7a285-9e06-4ea6-aa8a-0cc14ea90d77',
+                 'name': '30-seconds-workflow',
+                 'description': '',
+                 'createdAt': '2021-11-22T00:00:05.983220Z',
+                 'createdBy': {'id': 'ce8793d0-b3ac-4b21-8040-54ad790db431',
+                  'type': 'API_KEY'},
+                 'totalProcessingTime': 0,
+                 ...
+                 }
+            ```
         """
         url = (
             f"{self.auth._endpoint()}/projects/{self.project_id}/workflows/"
@@ -77,6 +90,11 @@ class Workflow:
     def workflow_tasks(self) -> Dict[str, str]:
         """
         Gets the building blocks of the workflow as a dictionary with `task_name:block-version`.
+
+        ??? Example "Example Return (Click to extend)"
+            ```python
+                {'esa-s2-l2a-gtiff-visual:1': '1.2.3', 'sharpening:1': '2.1.1'}
+            ```
         """
         logging.getLogger("up42.workflow").setLevel(logging.CRITICAL)
         workflow_tasks = self.get_workflow_tasks(basic=True)
@@ -90,6 +108,14 @@ class Workflow:
         will provide the compatible blocks for the last workflow task in the workflow.
 
         Currently no data blocks can be attached to other data blocks.
+
+        ??? Example "Example Return (Click to extend)"
+            ```python
+                {'zonal-statistics': 'a5b8b938-6fd6-4bac-92cd-dffd7f3169aa',
+                 'up42-exportdata-raster': '7ddcad20-e4d4-4ffd-9b3d-24555449275b',
+                 ...
+                }
+            ```
         """
         tasks: dict = self.get_workflow_tasks(basic=True)  # type: ignore
         if not tasks:
@@ -123,6 +149,14 @@ class Workflow:
 
         Returns:
             The workflow task info.
+
+        ??? Example "Example Return (Click to extend)"
+            ```python
+                {'zonal-statistics': 'a5b8b938-6fd6-4bac-92cd-dffd7f3169aa',
+                 'up42-exportdata-raster': '7ddcad20-e4d4-4ffd-9b3d-24555449275b',
+                 ...
+                }
+            ```
         """
         url = (
             f"{self.auth._endpoint()}/projects/{self.project_id}/workflows/"
@@ -287,6 +321,20 @@ class Workflow:
 
         Returns:
             Workflow parameters info json.
+
+        ??? Example "Example Return (Click to extend)"
+            ```python
+                {'esa-s2-l2a-gtiff-visual:1': {'ids': {'type': 'array', 'default': None},
+                  'bbox': {'type': 'array', 'default': None},
+                  'time': {'type': 'dateRange',
+                   'default': '2018-12-01T00:00:00+00:00/2021-12-31T23:59:59+00:00'},
+                  'limit': {'type': 'integer', 'default': 1, 'minimum': 1},
+                  'max_cloud_cover': {'type': 'integer',
+                   'default': 100,
+                   'maximum': 100,
+                   'minimum': 0}},
+                 'sharpening:1': {'strength': {'type': 'string', 'default': 'medium'}}}
+            ```
         """
         workflow_parameters_info = {}
         workflow_tasks = self.get_workflow_tasks()
@@ -495,6 +543,22 @@ class Workflow:
 
         Returns:
             A dictionary of estimation for each task in the workflow.
+
+        ??? Example "Example Return (Click to extend)"
+            ```python
+                {'esa-s2-l2a-gtiff-visual:1': {'blockConsumption': {'resources': {'unit': 'DATA_POINT',
+                    'min': 0,
+                    'max': 0},
+                   'credit': {'min': 0, 'max': 0}},
+                  'machineConsumption': {'duration': {'min': 0, 'max': 0},
+                   'credit': {'min': 1, 'max': 1}}},
+                 'sharpening:1': {'blockConsumption': {'resources': {'unit': 'SQUARE_KM',
+                    'min': 0.027816,
+                    'max': 0.027816},
+                   'credit': {'min': 0, 'max': 0}},
+                  'machineConsumption': {'duration': {'min': 72, 'max': 331},
+                   'credit': {'min': 1, 'max': 1}}}}
+            ```
         """
         if input_parameters is None:
             raise ValueError(


### PR DESCRIPTION
Adds function return examples to docstrings that are rended as toggleable admonitions in mkdocstrings code reference.

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
