### PR TITLE
Quicklooks download generic collection support

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -426,7 +426,7 @@ def test_download_quicklook_live(catalog_live):
     with tempfile.TemporaryDirectory() as tempdir:
         out_paths = catalog_live.download_quicklooks(
             image_ids=["36f52f1f-6de1-4079-b116-5d1215091339"],
-            sensor="pleiades",
+            collection="phr",
             output_directory=tempdir,
         )
         assert len(out_paths) == 1

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -364,16 +364,16 @@ def test_search_catalog_pagination_exhausted(catalog_pagination_mock):
 
 def test_download_quicklook(catalog_mock, requests_mock):
     sel_id = "6dffb8be-c2ab-46e3-9c1c-6958a54e4527"
-    provider = "oneatlas"
+    host = "oneatlas"
     url_quicklooks = (
-        f"{catalog_mock.auth._endpoint()}/catalog/{provider}/image/{sel_id}/quicklook"
+        f"{catalog_mock.auth._endpoint()}/catalog/{host}/image/{sel_id}/quicklook"
     )
     quicklook_file = Path(__file__).resolve().parent / "mock_data/a_quicklook.png"
     requests_mock.get(url_quicklooks, content=open(quicklook_file, "rb").read())
 
     with tempfile.TemporaryDirectory() as tempdir:
         out_paths = catalog_mock.download_quicklooks(
-            image_ids=[sel_id], sensor="pleiades", output_directory=tempdir
+            image_ids=[sel_id], collection="phr", output_directory=tempdir
         )
         assert len(out_paths) == 1
         assert Path(out_paths[0]).exists()
@@ -382,15 +382,15 @@ def test_download_quicklook(catalog_mock, requests_mock):
 
 def test_download_no_quicklook(catalog_mock, requests_mock):
     sel_id = "dfc54412-8b9c-45a3-b46a-dd030a47c2f3"
-    provider = "oneatlas"
+    host = "oneatlas"
     url_quicklook = (
-        f"{catalog_mock.auth._endpoint()}/catalog/{provider}/image/{sel_id}/quicklook"
+        f"{catalog_mock.auth._endpoint()}/catalog/{host}/image/{sel_id}/quicklook"
     )
     requests_mock.get(url_quicklook, status_code=404)
 
     with tempfile.TemporaryDirectory() as tempdir:
         out_paths = catalog_mock.download_quicklooks(
-            image_ids=[sel_id], sensor="pleiades", output_directory=tempdir
+            image_ids=[sel_id], collection="phr", output_directory=tempdir
         )
         assert len(out_paths) == 0
 
@@ -398,12 +398,14 @@ def test_download_no_quicklook(catalog_mock, requests_mock):
 def test_download_1_quicklook_1_no_quicklook(catalog_mock, requests_mock):
     sel_id_no = "dfc54412-8b9c-45a3-b46a-dd030a47c2f3"
     sel_id = "6dffb8be-c2ab-46e3-9c1c-6958a54e4527"
-    provider = "oneatlas"
-    url_no_quicklook = f"{catalog_mock.auth._endpoint()}/catalog/{provider}/image/{sel_id_no}/quicklook"
+    host = "oneatlas"
+    url_no_quicklook = (
+        f"{catalog_mock.auth._endpoint()}/catalog/{host}/image/{sel_id_no}/quicklook"
+    )
     requests_mock.get(url_no_quicklook, status_code=404)
 
     url_quicklook = (
-        f"{catalog_mock.auth._endpoint()}/catalog/{provider}/image/{sel_id}/quicklook"
+        f"{catalog_mock.auth._endpoint()}/catalog/{host}/image/{sel_id}/quicklook"
     )
     quicklook_file = Path(__file__).resolve().parent / "mock_data/a_quicklook.png"
     requests_mock.get(url_quicklook, content=open(quicklook_file, "rb").read())
@@ -411,7 +413,7 @@ def test_download_1_quicklook_1_no_quicklook(catalog_mock, requests_mock):
     with tempfile.TemporaryDirectory() as tempdir:
         out_paths = catalog_mock.download_quicklooks(
             image_ids=[sel_id, sel_id_no],
-            sensor="pleiades",
+            collection="phr",
             output_directory=tempdir,
         )
         assert len(out_paths) == 1

--- a/tests/test_e2e_catalog.py
+++ b/tests/test_e2e_catalog.py
@@ -25,9 +25,7 @@ def test_e2e_catalog():
         limit=10,
     )
     search_results = catalog.search(search_parameters=search_parameters)
-    catalog.download_quicklooks(
-        image_ids=search_results.id.to_list(), sensor="pleiades"
-    )
+    catalog.download_quicklooks(image_ids=search_results.id.to_list(), collection="phr")
 
 
 if __name__ == "__main__":

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -414,7 +414,6 @@ class Catalog(CatalogBase, VizTools):
         image_ids: List[str],
         collection: str,
         output_directory: Union[str, Path, None] = None,
-        **kwargs
     ) -> List[str]:
         """
         Gets the quicklooks of scenes from a single sensor. After download, can
@@ -430,10 +429,6 @@ class Catalog(CatalogBase, VizTools):
         Returns:
             List of quicklook image output file paths.
         """
-        #TODO: WHAT IF COLLECTION DOESNT HAVE QUICKLOOKS?
-        if "sensor" in kwargs:
-            logger.info("Parameter `sensor` will be deprecated, use the `collection` name instead.")
-
         if self.data_products is None:
             self.data_products = self.get_data_products(basic=True)  # type: ignore
         host = [


### PR DESCRIPTION
- Removes hardcoding of sensors supported for quicklooks_download
- Changes parameter sensor to collection (breaking change)

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
