### PR TITLE
Use pagination in get_orders - up5726

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">89%</text>
-        <text x="80" y="14">89%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">88%</text>
+        <text x="80" y="14">88%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">88%</text>
-        <text x="80" y="14">88%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">89%</text>
+        <text x="80" y="14">89%</text>
     </g>
 </svg>

--- a/pylintrc
+++ b/pylintrc
@@ -20,7 +20,8 @@ disable=
     fixme,
     duplicate-code,
     logging-fstring-interpolation,
-    logging-format-interpolation
+    logging-format-interpolation,
+    too-many-lines
     
 [FORMAT]
 max-line-length=120

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -211,7 +211,29 @@ JSON_ORDER = {
     "error": None,
 }
 
-JSON_ORDERS = {"data": {"orders": [JSON_ORDER["data"]]}, "error": None}
+JSON_ORDERS = {
+    "data": {
+        "content": [JSON_ORDER["data"]],
+        "pageable": {
+            "sort": {"sorted": True, "unsorted": False, "empty": False},
+            "pageNumber": 0,
+            "pageSize": 10,
+            "offset": 0,
+            "paged": True,
+            "unpaged": False,
+        },
+        "totalPages": 1,
+        "totalElements": 1,
+        "last": True,
+        "sort": {"sorted": True, "unsorted": False, "empty": False},
+        "numberOfElements": 1,
+        "first": True,
+        "size": 10,
+        "number": 0,
+        "empty": False,
+    },
+    "error": None,
+}
 
 
 @pytest.fixture()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -19,9 +19,7 @@ def test_init(storage_mock):
 
 
 def test_paginate(storage_mock, requests_mock):
-    url = "http://some_url/assets"
-
-    def paginated_response(page):
+    def _paginated_response(page):
         return {
             "data": {
                 "content": [{"something": "is"}, {"something": "is_not"}],
@@ -31,10 +29,12 @@ def test_paginate(storage_mock, requests_mock):
             },
         }
 
-    requests_mock.get(
-        "/assets", [{"json": paginated_response(page)} for page in range(0, 3)]
-    )
-    res = storage_mock._paginate(url)
+    list_mock_responses = [{"json": _paginated_response(page)} for page in range(0, 3)]
+
+    size = 50
+    url = "http://some_url/assets"
+    requests_mock.get(url + f"&size={size}", list_mock_responses)
+    res = storage_mock._query_paginated(url=url, limit=None, size=size)
     assert len(res) == 6
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -18,24 +18,52 @@ def test_init(storage_mock):
     assert storage_mock.workspace_id == WORKSPACE_ID
 
 
-def test_paginate(storage_mock, requests_mock):
-    def _paginated_response(page):
+def _mock_list_response_pages(total_pages, total_elements):
+    def _one_page_reponse(page_nr, total_pages, total_elements):
         return {
             "data": {
-                "content": [{"something": "is"}, {"something": "is_not"}],
-                "totalPages": 3,
-                "totalElements": 6,
-                "number": page,
+                "content": [{"something1": 1}, {"something2": 2}, {"something3": 3}],
+                "totalPages": total_pages,
+                "totalElements": total_elements,
+                "number": page_nr,
             },
         }
 
-    list_mock_responses = [{"json": _paginated_response(page)} for page in range(0, 3)]
+    return [
+        {"json": _one_page_reponse(page_nr, total_pages, total_elements)}
+        for page_nr in range(0, total_pages)
+    ]
 
-    size = 50
+
+def test_paginate(storage_mock, requests_mock):
     url = "http://some_url/assets"
-    requests_mock.get(url + f"&size={size}", list_mock_responses)
-    res = storage_mock._query_paginated(url=url, limit=None, size=size)
-    assert len(res) == 6
+
+    limit = None
+    size = 3
+    total_pages = 4
+    total_elements = 12
+    expected = 12
+    mock_list_response_pages = _mock_list_response_pages(total_pages, total_elements)
+    requests_mock.get(url + f"&size={size}", mock_list_response_pages)
+    res = storage_mock._query_paginated(url=url, limit=limit, size=size)
+    assert len(res) == expected
+
+
+def test_paginate_with_limit(storage_mock, requests_mock):
+    """
+    Test pagination with smaller limit than pagination size, and smaller limit than available elements.
+    """
+    url = "http://some_url/assets"
+
+    limit = 5
+    size = 50
+    total_pages = 4
+    total_elements = 12
+    expected = 5
+    mock_list_response_pages = _mock_list_response_pages(total_pages, total_elements)
+    requests_mock.get(url + f"&size={limit}", mock_list_response_pages)
+    res = storage_mock._query_paginated(url=url, limit=limit, size=size)
+    assert len(res) == expected
 
 
 def test_get_assets(storage_mock):

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -33,7 +33,7 @@ class Storage:
         self, url: str, limit: Optional[int] = None, size: int = 50
     ) -> List[dict]:
         """
-        Helper to fetch list of items in paginated endpoint.
+        Helper to fetch list of items in paginated endpoint, e.g. assets, orders.
 
         Args:
             url (str): The base url for paginated endpoint.
@@ -79,7 +79,7 @@ class Storage:
             Asset objects in the workspace or alternatively json info of the assets.
         """
         url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/assets?format=paginated"
-        assets_json = self._query_paginated(url, limit=limit)
+        assets_json = self._query_paginated(url=url, limit=limit)
         logger.info(f"Got {len(assets_json)} assets for workspace {self.workspace_id}.")
 
         if return_json:
@@ -106,11 +106,11 @@ class Storage:
             Order objects in the workspace or alternatively json info of the orders.
         """
         url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/orders?format=paginated"
-        orders_json = self._query_paginated(url, limit=limit)
+        orders_json = self._query_paginated(url=url, limit=limit)
         logger.info(f"Got {len(orders_json)} orders for workspace {self.workspace_id}.")
 
         if return_json:
-            return orders_json
+            return orders_json  # type: ignore
         else:
             orders = [
                 Order(self.auth, order_id=order["id"]) for order in tqdm(orders_json)

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -90,19 +90,23 @@ class Storage:
             ]
             return assets
 
-    def get_orders(self, return_json: bool = False) -> Union[List[Order], dict]:
+    def get_orders(
+        self, return_json: bool = False, limit: Optional[int] = None
+    ) -> Union[List[Order], dict]:
         """
         Gets all orders in the workspace as Order objects or json.
 
         Args:
             return_json: If set to True, returns json object.
+            limit: Optional, only return n first orders (sorted by date of creation).
+                Optimal to select if your workspace contains many orders, which would
+                slow down the query.
 
         Returns:
             Order objects in the workspace or alternatively json info of the orders.
         """
-        url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/orders"
-        response_json = self.auth._request(request_type="GET", url=url)
-        orders_json = response_json["data"]["orders"]
+        url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/orders?format=paginated"
+        orders_json = self._query_paginated(url, limit=limit)
         logger.info(f"Got {len(orders_json)} orders for workspace {self.workspace_id}.")
 
         if return_json:


### PR DESCRIPTION
- Uses the recently introduced API pagination for get_orders. 
- Adds limit parameter to get_assets and get_orders.
- Refactors the pagination helper function to be more efficient when using a limit < the pagination size.

TODO: Update documentation guide chapter examples.


Items:
* [x] Ran test & live-tests
* [x] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
