### PR TITLE
Adjust constructor parameters

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -87,12 +87,13 @@ def test_get_data_products_live(catalog_live):
 def test_construct_search_parameters(catalog_mock):
     search_parameters = catalog_mock.construct_search_parameters(
         geometry=mock_search_parameters["intersects"],
+        collections=["phr"],
         start_date="2014-01-01",
         end_date="2016-12-31",
-        collections=["phr"],
+        usage_type=["DATA", "ANALYTICS"],
+        limit=4,
         max_cloudcover=20,
         sortby="cloudCoverage",
-        limit=4,
         ascending=False,
     )
     assert isinstance(search_parameters, dict)

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -3,7 +3,7 @@ Catalog search functionality
 """
 
 from pathlib import Path
-from typing import Union, List, Dict, Any
+from typing import Union, List, Dict, Any, Optional
 import warnings
 
 from geopandas import GeoDataFrame
@@ -356,14 +356,16 @@ class Catalog(CatalogBase, VizTools):
     def construct_order_parameters(
         data_product_id: str,
         image_id: str,
-        aoi: Union[
-            dict,
-            Feature,
-            FeatureCollection,
-            list,
-            GeoDataFrame,
-            Polygon,
-        ],
+        aoi: Optional[
+            Union[
+                dict,
+                Feature,
+                FeatureCollection,
+                list,
+                GeoDataFrame,
+                Polygon,
+            ]
+        ] = None,
     ):
         """
         Helps constructing the parameters dictionary required for the catalog order.
@@ -389,15 +391,16 @@ class Catalog(CatalogBase, VizTools):
                                                                       (13.375966, 52.515068)),)})
             ```
         """
-        aoi = any_vector_to_fc(vector=aoi)
-        aoi = fc_to_query_geometry(fc=aoi, geometry_operation="intersects")
         order_parameters = {
             "dataProduct": data_product_id,
-            "params": {
-                "id": image_id,
-                "aoi": aoi,
-            },
+            "params": {"id": image_id},
         }
+
+        if aoi is not None:
+            aoi = any_vector_to_fc(vector=aoi)
+            aoi = fc_to_query_geometry(fc=aoi, geometry_operation="intersects")
+            order_parameters["params"]["aoi"] = aoi  # type:ignore
+
         return order_parameters
 
     def download_quicklooks(

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -207,7 +207,7 @@ class Catalog(CatalogBase, VizTools):
         end_date: str = "2020-01-30",
         usage_type: List[str] = ["DATA", "ANALYTICS"],
         limit: int = 10,
-        max_cloudcover: float = 100,
+        max_cloudcover: Optional[int] = None,
         sortby: str = "acquisitionDate",
         ascending: bool = True,
     ) -> dict:
@@ -228,8 +228,7 @@ class Catalog(CatalogBase, VizTools):
                 also result in results with ["DATA", "ANALYTICS"].
             limit: The maximum number of search results to return (1-max.500).
             max_cloudcover: Maximum cloudcover % - e.g. 100 will return all scenes,
-                8.4 will return all scenes with 8.4 or less cloudcover.
-                Ignored for collections that have no cloudcover (e.g. sentinel1).
+                8.4 will return all scenes with 8.4 or less cloudcover. Optional.
             sortby: The property to sort by, "cloudCoverage", "acquisitionDate",
                 "acquisitionIdentifier", "incidenceAngle", "snowCover".
             ascending: Ascending sort order by default, descending if False.
@@ -245,7 +244,7 @@ class Catalog(CatalogBase, VizTools):
         sort_order = "asc" if ascending else "desc"
 
         query_filters: Dict[Any, Any] = {}
-        if "Sentinel-1" not in collections:
+        if max_cloudcover is not None:
             query_filters["cloudCoverage"] = {"lte": max_cloudcover}  # type: ignore
 
         if usage_type == ["DATA"]:

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -221,14 +221,14 @@ class Catalog(CatalogBase, VizTools):
                 Also see catalog.get_collections().
             start_date: Query period starting day, format "2020-01-01".
             end_date: Query period ending day, format "2020-01-01".
-            usage_type: Filter for imagery that can just be purchased & downloaded or also
+            usage_type: Optional. Filter for imagery that can just be purchased & downloaded or also
                 processes. ["DATA"] (can only be download), ["ANALYTICS"] (can be downloaded
                 or used directly with a processing algorithm), ["DATA", "ANALYTICS"]
                 (can be any combination). The filter is inclusive, using ["DATA"] can
                 also result in results with ["DATA", "ANALYTICS"].
             limit: The maximum number of search results to return (1-max.500).
-            max_cloudcover: Maximum cloudcover % - e.g. 100 will return all scenes,
-                8.4 will return all scenes with 8.4 or less cloudcover. Optional.
+            max_cloudcover: Optional. Maximum cloudcover % - e.g. 100 will return all scenes,
+                8.4 will return all scenes with 8.4 or less cloudcover.
             sortby: The property to sort by, "cloudCoverage", "acquisitionDate",
                 "acquisitionIdentifier", "incidenceAngle", "snowCover".
             ascending: Ascending sort order by default, descending if False.
@@ -374,7 +374,7 @@ class Catalog(CatalogBase, VizTools):
             data_product_id: Id of the desired UP42 data product, see `catalog.get_data_products`
             image_id: The id of the desired image (from search results)
             aoi: The geometry of the order, one of dict, Feature, FeatureCollection,
-                list, GeoDataFrame, Polygon.
+                list, GeoDataFrame, Polygon. Not required for full-image products.
 
         Returns:
             The constructed parameters dictionary.

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -205,7 +205,7 @@ class Catalog(CatalogBase, VizTools):
         collections: List[str],
         start_date: str = "2020-01-01",
         end_date: str = "2020-01-30",
-        usage_type: List[str] = ["DATA", "ANALYTICS"],
+        usage_type: List[str] = None,
         limit: int = 10,
         max_cloudcover: Optional[int] = None,
         sortby: str = "acquisitionDate",
@@ -247,14 +247,15 @@ class Catalog(CatalogBase, VizTools):
         if max_cloudcover is not None:
             query_filters["cloudCoverage"] = {"lte": max_cloudcover}  # type: ignore
 
-        if usage_type == ["DATA"]:
-            query_filters["up42:usageType"] = {"in": ["DATA"]}
-        elif usage_type == ["ANALYTICS"]:
-            query_filters["up42:usageType"] = {"in": ["ANALYTICS"]}
-        elif usage_type == ["DATA", "ANALYTICS"]:
-            query_filters["up42:usageType"] = {"in": ["DATA", "ANALYTICS"]}
-        else:
-            raise ValueError("Select correct `usage_type`")
+        if usage_type is not None:
+            if usage_type == ["DATA"]:
+                query_filters["up42:usageType"] = {"in": ["DATA"]}
+            elif usage_type == ["ANALYTICS"]:
+                query_filters["up42:usageType"] = {"in": ["ANALYTICS"]}
+            elif usage_type == ["DATA", "ANALYTICS"]:
+                query_filters["up42:usageType"] = {"in": ["DATA", "ANALYTICS"]}
+            else:
+                raise ValueError("Select correct `usage_type`")
 
         search_parameters = {
             "datetime": time_period,


### PR DESCRIPTION
Some new collections (Capella) require different parameter definitions, this PR adjusts the construct_parameter functions for search and ordering to have more parameters as optional.

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
