### PR TITLE
Add get job credits methods and tests

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -234,6 +234,16 @@ JSON_ORDERS = {
     },
     "error": None,
 }
+MOCK_CREDITS = {
+    "data": {
+        "projectId": "20adecb9-97f6-42c0-8ba8-f1e2fa0bff39",
+        "projectDisplayId": "20adecb9",
+        "jobId": "feace0bb-ea26-4161-9026-852f26e46bc5",
+        "jobDisplayId": "feace0bb",
+        "creditsUsed": 100,
+    },
+    "error": None,
+}
 
 
 @pytest.fixture()
@@ -608,16 +618,7 @@ def job_mock(auth_mock, requests_mock):
     )
     requests_mock.get(
         url_download_result,
-        json={
-            "data": {
-                "projectId": "20adecb9-97f6-42c0-8ba8-f1e2fa0bff39",
-                "projectDisplayId": "20adecb9",
-                "jobId": "feace0bb-ea26-4161-9026-852f26e46bc5",
-                "jobDisplayId": "feace0bb",
-                "creditsUsed": 100,
-            },
-            "error": None,
-        },
+        json=MOCK_CREDITS,
     )
 
     return job

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -601,6 +601,25 @@ def job_mock(auth_mock, requests_mock):
         url_download_result, json={"data": {"url": DOWNLOAD_URL}, "error": {}}
     )
 
+    # get_job_credits
+    url_download_result = (
+        f"{job.auth._endpoint()}/projects/"
+        f"{job.project_id}/jobs/{job.job_id}/credits"
+    )
+    requests_mock.get(
+        url_download_result,
+        json={
+            "data": {
+                "projectId": "20adecb9-97f6-42c0-8ba8-f1e2fa0bff39",
+                "projectDisplayId": "20adecb9",
+                "jobId": "feace0bb-ea26-4161-9026-852f26e46bc5",
+                "jobDisplayId": "feace0bb",
+                "creditsUsed": 100,
+            },
+            "error": None,
+        },
+    )
+
     return job
 
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -186,6 +186,13 @@ def test_job_download_result_nounpacking(job_mock, requests_mock):
         assert len(out_files) == 1
 
 
+def test_get_job_credits_mock(job_mock):
+    out_files = job_mock.get_job_credits()
+
+    assert isinstance(out_files, dict)
+    assert out_files == {"creditsUsed": 100}
+
+
 @pytest.mark.skip(reason="Sometimes takes quite long to cancel the job on the server.")
 @pytest.mark.live
 def test_cancel_job_live(workflow_live):
@@ -265,3 +272,11 @@ def test_job_download_result_live_2gb_big_exceeding_2min_gcs_treshold(auth_live)
         for file in out_files:
             assert Path(file).exists()
         assert len(out_files) == 490
+
+
+@pytest.mark.live
+def test_get_job_credits(job_live):
+    out_files = job_live.get_job_credits()
+
+    assert isinstance(out_files, dict)
+    assert out_files == {"creditsUsed": 2}

--- a/up42/job.py
+++ b/up42/job.py
@@ -349,7 +349,7 @@ class Job(VizTools):
 
     def get_job_credits(self) -> dict:
         """
-        Convenience function to get the credit consumption of the job.
+        Convenience function that gets number of credits consumed in job.
 
         Returns:
             The consumed credits for the job.

--- a/up42/job.py
+++ b/up42/job.py
@@ -332,7 +332,7 @@ class Job(VizTools):
         in a dictionary of strings.
 
         Returns:
-            The data.json of alle single job tasks.
+            The data.json of all single job tasks.
         """
         jobtasks: List[dict] = self.get_jobtasks(return_json=True)  # type: ignore
         jobtasks_ids = [task["id"] for task in jobtasks]
@@ -346,3 +346,17 @@ class Job(VizTools):
 
             jobtasks_results_json[jobtask_id] = response_json
         return jobtasks_results_json
+
+    def get_job_credits(self) -> dict:
+        """
+        Convenience function to get the credit consumption of the job.
+
+        Returns:
+            The consumed credits for the job.
+        """
+        url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs/{self.job_id}/credits"
+        response_json = self.auth._request(request_type="GET", url=url)
+        credits_used = response_json["data"]["creditsUsed"]
+        credits_used_dict = {"creditsUsed": credits_used}
+
+        return credits_used_dict


### PR DESCRIPTION
The support team requested that the SDK outputs credit usage for each job. 

Two questions:
- What else would I need to update in the documenattion. The method doc is automatically uploaded to the docs. 
- What happens if the job status is "Running". This could fail right? The download_results method doesn't account for this either, so I'm wondering what the behaviour is here.

Items:
* [x] Ran test & live-tests
* [x] Implemented (new) unit tests
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
