### PR TITLE
user agent instead of custom header

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -101,7 +101,7 @@ def test_generate_headers(auth_mock):
         "Content-Type": "application/json",
         "Authorization": "Bearer token_1011",
         "cache-control": "no-cache",
-        "X-UP42-info": f"python/{version}",
+        "User-Agent": f"up42-py/{version} (https://github.com/up42/up42-py)",
     }
     assert auth_mock._generate_headers(token="token_1011") == expected_headers
 

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -189,7 +189,7 @@ class Auth:
             "Content-Type": "application/json",
             "Authorization": f"Bearer {token}",
             "cache-control": "no-cache",
-            "X-UP42-info": f"python/{version}",
+            "User-Agent": f"up42-py/{version} (https://github.com/up42/up42-py)",
         }
         return headers
 


### PR DESCRIPTION
Set user-agent instead of custom header to enable proper API/SDK tracking.

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
