### PR TITLE
Add sortorder and criteria get assets orders up5745

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,5 +1,3 @@
-from dateutil.parser import parse
-
 import pytest
 
 # pylint: disable=unused-import

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,3 +1,5 @@
+from dateutil.parser import parse
+
 import pytest
 
 # pylint: disable=unused-import
@@ -77,6 +79,10 @@ def test_get_assets(storage_mock):
 def test_get_assets_live(storage_live):
     assets = storage_live.get_assets()
     assert len(assets) >= 2
+    dates = [asset.info["createdAt"] for asset in assets]
+    # default descending, newest to oldest.
+    descending_dates = sorted(dates)[::-1]
+    assert descending_dates == dates
 
 
 def test_get_orders(storage_mock):
@@ -90,3 +96,7 @@ def test_get_orders(storage_mock):
 def test_get_orders_live(storage_live):
     orders = storage_live.get_orders()
     assert len(orders) >= 1
+    dates = [order.info["createdAt"] for order in orders]
+    # default descending, newest to oldest.
+    descending_dates = sorted(dates)[::-1]
+    assert descending_dates == dates

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -102,21 +102,32 @@ class Storage:
             return assets
 
     def get_orders(
-        self, return_json: bool = False, limit: Optional[int] = None
+        self,
+        return_json: bool = False,
+        limit: Optional[int] = None,
+        sortby: str = "createdAt",
+        descending: bool = True,
     ) -> Union[List[Order], dict]:
         """
         Gets all orders in the workspace as Order objects or json.
 
         Args:
             return_json: If set to True, returns json object.
-            limit: Optional, only return n first orders (sorted by date of creation).
-                Optimal to select if your workspace contains many orders, which would
-                slow down the query.
+            limit: Optional, only return n first assets by sorting criteria and order.
+                Optimal to select if your workspace contains many assets.
+            sortby: The sorting criteria, one of "createdAt", "updatedAt", "status", "dataProvider", "size".
+            descending: The sorting order, True for descending (default), False for ascending.
 
         Returns:
             Order objects in the workspace or alternatively json info of the orders.
         """
-        url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/orders?format=paginated"
+        allowed_sorting_criteria = ["createdAt", "updatedAt", "status", "dataProvider", "size"]
+        if sortby not in allowed_sorting_criteria:
+            raise ValueError(
+                f"sortby parameter must be one of {allowed_sorting_criteria}!"
+            )
+        sort = f"{sortby},{'desc' if descending else 'asc'}"
+        url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/orders?format=paginated&sort={sort}"
         orders_json = self._query_paginated(url=url, limit=limit)
         logger.info(f"Got {len(orders_json)} orders for workspace {self.workspace_id}.")
 

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -64,21 +64,32 @@ class Storage:
         return results_list
 
     def get_assets(
-        self, return_json: bool = False, limit: Optional[int] = None
+        self,
+        return_json: bool = False,
+        limit: Optional[int] = None,
+        sortby: str = "createdAt",
+        descending: bool = True,
     ) -> Union[List[Asset], dict]:
         """
         Gets all assets in the workspace as Asset objects or json.
 
         Args:
             return_json: If set to True, returns json object.
-            limit: Optional, only return n first assets (sorted by date of creation).
-                Optimal to select if your workspace contains many assets, which would
-                slow down the query.
+            limit: Optional, only return n first assets by sorting criteria and order.
+                Optimal to select if your workspace contains many assets.
+            sortby: The sorting criteria, one of "createdAt", "updatedAt", "source", "type", "name", "size".
+            descending: The sorting order, True for descending (default), False for ascending.
 
         Returns:
             Asset objects in the workspace or alternatively json info of the assets.
         """
-        url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/assets?format=paginated"
+        allowed_sorting_criteria = ["createdAt", "updatedAt", "source", "type", "name", "size"]
+        if sortby not in allowed_sorting_criteria:
+            raise ValueError(
+                f"sortby parameter must be one of {allowed_sorting_criteria}!"
+            )
+        sort = f"{sortby},{'desc' if descending else 'asc'}"
+        url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/assets?format=paginated&sort={sort}"
         assets_json = self._query_paginated(url=url, limit=limit)
         logger.info(f"Got {len(assets_json)} assets for workspace {self.workspace_id}.")
 

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -83,7 +83,14 @@ class Storage:
         Returns:
             Asset objects in the workspace or alternatively json info of the assets.
         """
-        allowed_sorting_criteria = ["createdAt", "updatedAt", "source", "type", "name", "size"]
+        allowed_sorting_criteria = [
+            "createdAt",
+            "updatedAt",
+            "source",
+            "type",
+            "name",
+            "size",
+        ]
         if sortby not in allowed_sorting_criteria:
             raise ValueError(
                 f"sortby parameter must be one of {allowed_sorting_criteria}!"
@@ -121,7 +128,13 @@ class Storage:
         Returns:
             Order objects in the workspace or alternatively json info of the orders.
         """
-        allowed_sorting_criteria = ["createdAt", "updatedAt", "status", "dataProvider", "size"]
+        allowed_sorting_criteria = [
+            "createdAt",
+            "updatedAt",
+            "status",
+            "dataProvider",
+            "size",
+        ]
         if sortby not in allowed_sorting_criteria:
             raise ValueError(
                 f"sortby parameter must be one of {allowed_sorting_criteria}!"


### PR DESCRIPTION
Followup to https://github.com/up42/up42-py/pull/265, adds sorting criteria and sorting order parameters to storage.get_assets and storage.get_orders.

This requires more mocktests, but a lot of effort since the sorting criteria would change the server response. Putting as Draft PR review for now.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
