### PR TITLE
Optional viz dependencies int54

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           name: Install requirements
           command: |
             pip install -r requirements.txt
+            pip install -r requirements-viz.txt
             pip install -r requirements-dev.txt
       - run:
           name: Runnning tests
@@ -23,6 +24,7 @@ jobs:
           name: Install requirements
           command: |
             pip install -r requirements.txt
+            pip install -r requirements-viz.txt
             pip install -r requirements-dev.txt
       - run:
           name: Runnning tests

--- a/requirements-viz.txt
+++ b/requirements-viz.txt
@@ -1,0 +1,5 @@
+rasterio
+folium
+branca
+matplotlib
+descartes

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,4 @@ requests-oauthlib
 tenacity
 tqdm
 geojson
-rasterio
 geopandas
-folium
-branca
-matplotlib
-descartes

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=parent_dir.joinpath("requirements.txt").read_text().splitlines(),
+    extras_require={
+        "viz": parent_dir.joinpath("requirements-viz.txt").read_text().splitlines(),
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -232,7 +232,7 @@ def get_example_aoi(
 
 
 def draw_aoi() -> None:
-    return Tools().draw_aoi()
+    return VizTools().draw_aoi()
 
 
 # pylint: disable=duplicate-code

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -15,16 +15,7 @@ from geopandas import GeoDataFrame
 import pandas as pd
 import shapely
 
-from up42.viztools import folium_base_map, DrawFoliumOverride
 from up42.utils import get_logger, format_time_period
-
-try:
-    from IPython import get_ipython
-
-    get_ipython().run_line_magic("matplotlib", "inline")
-except (ImportError, AttributeError):
-    # No Ipython installed, Installed but run in shell
-    pass
 
 logger = get_logger(__name__)
 
@@ -130,32 +121,6 @@ class Tools:
             return df
         else:
             return example_aoi
-
-    @staticmethod
-    def draw_aoi():
-        """
-        Displays an interactive map to draw an aoi by hand, returns the folium object if
-        not run in a Jupyter notebook.
-
-        Export the drawn aoi via the export button, then read the geometries via
-        read_aoi_file().
-        """
-        m = folium_base_map(layer_control=True)
-        DrawFoliumOverride(
-            export=True,
-            filename="aoi.geojson",
-            position="topleft",
-            draw_options={
-                "rectangle": {"repeatMode": False, "showArea": True},
-                "polygon": {"showArea": True, "allowIntersection": False},
-                "polyline": False,
-                "circle": False,
-                "marker": False,
-                "circlemarker": False,
-            },
-            edit_options={"polygon": {"allowIntersection": False}},
-        ).add_to(m)
-        return m
 
     @check_auth
     def get_blocks(

--- a/up42/viztools.py
+++ b/up42/viztools.py
@@ -15,12 +15,12 @@ import geopandas as gpd
 from geopandas import GeoDataFrame
 
 try:
-    import matplotlib.pyplot as plt
     import rasterio
     from rasterio.plot import show
     from rasterio.vrt import WarpedVRT
     import folium
     from folium.plugins import Draw
+    import matplotlib.pyplot as plt
 except ImportError:
     _viz_installed = False
 else:
@@ -54,8 +54,19 @@ except (ImportError, AttributeError):
     # No Ipython installed, Installed but run in shell
     pass
 
-
 logger = get_logger(__name__)
+
+
+def requires_viz(func):
+    def wrapper_func(*args, **kwargs):
+        if not _viz_installed:
+            raise ImportError(
+                "Some dependencies for the optional up42-py visualizations are missing. "
+                "You can install them via `install up42py[viz]`."
+            )
+        func(*args, **kwargs)
+
+    return wrapper_func
 
 
 # pylint: disable=no-member, duplicate-code
@@ -67,16 +78,7 @@ class VizTools:
         self.quicklooks = None
         self.results: Union[list, dict, None] = None
 
-        if not _viz_installed:
-            raise ImportError(
-                "Some dependencies for the optional up42-py vizualizations are missing. "
-                "You can install them via `install up42py[viz]`."
-            )
-
-        warnings.filterwarnings(
-            "ignore", category=rasterio.errors.NotGeoreferencedWarning
-        )
-
+    @requires_viz
     def plot_results(
         self,
         figsize: Tuple[int, int] = (14, 8),
@@ -101,6 +103,10 @@ class VizTools:
                 [rasterio.plot.show](https://rasterio.readthedocs.io/en/latest/api/rasterio.plot.html#rasterio.plot.show),
                  e.g. matplotlib cmap etc.
         """
+        warnings.filterwarnings(
+            "ignore", category=rasterio.errors.NotGeoreferencedWarning
+        )
+
         if filepaths is None:
             if self.results is None:
                 raise ValueError("You first need to download the results!")
@@ -161,6 +167,7 @@ class VizTools:
         plt.tight_layout()
         plt.show()
 
+    @requires_viz
     def plot_quicklooks(
         self,
         figsize: Tuple[int, int] = (8, 8),
@@ -215,6 +222,10 @@ class VizTools:
             name_column: Name of the feature property that provides the Feature/Layer name.
             save_html: The path for saving folium map as html file. With default None, no file is saved.
         """
+        warnings.filterwarnings(
+            "ignore", category=rasterio.errors.NotGeoreferencedWarning
+        )
+
         if result_df.shape[0] > 100:
             result_df = result_df.iloc[:100]
             logger.info(
@@ -310,6 +321,7 @@ class VizTools:
                 f.write(m._repr_html_())
         return m
 
+    @requires_viz
     def map_results(
         self,
         bands=[1, 2, 3],
@@ -375,6 +387,7 @@ class VizTools:
 
         return m
 
+    @requires_viz
     def map_quicklooks(
         self,
         scenes: GeoDataFrame,
@@ -419,6 +432,7 @@ class VizTools:
         return m
 
     @staticmethod
+    @requires_viz
     def plot_coverage(
         scenes: GeoDataFrame,
         aoi: Optional[GeoDataFrame] = None,
@@ -461,6 +475,7 @@ class VizTools:
         plt.show()
 
     @staticmethod
+    @requires_viz
     def draw_aoi() -> "folium.Map":
         """
         Displays an interactive map to draw an aoi by hand, returns the folium object if

--- a/up42/viztools.py
+++ b/up42/viztools.py
@@ -64,7 +64,7 @@ def requires_viz(func):
                 "Some dependencies for the optional up42-py visualizations are missing. "
                 "You can install them via `install up42py[viz]`."
             )
-        func(*args, **kwargs)
+        return func(*args, **kwargs)
 
     return wrapper_func
 

--- a/up42/viztools.py
+++ b/up42/viztools.py
@@ -13,12 +13,19 @@ import numpy as np
 from shapely.geometry import box
 import geopandas as gpd
 from geopandas import GeoDataFrame
-import matplotlib.pyplot as plt
-import rasterio
-from rasterio.plot import show
-from rasterio.vrt import WarpedVRT
-import folium
-from folium.plugins import Draw
+
+try:
+    import matplotlib.pyplot as plt
+    import rasterio
+    from rasterio.plot import show
+    from rasterio.vrt import WarpedVRT
+    import folium
+    from folium.plugins import Draw
+except ImportError:
+    _viz_installed = False
+else:
+    _viz_installed = True
+
 
 from up42.utils import (
     get_logger,
@@ -38,9 +45,6 @@ HIGHLIGHT_STYLE = {
     "weight": 3.5,
     "dashArray": "5, 5",
 }
-
-# ignore warnings
-warnings.filterwarnings("ignore", category=rasterio.errors.NotGeoreferencedWarning)
 
 try:
     from IPython import get_ipython
@@ -62,6 +66,16 @@ class VizTools:
         """
         self.quicklooks = None
         self.results: Union[list, dict, None] = None
+
+        if not _viz_installed:
+            raise ImportError(
+                "Some dependencies for the optional up42-py vizualizations are missing. "
+                "You can install them via `install up42py[viz]`."
+            )
+
+        warnings.filterwarnings(
+            "ignore", category=rasterio.errors.NotGeoreferencedWarning
+        )
 
     def plot_results(
         self,
@@ -187,7 +201,7 @@ class VizTools:
         show_features=False,
         name_column: str = "id",
         save_html: Optional[Path] = None,
-    ) -> folium.Map:
+    ) -> "folium.Map":
         """
         Displays data.json, and if available, one or multiple results geotiffs.
         Args:
@@ -304,7 +318,7 @@ class VizTools:
         show_features: bool = True,
         name_column: str = "uid",
         save_html: Path = None,
-    ) -> folium.Map:
+    ) -> "folium.Map":
         """
         Displays data.json, and if available, one or multiple results geotiffs.
 
@@ -370,7 +384,7 @@ class VizTools:
         filepaths: Optional[list] = None,
         name_column: str = "id",
         save_html: Optional[Path] = None,
-    ) -> folium.Map:
+    ) -> "folium.Map":
         """
         TODO: Currently only implemented for catalog!
 


### PR DESCRIPTION
Makes the dependencies for the vizualizations optional. Adds `pip install up42-py[viz]` installation option.

To check: How this affects the conda installation.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
