### PR TITLE
remove upper version requirement of Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
     ],
-    python_requires=">=3.7, <=3.10",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
remove upper version requirement of Python

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
