### PR TITLE
Split catalog base

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -44,6 +44,8 @@ JOB_NAME = "job_name_123"
 JOBTASK_ID = "jobtask_id_123"
 JOBTASK_NAME = "jobtask_name_123"
 
+DATA_PRODUCT_ID = "data_product_id_123"
+
 ORDER_ID = "order_id_123"
 ASSET_ID = "asset_id_123"
 
@@ -1112,7 +1114,9 @@ def webhooks_live(auth_live):
 @pytest.fixture()
 def catalog_mock(auth_mock, requests_mock):
     url_collections = f"{auth_mock._endpoint()}/collections"
-    collections_response = {"data": [{"name": "phr", "hostName": "oneatlas"}]}
+    collections_response = {
+        "data": [{"name": "phr", "hostName": "oneatlas", "type": "ARCHIVE"}]
+    }
     requests_mock.get(
         url=url_collections,
         json=collections_response,
@@ -1146,7 +1150,9 @@ def catalog_live(auth_live):
 @pytest.fixture()
 def catalog_pagination_mock(auth_mock, requests_mock):
     url_collections = f"{auth_mock._endpoint()}/collections"
-    collections_response = {"data": [{"name": "phr", "hostName": "oneatlas"}]}
+    collections_response = {
+        "data": [{"name": "phr", "hostName": "oneatlas", "type": "ARCHIVE"}]
+    }
     requests_mock.get(
         url=url_collections,
         json=collections_response,
@@ -1176,7 +1182,9 @@ def catalog_pagination_mock(auth_mock, requests_mock):
 @pytest.fixture()
 def catalog_usagetype_mock(auth_mock, requests_mock):
     url_collections = f"{auth_mock._endpoint()}/collections"
-    collections_response = {"data": [{"name": "phr", "hostName": "oneatlas"}]}
+    collections_response = {
+        "data": [{"name": "phr", "hostName": "oneatlas", "type": "ARCHIVE"}]
+    }
     requests_mock.get(
         url=url_collections,
         json=collections_response,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -415,7 +415,9 @@ def test_download_quicklook_live(catalog_live):
 
 def test_construct_order_parameters(catalog_mock):
     order_parameters = catalog_mock.construct_order_parameters(
-        data_product_id="123", image_id="123", aoi=mock_search_parameters["intersects"]
+        data_product_id="data_product_id_123",
+        image_id="123",
+        aoi=mock_search_parameters["intersects"],
     )
     assert isinstance(order_parameters, dict)
     assert list(order_parameters.keys()) == ["dataProduct", "params"]

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -26,24 +26,13 @@ logger = get_logger(__name__)
 
 
 # pylint: disable=duplicate-code
-class Catalog(VizTools):
+class CatalogBase:
     """
-    The Catalog class enables access to the UP42 catalog search. You can search
-    for satellite image scenes (for different sensors and criteria like cloud cover),
-    plot the scene coverage and download and plot the scene quicklooks.
-
-    Use the catalog:
-    ```python
-    catalog = up42.initialize_catalog()
-    ```
+    The base for Catalog and Tasking class, shared functionality.
     """
-
     def __init__(self, auth: Auth):
         self.auth = auth
-        self.quicklooks = None
-
-    def __repr__(self):
-        return f"Catalog(auth={self.auth})"
+        self.type: Union[str, None] = None
 
     def get_data_products(self, basic: bool = True) -> Union[Dict, List]:
         """
@@ -63,6 +52,9 @@ class Catalog(VizTools):
             collection_overview = {}
 
             for product in products:
+                if product["collection"]["type"] != self.type:
+                    continue
+
                 try:
                     if not product["collection"]["isIntegrated"]:
                         continue
@@ -98,7 +90,95 @@ class Catalog(VizTools):
         """
         url = f"{self.auth._endpoint()}/collections"
         json_response = self.auth._request("GET", url)
-        return json_response["data"]
+        collections = [c for c in json_response["data"] if c["type"] == self.type]
+        return collections
+
+    def place_order(
+        self,
+        order_parameters: Union[dict, None],
+        track_status: bool = False,
+        report_time: int = 120,
+        **kwargs,
+    ) -> "Order":
+        """
+        Place an order.
+
+        Args:
+            order_parameters: A dictionary like {dataProduct: ..., "params": {"id": ..., "aoi": ...}}
+            track_status (bool): If set to True, will only return the Order once it is `FULFILLED` or `FAILED`.
+            report_time (int): The interval (in seconds) to query the order status if `track_status` is True.
+
+        Warning "Deprecated order parameters"
+            The use of the 'scene' and 'geometry' parameters for the data ordering is deprecated. Please use the new
+            order_parameters parameter as described above.
+
+         Warning:
+            When placing orders of items that are in archive or cold storage,
+            the order fulfillment can happen up to **24h after order placement**.
+            In such cases, please make sure to set an appropriate `report_time`.
+            You can also use `Order.track_status` on the returned object to track the status later.
+
+        Returns:
+            Order: The placed order.
+        """
+        if "scene" in kwargs or "geometry" in kwargs:
+            # Deprecated, to be removed, use order_parameters.
+            message = (
+                "The use of the 'scene' and 'geometry' parameters for the data ordering is deprecated. "
+                "Please use the new 'order_parameters' parameter."
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+        elif order_parameters is None:
+            raise ValueError("Please provide the 'order_parameters' parameter!")
+
+        order = Order.place(self.auth, order_parameters)  # type: ignore
+        if track_status:
+            order.track_status(report_time)
+        return order
+
+
+class Catalog(CatalogBase, VizTools):
+    """
+    The Catalog class enables access to the UP42 catalog functionality (data archive search & ordering).
+
+    Use tasking:
+    ```python
+    catalog = up42.initialize_catalog()
+    ```
+    """
+
+    def __init__(self, auth: Auth):
+        self.auth = auth
+        self.quicklooks = None
+        self.type = "ARCHIVE"
+
+    def __repr__(self):
+        return f"Catalog(auth={self.auth})"
+
+    def estimate_order(self, order_parameters: Union[dict, None], **kwargs) -> int:
+        """
+        Estimate the cost of an order.
+
+        Args:
+            order_parameters: A dictionary like {dataProduct: ..., "params": {"id": ..., "aoi": ...}}
+
+        Returns:
+            int: An estimated cost for the order in UP42 credits.
+
+        Warning "Deprecated order parameters"
+            The use of the 'scene' and 'geometry' parameters for the data estimation is deprecated. Please use the new
+            order_parameters parameter as described above.
+        """
+        if "scene" in kwargs or "geometry" in kwargs:
+            # Deprecated, to be removed, use order_parameters.
+            message = (
+                "The use of the 'scene' and 'geometry' parameters for the data estimation is deprecated. "
+                "Please use the new 'order_parameters' parameter."
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+        elif order_parameters is None:
+            raise ValueError("Please provide the 'order_parameters' parameter!")
+        return Order.estimate(self.auth, order_parameters)  # type: ignore
 
     @deprecation("construct_search_parameters", "0.25.0")
     def construct_parameters(self, **kwargs):  # pragma: no cover
@@ -266,6 +346,82 @@ class Catalog(VizTools):
         else:
             return df.__geo_interface__
 
+    def construct_order_parameters(
+        self,
+        data_product_id: str,
+        image_id: str,
+        aoi: Union[
+            dict,
+            Feature,
+            FeatureCollection,
+            list,
+            GeoDataFrame,
+            Polygon,
+        ] = None,
+        **kwargs,
+    ):
+        """
+        Helps constructing the parameters dictionary required for the catalog order.
+
+        Args:
+            data_product_id: Id of the desired UP42 data product, see `catalog.get_data_products`
+            image_id: The id of the desired image (from search results)
+            aoi: The geometry of the order, one of dict, Feature, FeatureCollection,
+                list, GeoDataFrame, Polygon.
+            kwargs: Any additional required order parameters.
+
+        Returns:
+            The constructed parameters dictionary.
+
+        Example:
+            ```python
+            order_parameters = catalog.construct_order_parameters(
+                data_product_id='647780db-5a06-4b61-b525-577a8b68bb54',
+                image_id='6434e7af-2d41-4ded-a789-fb1b2447ac92',
+                aoi={'type': 'Polygon',
+                'coordinates': (((13.375966, 52.515068),
+                  (13.375966, 52.516639),
+                  (13.378314, 52.516639),
+                  (13.378314, 52.515068),
+                  (13.375966, 52.515068)),)})
+            ```
+        """
+        order_parameters = {
+            "dataProduct": data_product_id,
+            "params": {"id": image_id, **kwargs},
+        }
+        if aoi is not None:
+            aoi = any_vector_to_fc(vector=aoi)
+            aoi = fc_to_query_geometry(fc=aoi, geometry_operation="intersects")
+            order_parameters["params"]["aoi"] = aoi  # type:ignore
+
+        schema = self.get_data_product_schema(data_product_id)
+        required_params = schema["required"]
+        optional_params = list(
+            set(list(schema["properties"].keys())).difference(required_params)
+        )
+        logger.info(
+            f"Order parameters for this data product - Required: {required_params} - Optional: {optional_params}. "
+            f"Also see catalog.get_data_product_schema()"
+        )
+        missing_params = list(
+            set(required_params).difference(order_parameters["params"])
+        )
+        redundant_params = list(
+            set(order_parameters["params"]).difference(
+                required_params + optional_params
+            )
+        )
+
+        if not missing_params and not redundant_params:
+            logger.info("Correct order parameters!")
+        elif missing_params:
+            logger.info(f"Missing order parameters: {missing_params}")
+        else:
+            logger.info(f"Incorrect order parameters: {redundant_params}")
+
+        return order_parameters
+
     def download_quicklooks(
         self,
         image_ids: List[str],
@@ -337,119 +493,3 @@ class Catalog(VizTools):
 
         self.quicklooks = out_paths  # pylint: disable=attribute-defined-outside-init
         return out_paths
-
-    @staticmethod
-    def construct_order_parameters(
-        data_product_id: str,
-        image_id: str,
-        aoi: Union[
-            dict,
-            Feature,
-            FeatureCollection,
-            list,
-            GeoDataFrame,
-            Polygon,
-        ],
-    ):
-        """
-        Helps constructing the parameters dictionary required for the search.
-
-        Args:
-            data_product_id: Id of the desired UP42 data product, see `catalog.get_data_products`
-            image_id: The id of the desired image (from search results)
-            aoi: The geometry of the order, one of dict, Feature, FeatureCollection,
-                list, GeoDataFrame, Polygon.
-
-        Returns:
-            The constructed parameters dictionary.
-
-        Example:
-            ```python
-            order_parameters=catalog.construct_order_parameters(data_product_id='647780db-5a06-4b61-b525-577a8b68bb54',
-                                                                  image_id='6434e7af-2d41-4ded-a789-fb1b2447ac92',
-                                                                  aoi={'type': 'Polygon',
-                                                                    'coordinates': (((13.375966, 52.515068),
-                                                                      (13.375966, 52.516639),
-                                                                      (13.378314, 52.516639),
-                                                                      (13.378314, 52.515068),
-                                                                      (13.375966, 52.515068)),)})
-            ```
-        """
-        aoi = any_vector_to_fc(vector=aoi)
-        aoi = fc_to_query_geometry(fc=aoi, geometry_operation="intersects")
-        order_parameters = {
-            "dataProduct": data_product_id,
-            "params": {
-                "id": image_id,
-                "aoi": aoi,
-            },
-        }
-        return order_parameters
-
-    def estimate_order(self, order_parameters: Union[dict, None], **kwargs) -> int:
-        """
-        Estimate the cost of an order.
-
-        Args:
-            order_parameters: A dictionary like {dataProduct: ..., "params": {"id": ..., "aoi": ...}}
-
-        Returns:
-            int: An estimated cost for the order in UP42 credits.
-
-        Warning "Deprecated order parameters"
-            The use of the 'scene' and 'geometry' parameters for the data estimation is deprecated. Please use the new
-            order_parameters parameter as described above.
-        """
-        if "scene" in kwargs or "geometry" in kwargs:
-            # Deprecated, to be removed, use order_parameters.
-            message = (
-                "The use of the 'scene' and 'geometry' parameters for the data estimation is deprecated. "
-                "Please use the new 'order_parameters' parameter."
-            )
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-        elif order_parameters is None:
-            raise ValueError("Please provide the 'order_parameters' parameter!")
-        return Order.estimate(self.auth, order_parameters)  # type: ignore
-
-    def place_order(
-        self,
-        order_parameters: Union[dict, None],
-        track_status: bool = False,
-        report_time: int = 120,
-        **kwargs,
-    ) -> "Order":
-        """
-        Place an order.
-
-        Args:
-            order_parameters: A dictionary like {dataProduct: ..., "params": {"id": ..., "aoi": ...}}
-            track_status (bool): If set to True, will only return the Order once it is `FULFILLED` or `FAILED`.
-            report_time (int): The interval (in seconds) to query the order status if `track_status` is True.
-
-        Warning "Deprecated order parameters"
-            The use of the 'scene' and 'geometry' parameters for the data ordering is deprecated. Please use the new
-            order_parameters parameter as described above.
-
-         Warning:
-            When placing orders of items that are in archive or cold storage,
-            the order fulfillment can happen up to **24h after order placement**.
-            In such cases, please make sure to set an appropriate `report_time`.
-            You can also use `Order.track_status` on the returned object to track the status later.
-
-        Returns:
-            Order: The placed order.
-        """
-        if "scene" in kwargs or "geometry" in kwargs:
-            # Deprecated, to be removed, use order_parameters.
-            message = (
-                "The use of the 'scene' and 'geometry' parameters for the data ordering is deprecated. "
-                "Please use the new 'order_parameters' parameter."
-            )
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-        elif order_parameters is None:
-            raise ValueError("Please provide the 'order_parameters' parameter!")
-
-        order = Order.place(self.auth, order_parameters)  # type: ignore
-        if track_status:
-            order.track_status(report_time)
-        return order

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -30,6 +30,7 @@ class CatalogBase:
     """
     The base for Catalog and Tasking class, shared functionality.
     """
+
     def __init__(self, auth: Auth):
         self.auth = auth
         self.type: Union[str, None] = None
@@ -346,8 +347,8 @@ class Catalog(CatalogBase, VizTools):
         else:
             return df.__geo_interface__
 
+    @staticmethod
     def construct_order_parameters(
-        self,
         data_product_id: str,
         image_id: str,
         aoi: Union[
@@ -357,8 +358,7 @@ class Catalog(CatalogBase, VizTools):
             list,
             GeoDataFrame,
             Polygon,
-        ] = None,
-        **kwargs,
+        ],
     ):
         """
         Helps constructing the parameters dictionary required for the catalog order.
@@ -368,58 +368,31 @@ class Catalog(CatalogBase, VizTools):
             image_id: The id of the desired image (from search results)
             aoi: The geometry of the order, one of dict, Feature, FeatureCollection,
                 list, GeoDataFrame, Polygon.
-            kwargs: Any additional required order parameters.
 
         Returns:
             The constructed parameters dictionary.
 
         Example:
             ```python
-            order_parameters = catalog.construct_order_parameters(
-                data_product_id='647780db-5a06-4b61-b525-577a8b68bb54',
-                image_id='6434e7af-2d41-4ded-a789-fb1b2447ac92',
-                aoi={'type': 'Polygon',
-                'coordinates': (((13.375966, 52.515068),
-                  (13.375966, 52.516639),
-                  (13.378314, 52.516639),
-                  (13.378314, 52.515068),
-                  (13.375966, 52.515068)),)})
+            order_parameters=catalog.construct_order_parameters(data_product_id='647780db-5a06-4b61-b525-577a8b68bb54',
+                                                                  image_id='6434e7af-2d41-4ded-a789-fb1b2447ac92',
+                                                                  aoi={'type': 'Polygon',
+                                                                    'coordinates': (((13.375966, 52.515068),
+                                                                      (13.375966, 52.516639),
+                                                                      (13.378314, 52.516639),
+                                                                      (13.378314, 52.515068),
+                                                                      (13.375966, 52.515068)),)})
             ```
         """
+        aoi = any_vector_to_fc(vector=aoi)
+        aoi = fc_to_query_geometry(fc=aoi, geometry_operation="intersects")
         order_parameters = {
             "dataProduct": data_product_id,
-            "params": {"id": image_id, **kwargs},
+            "params": {
+                "id": image_id,
+                "aoi": aoi,
+            },
         }
-        if aoi is not None:
-            aoi = any_vector_to_fc(vector=aoi)
-            aoi = fc_to_query_geometry(fc=aoi, geometry_operation="intersects")
-            order_parameters["params"]["aoi"] = aoi  # type:ignore
-
-        schema = self.get_data_product_schema(data_product_id)
-        required_params = schema["required"]
-        optional_params = list(
-            set(list(schema["properties"].keys())).difference(required_params)
-        )
-        logger.info(
-            f"Order parameters for this data product - Required: {required_params} - Optional: {optional_params}. "
-            f"Also see catalog.get_data_product_schema()"
-        )
-        missing_params = list(
-            set(required_params).difference(order_parameters["params"])
-        )
-        redundant_params = list(
-            set(order_parameters["params"]).difference(
-                required_params + optional_params
-            )
-        )
-
-        if not missing_params and not redundant_params:
-            logger.info("Correct order parameters!")
-        elif missing_params:
-            logger.info(f"Missing order parameters: {missing_params}")
-        else:
-            logger.info(f"Incorrect order parameters: {redundant_params}")
-
         return order_parameters
 
     def download_quicklooks(


### PR DESCRIPTION
Splitting up the tasking PR into easier to review logical steps.

This PR splits up the catalog class into CatalogBase and Catalog (The tasking class later will inherit from CatalogBase). No functionality change.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
