### PR TITLE
Gcs download unpacking improvements

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -12,7 +12,7 @@ from up42.utils import (
     format_time_period,
     any_vector_to_fc,
     fc_to_query_geometry,
-    download_results_from_gcs,
+    download_from_gcs_unpack,
     filter_jobs_on_mode,
 )
 from up42.auth import Auth

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -25,7 +25,7 @@ from .context import (
 
 
 TOKEN = "token_123"
-DOWNLOAD_URL = "http://up42.api.com/abcdef"
+DOWNLOAD_URL = "http://up42.api.com/abcdef.tgz"
 
 PROJECT_ID = "project_id_123"
 PROJECT_APIKEY = "project_apikey_123"

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -83,6 +83,15 @@ def test_asset_download(asset_mock, requests_mock):
         assert out_paths[1].parent.is_dir()
 
 
+@pytest.mark.live
+def test_asset_download_live(asset_live):
+    with tempfile.TemporaryDirectory() as tempdir:
+        out_files = asset_live.download(Path(tempdir))
+        for file in out_files:
+            assert Path(file).exists()
+        assert len(out_files) == 44
+
+
 def test_asset_download_no_unpacking(asset_mock, requests_mock):
     out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
     with open(out_tgz, "rb") as src_tgz:
@@ -98,12 +107,3 @@ def test_asset_download_no_unpacking(asset_mock, requests_mock):
         for file in out_files:
             assert Path(file).exists()
         assert len(out_files) == 1
-
-
-@pytest.mark.live
-def test_asset_download_live(asset_live):
-    with tempfile.TemporaryDirectory() as tempdir:
-        out_files = asset_live.download(Path(tempdir))
-        for file in out_files:
-            assert Path(file).exists()
-        assert len(out_files) == 44

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -85,11 +85,27 @@ def test_asset_download(asset_mock, requests_mock):
 
 @pytest.mark.live
 def test_asset_download_live(asset_live):
+    """
+    tgz from block (storage)
+    """
     with tempfile.TemporaryDirectory() as tempdir:
         out_files = asset_live.download(Path(tempdir))
         for file in out_files:
             assert Path(file).exists()
         assert len(out_files) == 44
+
+
+@pytest.mark.live
+def test_asset_download_live_2(asset_live):
+    """
+    zip from order (storage)
+    """
+    asset_live.asset_id = os.getenv("TEST_UP42_ASSET_ID_2_zip")
+    with tempfile.TemporaryDirectory() as tempdir:
+        out_files = asset_live.download(Path(tempdir))
+        for file in out_files:
+            assert Path(file).exists()
+        assert len(out_files) == 42
 
 
 def test_asset_download_no_unpacking(asset_mock, requests_mock):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ from .context import (
     format_time_period,
     any_vector_to_fc,
     fc_to_query_geometry,
-    download_results_from_gcs,
+    download_from_gcs_unpack,
     filter_jobs_on_mode,
 )
 
@@ -257,7 +257,7 @@ def test_fc_to_query_geometry_multipolygon_raises():
     )
 
 
-def test_download_result_from_gcs(requests_mock):
+def test_download_gcs_unpack_tgz(requests_mock):
     cloud_storage_url = "http://clouddownload.api.com/abcdef"
 
     out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
@@ -270,7 +270,7 @@ def test_download_result_from_gcs(requests_mock):
     with tempfile.TemporaryDirectory() as tempdir:
         with open(Path(tempdir) / "dummy.txt", "w") as fp:
             fp.write("dummy")
-        out_files = download_results_from_gcs(
+        out_files = download_from_gcs_unpack(
             download_url=cloud_storage_url,
             output_directory=tempdir,
         )
@@ -281,7 +281,7 @@ def test_download_result_from_gcs(requests_mock):
         assert not (Path(tempdir) / "output").exists()
 
 
-def test_download_result_from_gcs_zip(requests_mock):
+def test_download_gcs_unpack_zip(requests_mock):
     cloud_storage_url = "http://clouddownload.api.com/abcdef"
 
     out_zip = Path(__file__).resolve().parent / "mock_data/result_tif.zip"
@@ -295,7 +295,7 @@ def test_download_result_from_gcs_zip(requests_mock):
     with tempfile.TemporaryDirectory() as tempdir:
         with open(Path(tempdir) / "dummy.txt", "w") as fp:
             fp.write("dummy")
-        out_files = download_results_from_gcs(
+        out_files = download_from_gcs_unpack(
             download_url=cloud_storage_url,
             output_directory=tempdir,
         )
@@ -306,7 +306,7 @@ def test_download_result_from_gcs_zip(requests_mock):
         assert not (Path(tempdir) / "output").exists()
 
 
-def test_download_result_from_gcs_not_compressed(requests_mock):
+def test_download_gcs_not_unpack(requests_mock):
     cloud_storage_url = "http://clouddownload.api.com/abcdef"
 
     out_zip = Path(__file__).resolve().parent / "mock_data/aoi_berlin.geojson"
@@ -321,7 +321,7 @@ def test_download_result_from_gcs_not_compressed(requests_mock):
         with open(Path(tempdir) / "dummy.txt", "w") as fp:
             fp.write("dummy")
         with pytest.raises(ValueError):
-            download_results_from_gcs(
+            download_from_gcs_unpack(
                 download_url=cloud_storage_url,
                 output_directory=tempdir,
             )

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -4,8 +4,8 @@ from typing import List, Union, Optional
 from up42.auth import Auth
 from up42.utils import (
     get_logger,
-    download_results_from_gcs,
-    download_results_from_gcs_without_unpacking,
+    download_from_gcs_unpack,
+    download_gcs_not_unpack,
 )
 
 logger = get_logger(__name__)
@@ -73,7 +73,7 @@ class Asset:
         Args:
             output_directory: The file output directory, defaults to the current working
                 directory.
-            unpacking: By default the final result which is in TAR or ZIP archive format will be unpacked.
+            unpacking: By default the download TGZ/TAR or ZIP archive file will be unpacked.
 
         Returns:
             List of the downloaded asset filepaths.
@@ -91,12 +91,12 @@ class Asset:
 
         download_url = self._get_download_url()
         if unpacking:
-            out_filepaths = download_results_from_gcs(
+            out_filepaths = download_from_gcs_unpack(
                 download_url=download_url,
                 output_directory=output_directory,
             )
         else:
-            out_filepaths = download_results_from_gcs_without_unpacking(
+            out_filepaths = download_gcs_not_unpack(
                 download_url=download_url,
                 output_directory=output_directory,
             )

--- a/up42/job.py
+++ b/up42/job.py
@@ -12,8 +12,8 @@ from up42.jobtask import JobTask
 from up42.viztools import VizTools
 from up42.utils import (
     get_logger,
-    download_results_from_gcs,
-    download_results_from_gcs_without_unpacking,
+    download_from_gcs_unpack,
+    download_gcs_not_unpack,
 )
 
 logger = get_logger(__name__)
@@ -212,12 +212,12 @@ class Job(VizTools):
 
         download_url = self._get_download_url()
         if unpacking:
-            out_filepaths = download_results_from_gcs(
+            out_filepaths = download_from_gcs_unpack(
                 download_url=download_url,
                 output_directory=output_directory,
             )
         else:
-            out_filepaths = download_results_from_gcs_without_unpacking(
+            out_filepaths = download_gcs_not_unpack(
                 download_url=download_url,
                 output_directory=output_directory,
             )

--- a/up42/jobtask.py
+++ b/up42/jobtask.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 
 from up42.auth import Auth
 from up42.viztools import VizTools
-from up42.utils import get_logger, download_results_from_gcs
+from up42.utils import get_logger, download_from_gcs_unpack
 
 logger = get_logger(__name__)
 
@@ -121,7 +121,7 @@ class JobTask(VizTools):
         logger.info(f"Download directory: {str(output_directory)}")
 
         download_url = self._get_download_url()
-        out_filepaths = download_results_from_gcs(
+        out_filepaths = download_from_gcs_unpack(
             download_url=download_url,
             output_directory=output_directory,
         )

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -147,11 +147,15 @@ def download_gcs_not_unpack(
         output_directory: The file output directory, defaults to the current working
             directory.
     """
-    output_directory = Path(output_directory)
+    if ".tgz" in download_url:
+        file_ending = ".tgz"
+    elif ".zip" in download_url:
+        file_ending = ".zip"
+    else:
+        ValueError("To be downloaded file is not a TGZ/TAR or ZIP archive.")
+    out_fp = Path().joinpath(output_directory, f"output.{file_ending}")
 
     # Download
-    out_filepaths: List[str] = []
-    out_fp = Path().joinpath(output_directory, "output.tgz")
     with open(out_fp, "wb") as dst:
         try:
             r = requests.get(download_url, stream=True)

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -78,11 +78,12 @@ def deprecation(
     return actual_decorator
 
 
-def download_results_from_gcs(
-    download_url: str, output_directory: Union[str, Path]
+def download_from_gcs_unpack(
+    download_url: str,
+    output_directory: Union[str, Path],
 ) -> List[str]:
     """
-    General download function for results of job and jobtask from cloud storage
+    General download function for results of storage assets, job & jobtask from cloud storage
     provider.
 
     Args:
@@ -91,32 +92,32 @@ def download_results_from_gcs(
             directory.
     """
     # Download
-    compressed_file = tempfile.mktemp()
-    with open(compressed_file, "wb") as dst_tgz:
+    out_temp = tempfile.mktemp()
+    with open(out_temp, "wb") as dst:
         try:
             r = requests.get(download_url, stream=True)
             r.raise_for_status()
             for chunk in tqdm(r.iter_content(chunk_size=1024)):
                 if chunk:  # filter out keep-alive new chunks
-                    dst_tgz.write(chunk)
+                    dst.write(chunk)
         except requests.exceptions.HTTPError as err:
-            logger.debug(f"Connection error, please try again! {err}")
-            raise requests.exceptions.HTTPError(
-                f"Connection error, please try again! {err}"
-            )
+            error_message = f"Connection error, please try again! {err}"
+            logger.debug(error_message)
+            raise requests.exceptions.HTTPError(error_message)
 
     # Unpack and avoid inherent output/ .. directory
-    out_filepaths = []
-    if tarfile.is_tarfile(compressed_file):
-        with tarfile.open(compressed_file) as tar_file:
+    # Order results are zip, job results are tgz(tar.gzipped)
+    out_filepaths: List[Path] = []
+    if tarfile.is_tarfile(out_temp):
+        with tarfile.open(out_temp) as tar_file:
             for tar_member in tar_file.getmembers():
                 if tar_member.isfile():
                     new_name = tar_member.name.split("output/")[1]
                     tar_member.name = new_name
                     tar_file.extract(tar_member, output_directory)
                     out_filepaths.append(Path(output_directory) / new_name)
-    elif zipfile.is_zipfile(compressed_file):
-        with zipfile.ZipFile(compressed_file) as zip_file:
+    elif zipfile.is_zipfile(out_temp):
+        with zipfile.ZipFile(out_temp) as zip_file:
             for zip_info in zip_file.infolist():
                 if not zip_info.filename.endswith("/"):
                     new_name = zip_info.filename.split("output/")[1]
@@ -124,7 +125,7 @@ def download_results_from_gcs(
                     zip_file.extract(zip_info, output_directory)
                     out_filepaths.append(Path(output_directory) / new_name)
     else:
-        raise ValueError("Downloaded file is not a TAR or ZIP archive.")
+        raise ValueError("Downloaded file is not a TGZ/TAR or ZIP archive.")
 
     logger.info(
         f"Download successful of {len(out_filepaths)} files to output_directory "
@@ -134,11 +135,11 @@ def download_results_from_gcs(
     return out_filepaths  # type: ignore
 
 
-def download_results_from_gcs_without_unpacking(
+def download_gcs_not_unpack(
     download_url: str, output_directory: Union[str, Path]
 ) -> List[str]:
     """
-    General download function for results of job and jobtask from cloud storage
+    General download function for assets, job and jobtasks from cloud storage
     provider.
 
     Args:
@@ -158,7 +159,6 @@ def download_results_from_gcs_without_unpacking(
             for chunk in tqdm(r.iter_content(chunk_size=1024)):
                 if chunk:  # filter out keep-alive new chunks
                     dst.write(chunk)
-            out_filepaths.append(str(out_fp))
         except requests.exceptions.HTTPError as err:
             logger.debug(f"Connection error, please try again! {err}")
             raise requests.exceptions.HTTPError(
@@ -166,9 +166,10 @@ def download_results_from_gcs_without_unpacking(
             )
 
     logger.info(
-        f"Download successful of {len(out_filepaths)} files to output_directory"
-        f" '{output_directory}': {[Path(p).name for p in out_filepaths]}"
+        f"Download successful of original archive file to output_directory"
+        f" '{output_directory}': {out_fp.name}. To automatically unpack the archive use `unpacking=True`"
     )
+    out_filepaths = [str(out_fp)]
     return out_filepaths
 
 


### PR DESCRIPTION
Ensures that assets from user storage that originate from archive orders (zip format) are correctly unpacked, even if they don't contain the up42-inherent "output" topfolder.

- Also slightly refactors the unpacking functions. 
- Checks the download url for the archive format for the filename of the unpacked download variant.
- Moves livetests under mocktests (wasnt the case in jobtest module yet).

Adds new testing env variable "TEST_UP42_ASSET_ID_2_zip", already updated in CI.

Items:
* [x] Ran test & live-tests
* [x] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
