### PR TITLE
fix livetest assertion

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -468,7 +468,7 @@ def test_estimate_order_from_catalog_live(catalog_live):
         mock_search_parameters["intersects"], search_results.loc[0]
     )
     assert isinstance(estimation, int)
-    assert estimation == 12
+    assert estimation == 32
 
 
 @pytest.mark.skip(reason="Placing orders costs credits.")


### PR DESCRIPTION
catalog order price estimation assertion changed due to filter changes

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
