### PR TITLE
Refactor retry mechanisms

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">88%</text>
-        <text x="80" y="14">88%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">89%</text>
+        <text x="80" y="14">89%</text>
     </g>
 </svg>

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -254,10 +254,7 @@ def auth_mock(requests_mock):
         json=json_get_workspace,
     )
     auth = Auth(
-        project_id=PROJECT_ID,
-        project_api_key=PROJECT_APIKEY,
-        authenticate=True,
-        retry=False,
+        project_id=PROJECT_ID, project_api_key=PROJECT_APIKEY, authenticate=True
     )
 
     # get_blocks

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -139,8 +139,7 @@ def test_request_non200_raises_error_not_dict(auth_mock, requests_mock):
     assert "Not found!" in str(e.value)
 
 
-def test_request_active_retry_no_retry_required(auth_mock, requests_mock):
-    # for the tests retry is False by default
+def test_request_active_retry_successfull_request(auth_mock, requests_mock):
     auth_mock.retry = True
     requests_mock.get(url="http://test.com", json={"data": {"xyz": 789}, "error": {}})
 
@@ -148,9 +147,7 @@ def test_request_active_retry_no_retry_required(auth_mock, requests_mock):
     assert response_json == {"data": {"xyz": 789}, "error": {}}
 
 
-def test_request_inactive_retry_token_timed_out_raises(auth_mock, requests_mock):
-    # for the tests retry is False by default
-    auth_mock.retry = False
+def test_request_token_timed_out_raises(auth_mock, requests_mock):
     a = requests_mock.get(
         "http://test.com",
         [
@@ -171,7 +168,6 @@ def test_request_inactive_retry_token_timed_out_raises(auth_mock, requests_mock)
 
 
 def test_request_active_retry_token_timed_out(auth_mock, requests_mock):
-    # for the tests retry is False by default
     auth_mock.retry = True
     a = requests_mock.get(
         "http://test.com",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,8 @@
+"""
+IMPORTANT: For all tests, by default retry for invalid token is disabled and is
+enabled on a per test-basis to avoid unintended side-effects.
+"""
+
 import io
 import json
 from pathlib import Path
@@ -189,8 +194,6 @@ def test_request_active_retry_token_timed_out(auth_mock, requests_mock):
 
 
 def test_request_rate_limited_retry(auth_mock, requests_mock):
-    # for the tests retry is False by default
-    auth_mock.retry = False
     a = requests_mock.get(
         "http://test.com",
         [

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -74,13 +74,6 @@ def test_get_token_live(auth_live):
     assert hasattr(auth_live, "token")
 
 
-@pytest.mark.live
-def test_get_token_live_timeout_5min(auth_live):
-    assert hasattr(auth_live, "token")
-    auth_live._get_workspace()
-    assert auth_live.workspace_id == WORKSPACE_ID
-
-
 def test_get_workspace(auth_mock):
     auth_mock._get_workspace()
     assert auth_mock.workspace_id == WORKSPACE_ID

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -139,17 +139,62 @@ def test_request_non200_raises_error_not_dict(auth_mock, requests_mock):
     assert "Not found!" in str(e.value)
 
 
-def test_request_with_retry(auth_mock, requests_mock):
+def test_request_active_retry_no_retry_required(auth_mock, requests_mock):
+    # for the tests retry is False by default
     auth_mock.retry = True
-    # Retry contains getting a new token, already mocked in fixture.
-
     requests_mock.get(url="http://test.com", json={"data": {"xyz": 789}, "error": {}})
 
     response_json = auth_mock._request(request_type="GET", url="http://test.com")
     assert response_json == {"data": {"xyz": 789}, "error": {}}
 
 
-def test_request_rate_limited(auth_mock, requests_mock):
+def test_request_inactive_retry_token_timed_out_raises(auth_mock, requests_mock):
+    # for the tests retry is False by default
+    auth_mock.retry = False
+    a = requests_mock.get(
+        "http://test.com",
+        [
+            {
+                "status_code": 401,
+                "json": {
+                    "data": {},
+                    "error": {"code": 401, "message": "token timeout"},
+                },
+            },
+            {"json": {"data": {"xyz": 789}, "error": {}}},
+        ],
+    )
+
+    with pytest.raises(requests.exceptions.RequestException):
+        auth_mock._request(request_type="GET", url="http://test.com")
+    assert a.call_count == 1
+
+
+def test_request_active_retry_token_timed_out(auth_mock, requests_mock):
+    # for the tests retry is False by default
+    auth_mock.retry = True
+    a = requests_mock.get(
+        "http://test.com",
+        [
+            {
+                "status_code": 401,
+                "json": {
+                    "data": {},
+                    "error": {"code": 401, "message": "token timeout"},
+                },
+            },
+            {"json": {"data": {"xyz": 789}, "error": {}}},
+        ],
+    )
+
+    response_json = auth_mock._request(request_type="GET", url="http://test.com")
+    assert response_json == {"data": {"xyz": 789}, "error": {}}
+    assert a.call_count == 2
+
+
+def test_request_rate_limited_retry(auth_mock, requests_mock):
+    # for the tests retry is False by default
+    auth_mock.retry = False
     a = requests_mock.get(
         "http://test.com",
         [
@@ -167,3 +212,69 @@ def test_request_rate_limited(auth_mock, requests_mock):
     response_json = auth_mock._request(request_type="GET", url="http://test.com")
     assert response_json == {"data": {"xyz": 789}, "error": {}}
     assert a.call_count == 2
+
+
+def test_request_token_timeout_during_rate_limitation_without_token_retry_raises(
+    auth_mock, requests_mock
+):
+    # for the tests retry is False by default
+    auth_mock.retry = False
+    a = requests_mock.get(
+        "http://test.com",
+        [
+            {
+                "status_code": 429,
+                "json": {
+                    "data": {},
+                    "error": {"code": 429, "message": "rate limited"},
+                },
+            },
+            {
+                "status_code": 401,
+                "json": {
+                    "data": {},
+                    "error": {"code": 401, "message": "token timeout"},
+                },
+            },
+            {"json": {"data": {"xyz": 789}, "error": {}}},
+        ],
+    )
+
+    with pytest.raises(requests.exceptions.RequestException):
+        auth_mock._request(request_type="GET", url="http://test.com")
+    assert a.call_count == 2
+
+
+def test_request_token_timeout_during_rate_limitation(auth_mock, requests_mock):
+    auth_mock.retry = True
+    a = requests_mock.get(
+        "http://test.com",
+        [
+            {
+                "status_code": 429,
+                "json": {
+                    "data": {},
+                    "error": {"code": 429, "message": "rate limited"},
+                },
+            },
+            {
+                "status_code": 401,
+                "json": {
+                    "data": {},
+                    "error": {"code": 401, "message": "token timeout"},
+                },
+            },
+            {
+                "status_code": 429,
+                "json": {
+                    "data": {},
+                    "error": {"code": 429, "message": "rate limited"},
+                },
+            },
+            {"json": {"data": {"xyz": 789}, "error": {}}},
+        ],
+    )
+
+    response_json = auth_mock._request(request_type="GET", url="http://test.com")
+    assert response_json == {"data": {"xyz": 789}, "error": {}}
+    assert a.call_count == 4

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -213,38 +213,9 @@ def test_request_rate_limited_retry(auth_mock, requests_mock):
     assert a.call_count == 2
 
 
-def test_request_token_timeout_during_rate_limitation_without_token_retry_raises(
+def test_request_active_retry_token_timeout_during_rate_limitation(
     auth_mock, requests_mock
 ):
-    # for the tests retry is False by default
-    auth_mock.retry = False
-    a = requests_mock.get(
-        "http://test.com",
-        [
-            {
-                "status_code": 429,
-                "json": {
-                    "data": {},
-                    "error": {"code": 429, "message": "rate limited"},
-                },
-            },
-            {
-                "status_code": 401,
-                "json": {
-                    "data": {},
-                    "error": {"code": 401, "message": "token timeout"},
-                },
-            },
-            {"json": {"data": {"xyz": 789}, "error": {}}},
-        ],
-    )
-
-    with pytest.raises(requests.exceptions.RequestException):
-        auth_mock._request(request_type="GET", url="http://test.com")
-    assert a.call_count == 2
-
-
-def test_request_token_timeout_during_rate_limitation(auth_mock, requests_mock):
     auth_mock.retry = True
     a = requests_mock.get(
         "http://test.com",

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -97,10 +97,6 @@ class Auth:
             self.authenticate: bool = kwargs["authenticate"]
         except KeyError:
             self.authenticate = True
-        try:
-            self.retry: bool = kwargs["retry"]
-        except KeyError:
-            self.retry = True
 
         if self.authenticate:
             self._find_credentials()

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -29,6 +29,12 @@ class retry_if_429_error(retry_if_exception):
     """
     Altered tenacity retry strategy that retries if the exception is an ``HTTPError``
     with a 429 status code (too many requests).
+class retry_if_429_rate_limit(retry_if_exception):
+    """
+    Custom tenacity error response that enables separate retry strategy for
+    429 HTTPError (too many requests) due to UP42 rate limitation.
+    Also see https://docs.up42.com/developers/api#section/API-Usage-Constraints/Rate-limiting
+
     Adapted from https://github.com/alexwlchan/handling-http-429-with-tenacity
     """
 
@@ -173,7 +179,7 @@ class Auth:
 
     # pylint: disable=dangerous-default-value
     @retry(
-        retry=retry_if_429_error(),
+        retry=retry_if_429_rate_limit(),
         wait=wait_random_exponential(multiplier=0.5, max=180),
         reraise=True,
     )

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -25,10 +25,24 @@ from up42.utils import get_logger
 logger = get_logger(__name__)
 
 
-class retry_if_429_error(retry_if_exception):
+class retry_if_401_invalid_token(retry_if_exception):
     """
-    Altered tenacity retry strategy that retries if the exception is an ``HTTPError``
-    with a 429 status code (too many requests).
+    Custom tenacity error response that enables separate retry strategy for
+    401 HTTPError (unauthorized response) due to invalid/timed out UP42 token.
+
+    Adapted from https://github.com/alexwlchan/handling-http-429-with-tenacity
+    """
+
+    def __init__(self):
+        def is_http_401_error(exception):
+            return (
+                isinstance(exception, requests.exceptions.HTTPError)
+                and exception.response.status_code == 401
+            )
+
+        super().__init__(predicate=is_http_401_error)
+
+
 class retry_if_429_rate_limit(retry_if_exception):
     """
     Custom tenacity error response that enables separate retry strategy for
@@ -251,7 +265,7 @@ class Auth:
                     stop=stop_after_attempt(2),
                     wait=wait_fixed(0.5),
                     retry=(
-                        retry_if_exception_type(requests.exceptions.HTTPError)
+                        retry_if_401_invalid_token()
                         | retry_if_exception_type(requests.exceptions.ConnectionError)
                     ),
                     after=self._get_token(),

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -268,8 +268,8 @@ class Auth:
                         retry_if_401_invalid_token()
                         | retry_if_exception_type(requests.exceptions.ConnectionError)
                     ),
-                    after=self._get_token(),
-                    reraise=True,
+                    after=self._get_token(),  # executed after each failed call.
+                    reraise=True,  # after final failed attempt, raises last attempt's exception instead of RetryError.
                 )
                 response = retryer(
                     self._request_helper, request_type, url, data, querystring

--- a/up42/project.py
+++ b/up42/project.py
@@ -16,7 +16,7 @@ class Project:
     new workflows, query already existing workflows & jobs in the project and manage
     the project settings.
 
-    Create a new project on the [**UP42 Console website**](authentication.md#authenticate).
+    Create a new project on the [**UP42 Console website**](https://sdk.up42.com/authentication/#get-your-project-credentials).
 
     Use an existing project:
     ```python

--- a/up42/project.py
+++ b/up42/project.py
@@ -16,7 +16,8 @@ class Project:
     new workflows, query already existing workflows & jobs in the project and manage
     the project settings.
 
-    Create a new project on the [**UP42 Console website**](https://sdk.up42.com/authentication/#get-your-project-credentials).
+    Create a new project on the
+    [**UP42 Console website**](https://sdk.up42.com/authentication/#get-your-project-credentials).
 
     Use an existing project:
     ```python


### PR DESCRIPTION
- Resolves issue of unintended token renewals by using wrong tenacity retry `after` syntax
- Further limits retry mechanism to connection error, token timeout, rate limit
- Refactors retry code
- Increases test coverage on retry requests
- Removes option to disable retry for unittests (this was implemented to avoid unintended side effects in tests but does more harm than good).

Items:
* [x] Ran test & live-tests
* [x] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
