### PR TITLE
add base requestsexception with 401 to token renewal check

### DIFF
--- a/up42/auth.py
+++ b/up42/auth.py
@@ -28,8 +28,7 @@ logger = get_logger(__name__)
 class retry_if_401_invalid_token(retry_if_exception):
     """
     Custom tenacity error response that enables separate retry strategy for
-    401 httperror error (unauthorized response) or 401 requestsexception (unable decode JWT)
-    due to invalid/timed out UP42 token.
+    401 error (unauthorized response, unable decode JWT) due to invalid/timed out UP42 token.
 
     Adapted from https://github.com/alexwlchan/handling-http-429-with-tenacity
     """
@@ -269,7 +268,7 @@ class Auth:
                 retry_if_401_invalid_token()
                 | retry_if_exception_type(requests.exceptions.ConnectionError)
             ),
-            after=lambda retry_state: self._get_token,  # type:ignore
+            after=lambda retry_state: self._get_token(),  # type:ignore
             reraise=True,
             # after final failed attempt, raises last attempt's exception instead of RetryError.
         )

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -28,7 +28,8 @@ logger = get_logger(__name__)
 class retry_if_401_invalid_token(retry_if_exception):
     """
     Custom tenacity error response that enables separate retry strategy for
-    401 HTTPError (unauthorized response) due to invalid/timed out UP42 token.
+    401 httperror error (unauthorized response) or 401 requestsexception (unable decode JWT)
+    due to invalid/timed out UP42 token.
 
     Adapted from https://github.com/alexwlchan/handling-http-429-with-tenacity
     """
@@ -36,7 +37,13 @@ class retry_if_401_invalid_token(retry_if_exception):
     def __init__(self):
         def is_http_401_error(exception):
             return (
-                isinstance(exception, requests.exceptions.HTTPError)
+                isinstance(
+                    exception,
+                    (
+                        requests.exceptions.HTTPError,
+                        requests.exceptions.RequestException,
+                    ),
+                )
                 and exception.response.status_code == 401
             )
 


### PR DESCRIPTION
Neccessary as token timeout can also raise base Requestsexception with 401.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
