### PR TITLE
Add collection support up5754

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -34,7 +34,7 @@ aoi = up42.get_example_aoi(location="Berlin", as_dataframe=True)
 search_parameters = catalog.construct_parameters(geometry=aoi, 
                                                  start_date="2018-01-01",
                                                  end_date="2020-12-31",
-                                                 collection="PHR",
+                                                 collection=["PHR"],
                                                  max_cloudcover=20,
                                                  sortby="cloudCoverage", 
                                                  limit=10)

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -3,10 +3,6 @@
 **Check data availability & download image preview quicklooks** via the catalog search. 
 You can filter by various parameters e.g. time period, area of interest, cloud cover etc.
 
-!!! Info "Supported Sensors"
-    Currently the UP42 catalog search supports these sensors: **Pleiades, Spot, Sentinel1, 
-    Sentinel2, Sentinel3, Sentinel5p**.
-
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/up42/up42-py/master?filepath=examples%2Fguides%2Fcatalog.ipynb)
 
@@ -18,6 +14,12 @@ up42.authenticate(project_id="123", project_api_key="456")
 #up42.authenticate(cfg_file="config.json")
 
 catalog = up42.initialize_catalog()
+```
+
+## See the available data collections
+
+```python
+catalog.get_collections()
 ```
 
 ## Search scenes in aoi
@@ -32,7 +34,7 @@ aoi = up42.get_example_aoi(location="Berlin", as_dataframe=True)
 search_parameters = catalog.construct_parameters(geometry=aoi, 
                                                  start_date="2018-01-01",
                                                  end_date="2020-12-31",
-                                                 sensors=["pleiades"],
+                                                 collection="PHR",
                                                  max_cloudcover=20,
                                                  sortby="cloudCoverage", 
                                                  limit=10)

--- a/docs/ordering.md
+++ b/docs/ordering.md
@@ -27,7 +27,7 @@ aoi = up42.get_example_aoi(location="Berlin", as_dataframe=True)
 search_parameters = catalog.construct_parameters(geometry=aoi, 
                                                  start_date="2018-01-01",
                                                  end_date="2020-12-31",
-                                                 collection="PHR",
+                                                 collection=["PHR"],
                                                  max_cloudcover=5,
                                                  sortby="cloudCoverage", 
                                                  limit=1)

--- a/docs/ordering.md
+++ b/docs/ordering.md
@@ -21,16 +21,17 @@ import up42
 up42.authenticate(project_id="123", project_api_key="456")
 
 catalog = up42.initialize_catalog()
+print(catalog.get_collections())
+
 aoi = up42.get_example_aoi(location="Berlin", as_dataframe=True)
 search_parameters = catalog.construct_parameters(geometry=aoi, 
                                                  start_date="2018-01-01",
                                                  end_date="2020-12-31",
-                                                 sensors=["pleiades"],
+                                                 collection="PHR",
                                                  max_cloudcover=5,
                                                  sortby="cloudCoverage", 
                                                  limit=1)
 search_results = catalog.search(search_parameters=search_parameters)
-
 ```
 
 ## Estimate the order price

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -920,6 +920,13 @@ def tools_live(auth_live):
 
 @pytest.fixture()
 def catalog_mock(auth_mock, requests_mock):
+    url_collections = f"{auth_mock._endpoint()}/collections"
+    collections_response = {"data": [{"name": "PHR"}]}
+    requests_mock.get(
+        url=url_collections,
+        json=collections_response,
+    )
+
     with open(
         Path(__file__).resolve().parent / "mock_data/search_response.json"
     ) as json_file:
@@ -940,6 +947,13 @@ def catalog_live(auth_live):
 
 @pytest.fixture()
 def catalog_pagination_mock(auth_mock, requests_mock):
+    url_collections = f"{auth_mock._endpoint()}/collections"
+    collections_response = {"data": [{"name": "PHR"}]}
+    requests_mock.get(
+        url=url_collections,
+        json=collections_response,
+    )
+
     with open(
         Path(__file__).resolve().parent / "mock_data/search_response.json"
     ) as json_file:
@@ -963,6 +977,13 @@ def catalog_pagination_mock(auth_mock, requests_mock):
 
 @pytest.fixture()
 def catalog_usagetype_mock(auth_mock, requests_mock):
+    url_collections = f"{auth_mock._endpoint()}/collections"
+    collections_response = {"data": [{"name": "PHR"}]}
+    requests_mock.get(
+        url=url_collections,
+        json=collections_response,
+    )
+
     with open(
         Path(__file__).resolve().parent / "mock_data/search_response.json"
     ) as json_file:

--- a/tests/mock_data/search_params_simple.json
+++ b/tests/mock_data/search_params_simple.json
@@ -12,14 +12,10 @@
             ]
         ]
     },
+    "collection": ["PHR"],
     "limit": 4,
     "query": {
         "cloudCoverage": {"lte": 20},
-        "dataBlock": {
-            "in": ["oneatlas-pleiades-fullscene", "oneatlas-pleiades-display", "oneatlas-pleiades-aoiclipped",
-                   "oneatlas-spot-fullscene", "oneatlas-spot-display", "oneatlas-spot-aoiclipped",
-                   "sobloo-s1-grd-fullscene", "sobloo-s1-grd-aoiclipped", "sobloo-s1-slc-fullscene"]
-        },
         "up42:usageType":  {"in": ["DATA", "ANALYTICS"]}
     },
     "sortby": [{"field": "properties.cloudCoverage", "direction": "desc"}]

--- a/tests/mock_data/search_params_simple.json
+++ b/tests/mock_data/search_params_simple.json
@@ -12,7 +12,7 @@
             ]
         ]
     },
-    "collection": ["PHR"],
+    "collections": ["PHR"],
     "limit": 4,
     "query": {
         "cloudCoverage": {"lte": 20},

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -38,12 +38,14 @@ def test_get_collections_live(catalog_live):
     collections = catalog_live.get_collections()
     assert isinstance(collections, list)
     assert collections[0]["name"]
+
+
 def test_construct_parameters(catalog_mock):
     search_parameters = catalog_mock.construct_parameters(
         geometry=mock_search_parameters["intersects"],
         start_date="2014-01-01",
         end_date="2016-12-31",
-        sensors=["pleiades", "spot", "sentinel1"],
+        collection="PHR",
         max_cloudcover=20,
         sortby="cloudCoverage",
         limit=4,
@@ -70,7 +72,7 @@ def test_construct_parameters_fc_multiple_features_raises(catalog_mock):
             geometry=fc,
             start_date="2020-01-01",
             end_date="2020-08-10",
-            sensors=["sentinel2"],
+            collection="PHR",
             limit=10,
             max_cloudcover=15,
             sortby="acquisitionDate",
@@ -86,7 +88,7 @@ def test_construct_parameters_unsopported_sensor_raises(catalog_mock):
     with pytest.raises(ValueError):
         catalog_mock.construct_parameters(
             geometry=mock_search_parameters["intersects"],
-            sensors=["some_unspoorted_sensor"],
+            collection="some_unsupported_collection",
         )
 
 
@@ -149,6 +151,7 @@ def test_search_usagetype(catalog_usagetype_mock):
         search_parameters = catalog_usagetype_mock.construct_parameters(
             start_date="2014-01-01T00:00:00",
             end_date="2020-12-31T23:59:59",
+            collection="PHR",
             limit=1,
             usage_type=params["usage_type"],
             geometry={
@@ -250,10 +253,11 @@ def test_search_catalog_pagination(catalog_mock):
     assert search_results.shape == (614, 14)
 
 
-@pytest.mark.live
+# @pytest.mark.live
 def test_search_catalog_pagination_live(catalog_live):
     search_params_limit_614 = {
         "datetime": "2014-01-01T00:00:00Z/2020-01-20T23:59:59Z",
+        "collection": ["PHR", "SPOT"],
         "intersects": {
             "type": "Polygon",
             "coordinates": [
@@ -267,18 +271,6 @@ def test_search_catalog_pagination_live(catalog_live):
             ],
         },
         "limit": 614,
-        "query": {
-            "dataBlock": {
-                "in": [
-                    "oneatlas-pleiades-fullscene",
-                    "oneatlas-pleiades-display",
-                    "oneatlas-pleiades-aoiclipped",
-                    "oneatlas-spot-fullscene",
-                    "oneatlas-spot-display",
-                    "oneatlas-spot-aoiclipped",
-                ]
-            }
-        },
     }
     search_results = catalog_live.search(search_params_limit_614)
     assert isinstance(search_results, gpd.GeoDataFrame)
@@ -305,18 +297,7 @@ def test_search_catalog_pagination_exhausted(catalog_pagination_mock):
             ],
         },
         "limit": 614,
-        "query": {
-            "dataBlock": {
-                "in": [
-                    "oneatlas-pleiades-fullscene",
-                    "oneatlas-pleiades-display",
-                    "oneatlas-pleiades-aoiclipped",
-                    "oneatlas-spot-fullscene",
-                    "oneatlas-spot-display",
-                    "oneatlas-spot-aoiclipped",
-                ]
-            }
-        },
+        "collection": ["PHR", "SPOT"],
     }
     search_results = catalog_pagination_mock.search(search_params_limit_614)
     assert isinstance(search_results, gpd.GeoDataFrame)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -27,6 +27,17 @@ with open(
     mock_search_parameters = json.load(json_file)
 
 
+def test_get_collections(catalog_mock):
+    collections = catalog_mock.get_collections()
+    assert isinstance(collections, list)
+    assert collections[0]["name"]
+
+
+@pytest.mark.live
+def test_get_collections_live(catalog_live):
+    collections = catalog_live.get_collections()
+    assert isinstance(collections, list)
+    assert collections[0]["name"]
 def test_construct_parameters(catalog_mock):
     search_parameters = catalog_mock.construct_parameters(
         geometry=mock_search_parameters["intersects"],

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -253,7 +253,7 @@ def test_search_catalog_pagination(catalog_mock):
     assert search_results.shape == (614, 14)
 
 
-# @pytest.mark.live
+@pytest.mark.live
 def test_search_catalog_pagination_live(catalog_live):
     search_params_limit_614 = {
         "datetime": "2014-01-01T00:00:00Z/2020-01-20T23:59:59Z",

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -45,7 +45,7 @@ def test_construct_parameters(catalog_mock):
         geometry=mock_search_parameters["intersects"],
         start_date="2014-01-01",
         end_date="2016-12-31",
-        collection="PHR",
+        collections=["PHR"],
         max_cloudcover=20,
         sortby="cloudCoverage",
         limit=4,
@@ -72,7 +72,7 @@ def test_construct_parameters_fc_multiple_features_raises(catalog_mock):
             geometry=fc,
             start_date="2020-01-01",
             end_date="2020-08-10",
-            collection="PHR",
+            collections=["PHR"],
             limit=10,
             max_cloudcover=15,
             sortby="acquisitionDate",
@@ -82,14 +82,6 @@ def test_construct_parameters_fc_multiple_features_raises(catalog_mock):
         str(e.value)
         == "The provided geometry contains multiple geometries, UP42 only accepts single geometries."
     )
-
-
-def test_construct_parameters_unsopported_sensor_raises(catalog_mock):
-    with pytest.raises(ValueError):
-        catalog_mock.construct_parameters(
-            geometry=mock_search_parameters["intersects"],
-            collection="some_unsupported_collection",
-        )
 
 
 def test_search(catalog_mock):
@@ -151,7 +143,7 @@ def test_search_usagetype(catalog_usagetype_mock):
         search_parameters = catalog_usagetype_mock.construct_parameters(
             start_date="2014-01-01T00:00:00",
             end_date="2020-12-31T23:59:59",
-            collection="PHR",
+            collections=["PHR"],
             limit=1,
             usage_type=params["usage_type"],
             geometry={
@@ -257,7 +249,7 @@ def test_search_catalog_pagination(catalog_mock):
 def test_search_catalog_pagination_live(catalog_live):
     search_params_limit_614 = {
         "datetime": "2014-01-01T00:00:00Z/2020-01-20T23:59:59Z",
-        "collection": ["PHR", "SPOT"],
+        "collections": ["PHR", "SPOT"],
         "intersects": {
             "type": "Polygon",
             "coordinates": [
@@ -297,7 +289,7 @@ def test_search_catalog_pagination_exhausted(catalog_pagination_mock):
             ],
         },
         "limit": 614,
-        "collection": ["PHR", "SPOT"],
+        "collections": ["PHR", "SPOT"],
     }
     search_results = catalog_pagination_mock.search(search_params_limit_614)
     assert isinstance(search_results, gpd.GeoDataFrame)

--- a/tests/test_e2e_catalog.py
+++ b/tests/test_e2e_catalog.py
@@ -21,7 +21,7 @@ def test_e2e_catalog():
         geometry=aoi,
         start_date="2018-01-01",
         end_date="2020-12-31",
-        sensors=["pleiades"],
+        collection="PHR",
         max_cloudcover=20,
         sortby="cloudCoverage",
         limit=10,

--- a/tests/test_e2e_catalog.py
+++ b/tests/test_e2e_catalog.py
@@ -21,7 +21,7 @@ def test_e2e_catalog():
         geometry=aoi,
         start_date="2018-01-01",
         end_date="2020-12-31",
-        collection="PHR",
+        collections=["PHR"],
         max_cloudcover=20,
         sortby="cloudCoverage",
         limit=10,

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -53,8 +53,8 @@ class Catalog(VizTools):
         return json_response["data"]
 
     # pylint: disable=dangerous-default-value
+    @staticmethod
     def construct_parameters(
-        self,
         geometry: Union[
             dict,
             Feature,

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -3,7 +3,7 @@ Catalog search functionality
 """
 
 from pathlib import Path
-from typing import Union, List, Tuple
+from typing import Union, List, Tuple, Dict, Any
 
 from pandas import Series
 from geopandas import GeoDataFrame
@@ -23,47 +23,6 @@ from up42.utils import (
 
 logger = get_logger(__name__)
 
-
-supported_sensors = {
-    "pleiades": {
-        "blocks": [
-            "oneatlas-pleiades-fullscene",
-            "oneatlas-pleiades-display",
-            "oneatlas-pleiades-aoiclipped",
-        ],
-        "provider": "oneatlas",
-    },
-    "spot": {
-        "blocks": [
-            "oneatlas-spot-fullscene",
-            "oneatlas-spot-display",
-            "oneatlas-spot-aoiclipped",
-        ],
-        "provider": "oneatlas",
-    },
-    "sentinel1": {
-        "blocks": [
-            "sobloo-s1-grd-fullscene",
-            "sobloo-s1-grd-aoiclipped",
-            "sobloo-s1-slc-fullscene",
-        ],
-        "provider": "sobloo-image",
-    },
-    "sentinel2": {
-        "blocks": [
-            "sobloo-s2-l1c-fullscene",
-            "sobloo-s2-l1c-aoiclipped",
-        ],
-        "provider": "sobloo-image",
-    },
-    "sentinel3": {"blocks": ["sobloo-s3"], "provider": "sobloo-image"},
-    "sentinel5p": {
-        "blocks": [
-            "sobloo-s5p",
-        ],
-        "provider": "sobloo-image",
-    },
-}
 
 # pylint: disable=duplicate-code
 class Catalog(VizTools):
@@ -85,9 +44,17 @@ class Catalog(VizTools):
     def __repr__(self):
         return f"Catalog(auth={self.auth})"
 
+    def get_collections(self) -> Union[Dict, List]:
+        """
+        Get the available data collections.
+        """
+        url = f"{self.auth._endpoint()}/collections"
+        json_response = self.auth._request("GET", url)
+        return json_response["data"]
+
     # pylint: disable=dangerous-default-value
-    @staticmethod
     def construct_parameters(
+        self,
         geometry: Union[
             dict,
             Feature,

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -115,7 +115,7 @@ class Catalog(VizTools):
         sort_order = "asc" if ascending else "desc"
 
         query_filters: Dict[Any, Any] = {}
-        if collection != ["sentinel1"]:
+        if collection != ["Sentinel-1"]:
             query_filters["cloudCoverage"] = {"lte": max_cloudcover}  # type: ignore
 
         if usage_type == ["DATA"]:

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -221,12 +221,21 @@ class Catalog(VizTools):
         Returns:
             List of quicklook image output file paths.
         """
+        supported_sensors = {
+            "pleiades": "oneatlas",
+            "spot": "oneatlas",
+            "sentinel1": "sobloo-image",
+            "sentinel2": "sobloo-image",
+            "sentinel3": "sobloo-image",
+            "sentinel5p": "sobloo-image",
+        }
+
         if sensor not in list(supported_sensors.keys()):
             raise ValueError(
                 f"Currently only these sensors are supported: "
                 f"{list(supported_sensors.keys())}"
             )
-        provider = supported_sensors[sensor]["provider"]
+        provider = supported_sensors[sensor]
         logger.info(
             f"Getting quicklooks from provider {provider} for image_ids: "
             f"{image_ids}"

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -64,16 +64,9 @@ class Catalog(VizTools):
             Point,
             Polygon,
         ],
+        collection: str,
         start_date: str = "2020-01-01",
         end_date: str = "2020-01-30",
-        sensors: List[str] = [
-            "pleiades",
-            "spot",
-            "sentinel1",
-            "sentinel2",
-            "sentinel3",
-            "sentinel5p",
-        ],
         usage_type: List[str] = ["DATA", "ANALYTICS"],
         limit: int = 10,
         max_cloudcover: float = 100,
@@ -88,8 +81,8 @@ class Catalog(VizTools):
                 list, GeoDataFrame, Point, Polygon.
             start_date: Query period starting day, format "2020-01-01".
             end_date: Query period ending day, format "2020-01-01".
-            sensors: The satellite sensors to search for, one or multiple of
-                ["pleiades", "spot", "sentinel1", "sentinel2", "sentinel3", "sentinel5p"]
+            collection: The satellite sensor collection to search for, e.g. "PHR",
+                see catalog.get_collections().
             usage_type: Filter for imagery that can just be purchased & downloaded or also
                 processes. ["DATA"] (can only be download), ["ANALYTICS"] (can be downloaded
                 or used directly with a processing algorithm), ["DATA", "ANALYTICS"]
@@ -98,7 +91,7 @@ class Catalog(VizTools):
             limit: The maximum number of search results to return (1-max.500).
             max_cloudcover: Maximum cloudcover % - e.g. 100 will return all scenes,
                 8.4 will return all scenes with 8.4 or less cloudcover.
-                Ignored for sensors that have no cloudcover (e.g. sentinel1).
+                Ignored for collections that have no cloudcover (e.g. sentinel1).
             sortby: The property to sort by, "cloudCoverage", "acquisitionDate",
                 "acquisitionIdentifier", "incidenceAngle", "snowCover".
             ascending: Ascending sort order by default, descending if False.
@@ -106,43 +99,42 @@ class Catalog(VizTools):
         Returns:
             The constructed parameters dictionary.
         """
+        available_collections = [
+            collection["name"] for collection in self.get_collections()
+        ]
+        if collection not in available_collections:
+            raise ValueError(
+                f"Currently only these collections/sensors are supported: "
+                f"{available_collections}. Also see catalog.get_collections."
+            )
         time_period = format_time_period(start_date=start_date, end_date=end_date)
-
-        block_filters: List[str] = []
-        for sensor in sensors:
-            if sensor not in list(supported_sensors.keys()):
-                raise ValueError(
-                    f"Currently only these sensors are supported: "
-                    f"{list(supported_sensors.keys())}"
-                )
-            block_filters.extend(supported_sensors[sensor]["blocks"])
-
         aoi_fc = any_vector_to_fc(
             vector=geometry,
         )
         aoi_geometry = fc_to_query_geometry(fc=aoi_fc, geometry_operation="intersects")
-
         sort_order = "asc" if ascending else "desc"
-        query_filters = {"dataBlock": {"in": block_filters}}
-        if sensors != ["sentinel1"]:
+
+        query_filters: Dict[Any, Any] = {}
+        if collection != ["sentinel1"]:
             query_filters["cloudCoverage"] = {"lte": max_cloudcover}  # type: ignore
+
+        if usage_type == ["DATA"]:
+            query_filters["up42:usageType"] = {"in": ["DATA"]}
+        elif usage_type == ["ANALYTICS"]:
+            query_filters["up42:usageType"] = {"in": ["ANALYTICS"]}
+        elif usage_type == ["DATA", "ANALYTICS"]:
+            query_filters["up42:usageType"] = {"in": ["DATA", "ANALYTICS"]}
+        else:
+            raise ValueError("Select correct `usage_type`")
 
         search_parameters = {
             "datetime": time_period,
             "intersects": aoi_geometry,
             "limit": limit,
+            "collections": [collection],
             "query": query_filters,
             "sortby": [{"field": f"properties.{sortby}", "direction": sort_order}],
         }
-
-        if usage_type == ["DATA"]:
-            search_parameters["query"]["up42:usageType"] = {"in": ["DATA"]}
-        elif usage_type == ["ANALYTICS"]:
-            search_parameters["query"]["up42:usageType"] = {"in": ["ANALYTICS"]}
-        elif usage_type == ["DATA", "ANALYTICS"]:
-            search_parameters["query"]["up42:usageType"] = {"in": ["DATA", "ANALYTICS"]}
-        else:
-            raise ValueError("Select correct `usage_type`")
 
         return search_parameters
 

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -64,7 +64,7 @@ class Catalog(VizTools):
             Point,
             Polygon,
         ],
-        collection: str,
+        collections: List[str],
         start_date: str = "2020-01-01",
         end_date: str = "2020-01-30",
         usage_type: List[str] = ["DATA", "ANALYTICS"],
@@ -81,8 +81,8 @@ class Catalog(VizTools):
                 list, GeoDataFrame, Point, Polygon.
             start_date: Query period starting day, format "2020-01-01".
             end_date: Query period ending day, format "2020-01-01".
-            collection: The satellite sensor collection to search for, e.g. "PHR",
-                see catalog.get_collections().
+            collection: The satellite sensor collections to search for, e.g. ["PHR"] or ["PHR", "SPOT"].
+                Also see catalog.get_collections().
             usage_type: Filter for imagery that can just be purchased & downloaded or also
                 processes. ["DATA"] (can only be download), ["ANALYTICS"] (can be downloaded
                 or used directly with a processing algorithm), ["DATA", "ANALYTICS"]
@@ -99,14 +99,6 @@ class Catalog(VizTools):
         Returns:
             The constructed parameters dictionary.
         """
-        available_collections = [
-            collection["name"] for collection in self.get_collections()
-        ]
-        if collection not in available_collections:
-            raise ValueError(
-                f"Currently only these collections/sensors are supported: "
-                f"{available_collections}. Also see catalog.get_collections."
-            )
         time_period = format_time_period(start_date=start_date, end_date=end_date)
         aoi_fc = any_vector_to_fc(
             vector=geometry,
@@ -115,7 +107,7 @@ class Catalog(VizTools):
         sort_order = "asc" if ascending else "desc"
 
         query_filters: Dict[Any, Any] = {}
-        if collection != ["Sentinel-1"]:
+        if not "Sentinel-1" in collections:
             query_filters["cloudCoverage"] = {"lte": max_cloudcover}  # type: ignore
 
         if usage_type == ["DATA"]:
@@ -131,7 +123,7 @@ class Catalog(VizTools):
             "datetime": time_period,
             "intersects": aoi_geometry,
             "limit": limit,
-            "collections": [collection],
+            "collections": collections,
             "query": query_filters,
             "sortby": [{"field": f"properties.{sortby}", "direction": sort_order}],
         }


### PR DESCRIPTION
- Adds support for UP42 data collections
- Breaking change: Adjust catalog.construct_parameters to use collections instead of sensors (already removed from API).

Items:
* [x] Ran test & live-tests
* [x] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [x] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
