### PR TITLE
Improve quicklooks plotting - bands selection

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -363,7 +363,7 @@ def test_download_quicklook(catalog_mock, requests_mock):
 
 def test_download_no_quicklook(catalog_mock, requests_mock):
     sel_id = "dfc54412-8b9c-45a3-b46a-dd030a47c2f3"
-    provider = "sobloo-image"
+    provider = "oneatlas"
     url_quicklook = (
         f"{catalog_mock.auth._endpoint()}/catalog/{provider}/image/{sel_id}/quicklook"
     )
@@ -371,7 +371,7 @@ def test_download_no_quicklook(catalog_mock, requests_mock):
 
     with tempfile.TemporaryDirectory() as tempdir:
         out_paths = catalog_mock.download_quicklooks(
-            image_ids=[sel_id], sensor="sentinel5p", output_directory=tempdir
+            image_ids=[sel_id], sensor="pleiades", output_directory=tempdir
         )
         assert len(out_paths) == 0
 
@@ -379,7 +379,7 @@ def test_download_no_quicklook(catalog_mock, requests_mock):
 def test_download_1_quicklook_1_no_quicklook(catalog_mock, requests_mock):
     sel_id_no = "dfc54412-8b9c-45a3-b46a-dd030a47c2f3"
     sel_id = "6dffb8be-c2ab-46e3-9c1c-6958a54e4527"
-    provider = "sobloo-image"
+    provider = "oneatlas"
     url_no_quicklook = f"{catalog_mock.auth._endpoint()}/catalog/{provider}/image/{sel_id_no}/quicklook"
     requests_mock.get(url_no_quicklook, status_code=404)
 
@@ -392,7 +392,7 @@ def test_download_1_quicklook_1_no_quicklook(catalog_mock, requests_mock):
     with tempfile.TemporaryDirectory() as tempdir:
         out_paths = catalog_mock.download_quicklooks(
             image_ids=[sel_id, sel_id_no],
-            sensor="sentinel5p",
+            sensor="pleiades",
             output_directory=tempdir,
         )
         assert len(out_paths) == 1

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -290,6 +290,10 @@ class Catalog(VizTools):
         supported_sensors = {
             "pleiades": "oneatlas",
             "spot": "oneatlas",
+            "capella-gec": "capellaspace",
+            "capella-geo": "capellaspace",
+            "capella-sicd": "capellaspace",
+            "capella-slc": "capellaspace",
         }
 
         if sensor not in list(supported_sensors.keys()):

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -290,10 +290,6 @@ class Catalog(VizTools):
         supported_sensors = {
             "pleiades": "oneatlas",
             "spot": "oneatlas",
-            "sentinel1": "sobloo-image",
-            "sentinel2": "sobloo-image",
-            "sentinel3": "sobloo-image",
-            "sentinel5p": "sobloo-image",
         }
 
         if sensor not in list(supported_sensors.keys()):

--- a/up42/order.py
+++ b/up42/order.py
@@ -9,8 +9,6 @@ from up42.utils import (
 
 logger = get_logger(__name__)
 
-DATA_PROVIDERS = ["oneatlas"]
-
 
 class Order:
     """

--- a/up42/viztools.py
+++ b/up42/viztools.py
@@ -82,7 +82,7 @@ class VizTools:
     def plot_results(
         self,
         figsize: Tuple[int, int] = (14, 8),
-        bands: List[int] = [1, 2, 3],
+        bands: Optional[List[int]] = None,
         titles: Optional[List[str]] = None,
         filepaths: Union[List[Union[str, Path]], dict, None] = None,
         plot_file_format: List[str] = [".tif"],
@@ -94,7 +94,7 @@ class VizTools:
 
         Args:
             figsize: matplotlib figure size.
-            bands: Image bands and order to plot, default [1,2,3]. First band is 1.
+            bands: Image bands and order to plot, e.g. [1,2,3]. First band is 1.
             titles: Optional list of titles for the subplots.
             filepaths: Paths to images to plot. Optional, by default picks up the last
                 downloaded results.
@@ -145,12 +145,17 @@ class VizTools:
         else:
             axs = [axs]
 
-        if len(bands) != 3:
-            if len(bands) == 1:
-                if "cmap" not in kwargs:
-                    kwargs["cmap"] = "gray"
-            else:
-                raise ValueError("Parameter bands can only contain one or three bands.")
+        if bands is None:
+            with rasterio.open(imagepaths[0]) as src:
+                if src.count == 1:
+                    bands = [1]
+                else:
+                    bands = [1, 2, 3]
+        if len(bands) == 1:
+            kwargs["cmap"] = "gray"
+        if len(bands) not in [1, 3]:
+            raise ValueError("Parameter bands can only contain one or three bands.")
+
         for idx, (fp, title) in enumerate(zip(imagepaths, titles)):
             with rasterio.open(fp) as src:
                 img_array = src.read(bands)
@@ -179,11 +184,10 @@ class VizTools:
         respective object, e.g. job, catalog).
 
         Args:
-                figsize: matplotlib figure size.
-                filepaths: Paths to images to plot. Optional, by default picks up the last
-                        downloaded results.
-                titles: List of titles for the subplots, optional.
-
+            figsize: matplotlib figure size.
+            filepaths: Paths to images to plot. Optional, by default picks up the last
+                    downloaded results.
+            titles: List of titles for the subplots, optional.
         """
         if filepaths is None:
             if self.quicklooks is None:


### PR DESCRIPTION
- Removes sentinel from catalog quicklook viz functionality
- adds capella (preliminary, the sensor schema will be refactored to avoid hardcoding
- Makes bands parameter optional for the image visualizations
- Automatically determines if 1 or 3 bands should be plotted by default

Urgent request for demo, code review after merging.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
