### PR TITLE
Fix: Get specific jobtask info

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -750,6 +750,7 @@ def jobtask_mock(auth_mock, requests_mock):
         json={
             "data": [
                 {
+                    "id": JOBTASK_ID,
                     "xyz": 789,
                     "name": JOBTASK_NAME,
                     "status": "SUCCESSFULL",

--- a/up42/jobtask.py
+++ b/up42/jobtask.py
@@ -40,12 +40,11 @@ class JobTask(VizTools):
         self._info = self.info
 
     def __repr__(self):
-        info = self.info[0]
         return (
-            f"JobTask(name: {info['name']}, jobtask_id: {self.jobtask_id}, "
-            f"status: {info['status']}, startedAt: {info['startedAt']}, "
-            f"finishedAt: {info['finishedAt']}, job_name: {info['name']}, "
-            f"block_name: {info['block']['name']}, block_version: {info['blockVersion']}"
+            f"JobTask(name: {self._info['name']}, jobtask_id: {self.jobtask_id}, "
+            f"status: {self._info['status']}, startedAt: {self._info['startedAt']}, "
+            f"finishedAt: {self._info['finishedAt']}, job_name: {self._info['name']}, "
+            f"block_name: {self._info['block']['name']}, block_version: {self._info['blockVersion']}"
         )
 
     @property

--- a/up42/jobtask.py
+++ b/up42/jobtask.py
@@ -40,11 +40,12 @@ class JobTask(VizTools):
         self._info = self.info
 
     def __repr__(self):
+        info = self.info
         return (
-            f"JobTask(name: {self._info['name']}, jobtask_id: {self.jobtask_id}, "
-            f"status: {self._info['status']}, startedAt: {self._info['startedAt']}, "
-            f"finishedAt: {self._info['finishedAt']}, job_name: {self._info['name']}, "
-            f"block_name: {self._info['block']['name']}, block_version: {self._info['blockVersion']}"
+            f"JobTask(name: {info['name']}, jobtask_id: {self.jobtask_id}, "
+            f"status: {info['status']}, startedAt: {info['startedAt']}, "
+            f"finishedAt: {info['finishedAt']}, job_name: {info['name']}, "
+            f"block_name: {info['block']['name']}, block_version: {info['blockVersion']}"
         )
 
     @property

--- a/up42/jobtask.py
+++ b/up42/jobtask.py
@@ -51,15 +51,18 @@ class JobTask(VizTools):
     @property
     def info(self) -> dict:
         """
-        Gets the jobtask metadata information.
+        Gets or updates the jobtask metadata information.
         """
         url = (
             f"{self.auth._endpoint()}/projects/{self.project_id}/jobs/{self.job_id}"
             f"/tasks/"
         )
         response_json = self.auth._request(request_type="GET", url=url)
-        self._info = response_json["data"]
-        return response_json["data"]
+        info_all_jobtasks = response_json["data"]
+        self._info = next(
+            item for item in info_all_jobtasks if item["id"] == self.jobtask_id
+        )
+        return self._info
 
     def get_results_json(self, as_dataframe: bool = False) -> Union[dict, GeoDataFrame]:
         """


### PR DESCRIPTION
Fixes the jobtask info/representation calls by providing the information about the specific, correct jobtask.

Before, jobtask.info returned a list of information for each jobtask, as this is the default return of the UP42 API. This did not fit the jobtask object model which is for a single jobtask. Now instead the correct jobtask information for the specific jobtask is returned and used in the jobtask representation.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
