### PR TITLE
add limit and sorting - get_jobs

### DIFF
--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -240,4 +240,4 @@ def test_estimate_order_live(order_payload, auth_live):
         auth_live, order_payload["dataProviderName"], order_payload["orderParams"]
     )
     assert isinstance(estimation, int)
-    assert estimation == 105
+    assert estimation == 100

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -83,6 +83,11 @@ def test_get_jobs_pagination(project_mock):
     assert len(jobcollection.jobs) == 120
 
 
+def test_get_jobs_pagination_limit(project_mock):
+    jobcollection = project_mock.get_jobs(limit=110)
+    assert len(jobcollection.jobs) == 110
+
+
 @pytest.mark.skip(
     reason="too many jobs in test project, triggers too many job info requests."
 )

--- a/up42/project.py
+++ b/up42/project.py
@@ -131,7 +131,13 @@ class Project:
             return workflows
 
     def get_jobs(
-        self, return_json: bool = False, test_jobs: bool = True, real_jobs: bool = True
+        self,
+        return_json: bool = False,
+        test_jobs: bool = True,
+        real_jobs: bool = True,
+        limit: int = 500,
+        sortby: str = "createdAt",
+        descending: bool = True,
     ) -> Union[JobCollection, List[dict]]:
         """
         Get all jobs in the project as a JobCollection or json.
@@ -143,25 +149,49 @@ class Project:
             return_json: If true, returns the job info jsons instead of JobCollection.
             test_jobs: Return test jobs or test queries.
             real_jobs: Return real jobs.
+            limit: Optional, only return n first assets by sorting criteria and order.
+                Optimal to select if your workspace contains many assets.
+            sortby: The sorting criteria, one of "createdAt", "name", "id", "mode", "status", "startedAt", "finishedAt".
+            descending: The sorting order, True for descending (default), False for ascending.
 
         Returns:
             All job objects in a JobCollection, or alternatively the jobs info as json.
         """
+        allowed_sorting_criteria = [
+            "createdAt",
+            "name",
+            "id",
+            "mode",
+            "status",
+            "startedAt",
+            "finishedAt",
+        ]
+        if sortby not in allowed_sorting_criteria:
+            raise ValueError(
+                f"sortby parameter must be one of {allowed_sorting_criteria}!"
+            )
+        sort = f"{sortby},{'desc' if descending else 'asc'}"
+
         page = 0
-        url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs?page={page}"
+        url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs?page={page}&sort={sort}"
         response_json = self.auth._request(request_type="GET", url=url)
         jobs_json = filter_jobs_on_mode(response_json["data"], test_jobs, real_jobs)
 
         # API get jobs pagination exhaustion is indicated by empty next page (no last page flag)
-        while len(response_json["data"]) > 0:
+        logging.getLogger("up42.utils").setLevel(logging.CRITICAL)
+        while len(response_json["data"]) > 0 and len(jobs_json) < limit:
             page += 1
-            url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs?page={page}"
+            url = f"{self.auth._endpoint()}/projects/{self.project_id}/jobs?page={page}&sort={sort}"
             response_json = self.auth._request(request_type="GET", url=url)
             if len(response_json["data"]) > 0:
                 jobs_json.extend(
                     filter_jobs_on_mode(response_json["data"], test_jobs, real_jobs)
                 )
-        logger.info(f"Got {len(jobs_json)} jobs in project {self.project_id}.")
+        logging.getLogger("up42.utils").setLevel(logging.INFO)
+        jobs_json = jobs_json[:limit]
+        logger.info(
+            f"Got {len(jobs_json)} jobs (limit parameter {limit}) in project {self.project_id}."
+        )
         if return_json:
             return jobs_json
         else:

--- a/up42/project.py
+++ b/up42/project.py
@@ -149,8 +149,7 @@ class Project:
             return_json: If true, returns the job info jsons instead of JobCollection.
             test_jobs: Return test jobs or test queries.
             real_jobs: Return real jobs.
-            limit: Optional, only return n first assets by sorting criteria and order.
-                Optimal to select if your workspace contains many assets.
+            limit: Only return n first jobs by sorting criteria and order, default 500.
             sortby: The sorting criteria, one of "createdAt", "name", "id", "mode", "status", "startedAt", "finishedAt".
             descending: The sorting order, True for descending (default), False for ascending.
 


### PR DESCRIPTION
Adds limit parameter and sorting oprtions to `project.get_jobs`.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
