### PR TITLE
use functools to enable mkdocstrings to pick up wrapped decorator fun…

### DIFF
--- a/docs/reference/up42-reference.md
+++ b/docs/reference/up42-reference.md
@@ -4,9 +4,9 @@
     rendering:
         show_root_toc_entry: False
         show_if_no_docstring: False
+        group_by_category: False
         
 ::: up42.tools.Tools
     rendering:
         show_root_toc_entry: False
         group_by_category: False
-        heading_level: 3

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -4,14 +4,14 @@ not bound to a specific higher level UP42 object.
 """
 
 import json
-
+from functools import wraps
 from pathlib import Path
 from typing import List, Union, Dict, Optional
 from datetime import date, datetime, timedelta
-from geopandas import GeoDataFrame
 
 import requests.exceptions
 import geopandas as gpd
+from geopandas import GeoDataFrame
 import pandas as pd
 import shapely
 
@@ -31,6 +31,7 @@ logger = get_logger(__name__)
 
 def check_auth(func, *args, **kwargs):
     # pylint: disable=unused-argument
+    @wraps(func)  # required for mkdocstrings
     def inner(self, *args, **kwargs):
         if not hasattr(self, "auth"):
             raise Exception(
@@ -250,7 +251,6 @@ class Tools:
         response_coverage = requests.get(details_json["url"]).json()
         return response_coverage
 
-    @check_auth
     def get_credits_balance(self) -> dict:
         """
         Display the overall credits available in your account.

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -251,6 +251,7 @@ class Tools:
         response_coverage = requests.get(details_json["url"]).json()
         return response_coverage
 
+    @check_auth
     def get_credits_balance(self) -> dict:
         """
         Display the overall credits available in your account.


### PR DESCRIPTION
Decorated functions weren't picked up for the docs code reference via mkdocstrings. Wrapping with functools, see [issue](https://github.com/mkdocstrings/mkdocstrings/issues/162).

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
