### PR TITLE
Surface error message details

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -132,7 +132,7 @@ def test_request_non200_raises(auth_mock, requests_mock):
 
     with pytest.raises(requests.exceptions.RequestException) as e:
         auth_mock._request(request_type="GET", url="http://test.com")
-    assert "some 403 error message!" in str(e.value)
+    assert "{'code': 403, 'message': 'some 403 error message'}" in str(e.value)
 
 
 def test_request_non200_raises_error_not_dict(auth_mock, requests_mock):

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -278,10 +278,9 @@ class Auth:
                 self._request_helper, request_type, url, data, querystring
             )
         except requests.exceptions.RequestException as err:  # Base error class
-            err_message = json.loads(err.response.text)["error"]
-            if "code" in err_message:
-                err_message = f"{err_message['code']} Error - {err_message['message']}!"
-            logger.error(err_message)
+            # Raising the original `err` error would not surface the relevant error message (contained in API response)
+            err_message = err.response.json()["error"]
+            logger.error(f"Error {err_message}")
             raise requests.exceptions.RequestException(err_message) from err
 
         # Handle response text.


### PR DESCRIPTION
Simplify API error message surfacing. Just passes through the original API error message, no additional formatting. This also surfaces the "details" key which is contained in some API error messages.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
