### PR TITLE
Fix failling publish docs

### DIFF
--- a/examples/guides/30-seconds-example.ipynb
+++ b/examples/guides/30-seconds-example.ipynb
@@ -41,7 +41,7 @@
     "# Construct workflow\n",
     "workflow = project.create_workflow(name=\"30-seconds-workflow\", use_existing=True)\n",
     "#print(up42.get_blocks(basic=True))\n",
-    "input_tasks = [\"Sentinel-2 L2A Visual Visual (GeoTIFF)\", \"Sharpening Filter\"]\n",
+    "input_tasks = [\"Sentinel-2 L2A Visual (GeoTIFF)\", \"Sharpening Filter\"]\n",
     "workflow.add_workflow_tasks(input_tasks)"
    ]
   },
@@ -129,7 +129,9 @@
  ],
  "metadata": {
   "kernelspec": {
+   "display_name": "up42-py",
    "language": "python",
+   "name": "up42-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -141,6 +143,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Attempt at fixing the 30 seconds example python notebook that was changed accidentally.

json in examples/guides/30-seconds-example.ipynb has now been validated.



Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
