### PR TITLE
Initalization restructure

### DIFF
--- a/docs/macros.py
+++ b/docs/macros.py
@@ -54,7 +54,7 @@ def define_env(env):
 
         if exclude_viztools:
             function_methods = [
-                f for f in function_methods if f not in dir(up42.VizTools)
+                f for f in function_methods if f not in dir(up42.viztools.VizTools)
             ]
         if exclude:
             function_methods = [f for f in function_methods if f not in exclude]
@@ -79,28 +79,30 @@ def define_env(env):
     # (In code reference added automatically by mkdocstrings).
     # Every class requires a docstring, otherwise mkdocs fails!
     env.variables.docstring_up42 = indent(up42.__doc__)  # init module docstring
-    env.variables.docstring_project = indent(up42.Project.__doc__)
-    env.variables.docstring_workflow = indent(up42.Workflow.__doc__)
-    env.variables.docstring_job = indent(up42.Job.__doc__)
-    env.variables.docstring_jobtask = indent(up42.JobTask.__doc__)
-    env.variables.docstring_jobcollection = indent(up42.JobCollection.__doc__)
-    env.variables.docstring_catalog = indent(up42.Catalog.__doc__)
-    env.variables.docstring_tasking = indent(up42.Tasking.__doc__)
-    env.variables.docstring_order = indent(up42.Order.__doc__)
-    env.variables.docstring_storage = indent(up42.Storage.__doc__)
-    env.variables.docstring_asset = indent(up42.Asset.__doc__)
-    env.variables.docstring_webhooks = indent(up42.Webhooks.__doc__)
+    env.variables.docstring_project = indent(up42.project.Project.__doc__)
+    env.variables.docstring_workflow = indent(up42.workflow.Workflow.__doc__)
+    env.variables.docstring_job = indent(up42.job.Job.__doc__)
+    env.variables.docstring_jobtask = indent(up42.jobtask.JobTask.__doc__)
+    env.variables.docstring_jobcollection = indent(
+        up42.jobcollection.JobCollection.__doc__
+    )
+    env.variables.docstring_catalog = indent(up42.catalog.Catalog.__doc__)
+    env.variables.docstring_tasking = indent(up42.tasking.Tasking.__doc__)
+    env.variables.docstring_order = indent(up42.order.Order.__doc__)
+    env.variables.docstring_storage = indent(up42.storage.Storage.__doc__)
+    env.variables.docstring_asset = indent(up42.asset.Asset.__doc__)
+    env.variables.docstring_webhooks = indent(up42.webhooks.Webhooks.__doc__)
 
     # Class functions for reference and structure chapter
     env.variables.funcs_up42 = get_methods(up42, exclude_viztools=True)
-    env.variables.funcs_project = get_methods(up42.Project)
-    env.variables.funcs_workflow = get_methods(up42.Workflow)
-    env.variables.funcs_job = get_methods(up42.Job)
+    env.variables.funcs_project = get_methods(up42.project.Project)
+    env.variables.funcs_workflow = get_methods(up42.workflow.Workflow)
+    env.variables.funcs_job = get_methods(up42.job.Job)
     env.variables.funcs_jobtask = get_methods(
-        up42.JobTask, exclude=["map_quicklooks", "plot_coverage"]
+        up42.jobtask.JobTask, exclude=["map_quicklooks", "plot_coverage"]
     )
     env.variables.funcs_jobcollection = get_methods(
-        up42.JobCollection,
+        up42.jobcollection.JobCollection,
         exclude=[
             "plot_quicklooks",
             "map_quicklooks",
@@ -108,11 +110,11 @@ def define_env(env):
         ],
     )
     env.variables.funcs_catalog = get_methods(
-        up42.Catalog, exclude=["plot_results", "map_results"]
+        up42.catalog.Catalog, exclude=["plot_results", "map_results"]
     )
-    env.variables.funcs_tasking = get_methods(up42.Tasking)
-    env.variables.funcs_order = get_methods(up42.Order)
-    env.variables.funcs_storage = get_methods(up42.Storage)
-    env.variables.funcs_asset = get_methods(up42.Asset)
-    env.variables.funcs_webhooks = get_methods(up42.Webhooks)
-    env.variables.funcs_webhook = get_methods(up42.Webhook)
+    env.variables.funcs_tasking = get_methods(up42.tasking.Tasking)
+    env.variables.funcs_order = get_methods(up42.order.Order)
+    env.variables.funcs_storage = get_methods(up42.storage.Storage)
+    env.variables.funcs_asset = get_methods(up42.asset.Asset)
+    env.variables.funcs_webhooks = get_methods(up42.webhooks.Webhooks)
+    env.variables.funcs_webhook = get_methods(up42.webhooks.Webhook)

--- a/docs/reference/up42-reference.md
+++ b/docs/reference/up42-reference.md
@@ -5,8 +5,28 @@
         show_root_toc_entry: False
         show_if_no_docstring: False
         group_by_category: False
-        
-::: up42.tools.Tools
+
+::: up42.main
+    selection:
+        members:
+            - "authenticate"
+    rendering:
+       show_root_toc_entry: False
+       show_if_no_docstring: False
+       group_by_category: False
+
+::: up42.initialization
     rendering:
         show_root_toc_entry: False
+        show_if_no_docstring: False
+        group_by_category: False
+
+::: up42.main
+    selection:
+        filters:
+            - "!authenticate"
+            - "!^_"
+    rendering:
+        show_root_toc_entry: False
+        show_if_no_docstring: False
         group_by_category: False

--- a/tests/context.py
+++ b/tests/context.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../u
 
 # Import the required classes and functions
 # pylint: disable=unused-import,wrong-import-position
-from up42.tools import Tools
+from up42.tools import read_vector_file, get_example_aoi
 from up42.viztools import folium_base_map, VizTools
 from up42.utils import (
     format_time_period,
@@ -29,14 +29,29 @@ from up42.storage import Storage
 from up42.asset import Asset
 from up42.order import Order
 from up42.webhooks import Webhooks, Webhook
-from up42.__init__ import (
+from up42 import main
+from up42.main import (
     authenticate,
+    get_webhooks,
+    create_webhook,
+    get_webhook_events,
+    get_blocks,
+    get_block_details,
+    get_block_coverage,
+    get_credits_balance,
+    get_credits_history,
+    validate_manifest,
+)
+from up42.initialization import (
     initialize_project,
     initialize_catalog,
+    initialize_tasking,
     initialize_workflow,
     initialize_job,
     initialize_jobtask,
+    initialize_jobcollection,
     initialize_storage,
     initialize_order,
     initialize_asset,
+    initialize_webhook,
 )

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -9,7 +9,7 @@ from .fixtures_jobtask import *
 from .fixtures_order import *
 from .fixtures_project import *
 from .fixtures_storage import *
-from .fixtures_tools import *
+from .fixtures_main import *
 from .fixtures_webhook import *
 from .fixtures_workflow import *
 from .fixtures_globals import *

--- a/tests/fixtures/fixtures_main.py
+++ b/tests/fixtures/fixtures_main.py
@@ -4,20 +4,6 @@ import copy
 
 import pytest
 
-from ..context import (
-    Tools,
-)
-
-
-@pytest.fixture()
-def tools_mock(auth_mock):
-    return Tools(auth=auth_mock)
-
-
-@pytest.fixture()
-def tools_live(auth_live):
-    return Tools(auth=auth_live)
-
 
 @pytest.fixture()
 def credits_history_mock(auth_mock, requests_mock):
@@ -31,7 +17,7 @@ def credits_history_mock(auth_mock, requests_mock):
         url=url_get_credits_history,
         json=response_json,
     )
-    return Tools(auth=auth_mock)
+    return auth_mock
 
 
 @pytest.fixture()
@@ -64,4 +50,4 @@ def credits_history_pagination_mock(auth_mock, requests_mock):
         url=url_get_credits_history_size_last,
         json=pagination_response_json_last,
     )
-    return Tools(auth=auth_mock)
+    return auth_mock

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -2,15 +2,24 @@ import pytest
 
 # pylint: disable=unused-import
 from .context import (
-    authenticate,
     initialize_project,
     initialize_catalog,
     initialize_workflow,
     initialize_job,
     initialize_jobtask,
+    initialize_jobcollection,
     initialize_storage,
     initialize_order,
     initialize_asset,
+    Project,
+    Catalog,
+    Workflow,
+    Job,
+    JobTask,
+    JobCollection,
+    Storage,
+    Order,
+    Asset,
 )
 from .fixtures import (
     PROJECT_ID,
@@ -35,23 +44,23 @@ import up42  # pylint: disable=wrong-import-order
 
 def test_initialize_object_without_auth_raises():
     with pytest.raises(RuntimeError):
-        up42.initialize_project()
+        initialize_project()
     with pytest.raises(RuntimeError):
-        up42.initialize_catalog()
+        initialize_catalog()
     with pytest.raises(RuntimeError):
-        up42.initialize_workflow(workflow_id=WORKFLOW_ID)
+        initialize_workflow(workflow_id=WORKFLOW_ID)
     with pytest.raises(RuntimeError):
-        up42.initialize_job(job_id=JOB_ID)
+        initialize_job(job_id=JOB_ID)
     with pytest.raises(RuntimeError):
-        up42.initialize_jobtask(job_id=JOB_ID, jobtask_id=JOBTASK_ID)
+        initialize_jobtask(job_id=JOB_ID, jobtask_id=JOBTASK_ID)
     with pytest.raises(RuntimeError):
-        up42.initialize_jobcollection(job_ids=[JOB_ID, JOB_ID])
+        initialize_jobcollection(job_ids=[JOB_ID, JOB_ID])
     with pytest.raises(RuntimeError):
-        up42.initialize_storage()
+        initialize_storage()
     with pytest.raises(RuntimeError):
-        up42.initialize_order(order_id=ORDER_ID)
+        initialize_order(order_id=ORDER_ID)
     with pytest.raises(RuntimeError):
-        up42.initialize_asset(asset_id=ASSET_ID)
+        initialize_asset(asset_id=ASSET_ID)
 
 
 # pylint: disable=unused-argument
@@ -73,21 +82,21 @@ def test_global_auth_initialize_objects(
         get_info=False,
         retry=False,
     )
-    project = up42.initialize_project()
-    assert isinstance(project, up42.Project)
-    catalog = up42.initialize_catalog()
-    assert isinstance(catalog, up42.Catalog)
-    workflow = up42.initialize_workflow(workflow_id=WORKFLOW_ID)
-    assert isinstance(workflow, up42.Workflow)
-    job = up42.initialize_job(job_id=JOB_ID)
-    assert isinstance(job, up42.Job)
-    jobtask = up42.initialize_jobtask(job_id=JOB_ID, jobtask_id=JOBTASK_ID)
-    assert isinstance(jobtask, up42.JobTask)
-    jobcollection = up42.initialize_jobcollection(job_ids=[JOB_ID, JOB_ID])
-    assert isinstance(jobcollection, up42.JobCollection)
-    storage = up42.initialize_storage()
-    assert isinstance(storage, up42.Storage)
-    order = up42.initialize_order(order_id=ORDER_ID)
-    assert isinstance(order, up42.Order)
-    asset = up42.initialize_asset(asset_id=ASSET_ID)
-    assert isinstance(asset, up42.Asset)
+    project = initialize_project()
+    assert isinstance(project, Project)
+    catalog = initialize_catalog()
+    assert isinstance(catalog, Catalog)
+    workflow = initialize_workflow(workflow_id=WORKFLOW_ID)
+    assert isinstance(workflow, Workflow)
+    job = initialize_job(job_id=JOB_ID)
+    assert isinstance(job, Job)
+    jobtask = initialize_jobtask(job_id=JOB_ID, jobtask_id=JOBTASK_ID)
+    assert isinstance(jobtask, JobTask)
+    jobcollection = initialize_jobcollection(job_ids=[JOB_ID, JOB_ID])
+    assert isinstance(jobcollection, JobCollection)
+    storage = initialize_storage()
+    assert isinstance(storage, Storage)
+    order = initialize_order(order_id=ORDER_ID)
+    assert isinstance(order, Order)
+    asset = initialize_asset(asset_id=ASSET_ID)
+    assert isinstance(asset, Asset)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,258 @@
+import json
+from pathlib import Path
+
+import pytest
+import pandas as pd
+import requests
+
+# pylint: disable=unused-import
+from .fixtures import (
+    auth_mock,
+    auth_live,
+    credits_history_mock,
+    credits_history_pagination_mock,
+)
+from .context import (
+    main,
+    get_blocks,
+    get_block_details,
+    get_block_coverage,
+    get_credits_balance,
+    get_credits_history,
+    validate_manifest,
+)
+
+
+def test_get_blocks(auth_mock, requests_mock, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_mock)
+    url_get_blocks = f"{auth_mock._endpoint()}/blocks"
+    requests_mock.get(
+        url=url_get_blocks,
+        json={
+            "data": [
+                {"id": "789-2736-212", "name": "tiling"},
+                {"id": "789-2736-212", "name": "sharpening"},
+            ],
+            "error": {},
+        },
+    )
+    blocks = get_blocks()
+    assert isinstance(blocks, dict)
+    assert "tiling" in list(blocks.keys())
+
+
+@pytest.mark.live
+def test_get_blocks_live(auth_live, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_live)
+    blocks = get_blocks(basic=False)
+    assert isinstance(blocks, list)
+    blocknames = [block["name"] for block in blocks]
+    assert "tiling" in blocknames
+
+
+def test_get_blocks_not_basic_dataframe(auth_mock, requests_mock, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_mock)
+    url_get_blocks = f"{auth_mock._endpoint()}/blocks"
+    json_get_blocks = {
+        "data": [
+            {"id": "789-2736-212", "name": "tiling"},
+            {"id": "789-2736-212", "name": "sharpening"},
+        ],
+        "error": {},
+    }
+    requests_mock.get(url=url_get_blocks, json=json_get_blocks)
+
+    blocks_df = get_blocks(basic=False, as_dataframe=True)
+    assert isinstance(blocks_df, pd.DataFrame)
+    assert "tiling" in blocks_df["name"].to_list()
+
+
+def test_get_block_details(auth_mock, requests_mock, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_mock)
+    block_id = "273612-13"
+    url_get_blocks_details = f"{auth_mock._endpoint()}/blocks/{block_id}"
+    requests_mock.get(
+        url=url_get_blocks_details,
+        json={
+            "data": {"id": "273612-13", "name": "tiling", "createdAt": "123"},
+            "error": {},
+        },
+    )
+    details = get_block_details(block_id=block_id)
+    assert isinstance(details, dict)
+    assert details["id"] == block_id
+    assert "createdAt" in details
+
+
+@pytest.mark.live
+def test_get_block_details_live(auth_live, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_live)
+    tiling_id = "3e146dd6-2b67-4d6e-a422-bb3d973e32ff"
+
+    details = get_block_details(block_id=tiling_id)
+    assert isinstance(details, dict)
+    assert details["id"] == tiling_id
+    assert "createdAt" in details
+
+
+def test_get_block_coverage(auth_mock, requests_mock, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_mock)
+    block_id = "273612-13"
+    url_get_blocks_coverage = f"{auth_mock._endpoint()}/blocks/{block_id}/coverage"
+    requests_mock.get(
+        url=url_get_blocks_coverage,
+        json={
+            "data": {
+                "url": "https://storage.googleapis.com/coverage-area-interstellar-prod/coverage.json"
+            },
+            "error": {},
+        },
+    )
+    url_geojson_response = (
+        "https://storage.googleapis.com/coverage-area-interstellar-prod/coverage.json"
+    )
+    requests_mock.get(
+        url=url_geojson_response,
+        json={
+            "type": "FeatureCollection",
+            "name": "bundle6m",
+            "crs": {
+                "type": "name",
+                "properties": {"name": "urn:ogc:def:crs:OGC:1.3:CRS84"},
+            },
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": {"type": "MultiPolygon", "coordinates": []},
+                }
+            ],
+        },
+    )
+    coverage = get_block_coverage(block_id=block_id)
+    assert isinstance(coverage, dict)
+    assert "features" in coverage
+
+
+@pytest.mark.live
+def test_get_block_coverage_live(auth_live, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_live)
+    block_id = "625fd923-8ae6-4ac3-8e13-f51d3c977222"
+    coverage = get_block_coverage(block_id=block_id)
+    assert isinstance(coverage, dict)
+    assert "features" in coverage
+
+
+@pytest.mark.live
+def test_get_block_coverage_noresults_live(auth_live, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_live)
+    # pylint: disable=unused-variable
+    try:
+        block_id = "045019bb-06fc-4fa1-b703-318725b4d8af"
+        coverage = get_block_coverage(block_id=block_id)
+    except requests.exceptions.RequestException as err:
+        assert True
+        return
+    assert False
+
+
+def test_get_credits_balance(auth_mock, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_mock)
+    balance = get_credits_balance()
+    assert isinstance(balance, dict)
+    assert "balance" in balance
+
+
+@pytest.mark.live
+def test_get_credits_balance_live(auth_live, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_live)
+    balance = get_credits_balance()
+    assert isinstance(balance, dict)
+    assert "balance" in balance
+
+
+def test_get_credits_history(credits_history_mock, monkeypatch):
+    monkeypatch.setattr(main, "_auth", credits_history_mock)
+    credits_history = get_credits_history()
+    assert isinstance(credits_history, dict)
+    assert "content" in credits_history
+    assert isinstance(credits_history["content"], list)
+    assert len(credits_history["content"]) == 10
+
+
+def test_get_credits_history_pagination(credits_history_pagination_mock, monkeypatch):
+    monkeypatch.setattr(main, "_auth", credits_history_pagination_mock)
+    credits_history = get_credits_history()
+    assert isinstance(credits_history, dict)
+    assert "content" in credits_history
+    assert isinstance(credits_history["content"], list)
+    assert len(credits_history["content"]) == 2500
+
+
+@pytest.mark.parametrize(
+    "start_date,end_date",
+    [(None, "2014-01-01"), ("2014-01-01", None)],
+)
+def test_get_credits_history_no_bounds(
+    credits_history_mock, start_date, end_date, monkeypatch
+):
+    monkeypatch.setattr(main, "_auth", credits_history_mock)
+    balance_history_no_enddate = get_credits_history(start_date=start_date)
+    assert isinstance(balance_history_no_enddate, dict)
+    assert "content" in balance_history_no_enddate
+    assert isinstance(balance_history_no_enddate["content"], list)
+    balance_history_no_startdate = get_credits_history(end_date=end_date)
+    assert isinstance(balance_history_no_startdate, dict)
+    assert "content" in balance_history_no_startdate
+    assert isinstance(balance_history_no_startdate["content"], list)
+
+
+@pytest.mark.live
+def test_get_credits_history_live(auth_live, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_live)
+    balance_history = get_credits_history(
+        start_date="2022-03-01", end_date="2022-03-02"
+    )
+    assert isinstance(balance_history, dict)
+    assert "content" in balance_history
+    assert len(balance_history["content"]) == 32
+    assert isinstance(balance_history["content"], list)
+
+
+def test_validate_manifest(auth_mock, requests_mock, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_mock)
+    fp = Path(__file__).resolve().parent / "mock_data/manifest.json"
+    url_validate_mainfest = f"{auth_mock._endpoint()}/validate-schema/block"
+    requests_mock.post(
+        url=url_validate_mainfest,
+        json={"data": {"valid": True, "errors": []}, "error": {}},
+    )
+
+    result = validate_manifest(path_or_json=fp)
+    assert result == {"valid": True, "errors": []}
+
+
+@pytest.mark.live
+def test_validate_manifest_valid_live(auth_live, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_live)
+    fp = Path(__file__).resolve().parent / "mock_data/manifest.json"
+    result = validate_manifest(path_or_json=fp)
+    assert result == {"valid": True, "errors": []}
+
+
+@pytest.mark.live
+def test_validate_manifest_invalid_live(auth_live, monkeypatch):
+    monkeypatch.setattr(main, "_auth", auth_live)
+    fp = Path(__file__).resolve().parent / "mock_data/manifest.json"
+    with open(fp) as src:
+        mainfest_json = json.load(src)
+        mainfest_json.update(
+            {
+                "_up42_specification_version": 1,
+                "input_capabilities": {
+                    "invalidtype": {"up42_standard": {"format": "GTiff"}}
+                },
+            }
+        )
+    with pytest.raises(requests.exceptions.RequestException):
+        validate_manifest(path_or_json=mainfest_json)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,261 +1,27 @@
-import json
 from pathlib import Path
 
 import pytest
 import geopandas as gpd
-import pandas as pd
-import requests
 
-# pylint: disable=unused-import
-from .fixtures import (
-    auth_mock,
-    tools_mock,
-    auth_live,
-    tools_live,
-    credits_history_mock,
-    credits_history_pagination_mock,
-)
-from .context import Tools
+from .context import read_vector_file, get_example_aoi
 
 
 @pytest.mark.parametrize("vector_format", ["geojson", "kml", "wkt"])
-def test_read_vector_file_different_formats(tools_mock, vector_format):
+def test_read_vector_file_different_formats(vector_format):
     fp = Path(__file__).resolve().parent / f"mock_data/aoi_berlin.{vector_format}"
-    fc = tools_mock.read_vector_file(filename=fp)
+    fc = read_vector_file(filename=fp)
     assert isinstance(fc, dict)
     assert fc["type"] == "FeatureCollection"
 
 
-def test_read_vector_file_as_df(tools_mock):
+def test_read_vector_file_as_df():
     fp = Path(__file__).resolve().parent / "mock_data/aoi_berlin.geojson"
-    df = tools_mock.read_vector_file(filename=fp, as_dataframe=True)
+    df = read_vector_file(filename=fp, as_dataframe=True)
     assert isinstance(df, gpd.GeoDataFrame)
     assert df.crs.to_epsg() == 4326
 
 
-def test_get_example_aoi(tools_mock):
-    fc = tools_mock.get_example_aoi("Berlin")
+def test_get_example_aoi():
+    fc = get_example_aoi("Berlin")
     assert isinstance(fc, dict)
     assert fc["type"] == "FeatureCollection"
-
-
-def test_get_blocks(tools_mock, requests_mock):
-    url_get_blocks = f"{tools_mock.auth._endpoint()}/blocks"
-    requests_mock.get(
-        url=url_get_blocks,
-        json={
-            "data": [
-                {"id": "789-2736-212", "name": "tiling"},
-                {"id": "789-2736-212", "name": "sharpening"},
-            ],
-            "error": {},
-        },
-    )
-    blocks = tools_mock.get_blocks()
-    assert isinstance(blocks, dict)
-    assert "tiling" in list(blocks.keys())
-
-
-@pytest.mark.live
-def test_get_blocks_live(tools_live):
-    blocks = tools_live.get_blocks(basic=False)
-    assert isinstance(blocks, list)
-    blocknames = [block["name"] for block in blocks]
-    assert "tiling" in blocknames
-
-
-def test_get_blocks_not_basic_dataframe(tools_mock, requests_mock):
-    url_get_blocks = f"{tools_mock.auth._endpoint()}/blocks"
-    json_get_blocks = {
-        "data": [
-            {"id": "789-2736-212", "name": "tiling"},
-            {"id": "789-2736-212", "name": "sharpening"},
-        ],
-        "error": {},
-    }
-    requests_mock.get(url=url_get_blocks, json=json_get_blocks)
-
-    blocks_df = tools_mock.get_blocks(basic=False, as_dataframe=True)
-    assert isinstance(blocks_df, pd.DataFrame)
-    assert "tiling" in blocks_df["name"].to_list()
-
-
-def test_get_block_details(tools_mock, requests_mock):
-    block_id = "273612-13"
-    url_get_blocks_details = f"{tools_mock.auth._endpoint()}/blocks/{block_id}"
-    requests_mock.get(
-        url=url_get_blocks_details,
-        json={
-            "data": {"id": "273612-13", "name": "tiling", "createdAt": "123"},
-            "error": {},
-        },
-    )
-    details = tools_mock.get_block_details(block_id=block_id)
-    assert isinstance(details, dict)
-    assert details["id"] == block_id
-    assert "createdAt" in details
-
-
-@pytest.mark.live
-def test_get_block_details_live(tools_live):
-    tiling_id = "3e146dd6-2b67-4d6e-a422-bb3d973e32ff"
-
-    details = tools_live.get_block_details(block_id=tiling_id)
-    assert isinstance(details, dict)
-    assert details["id"] == tiling_id
-    assert "createdAt" in details
-
-
-def test_get_block_coverage(tools_mock, requests_mock):
-    block_id = "273612-13"
-    url_get_blocks_coverage = (
-        f"{tools_mock.auth._endpoint()}/blocks/{block_id}/coverage"
-    )
-    requests_mock.get(
-        url=url_get_blocks_coverage,
-        json={
-            "data": {
-                "url": "https://storage.googleapis.com/coverage-area-interstellar-prod/coverage.json"
-            },
-            "error": {},
-        },
-    )
-    url_geojson_response = (
-        "https://storage.googleapis.com/coverage-area-interstellar-prod/coverage.json"
-    )
-    requests_mock.get(
-        url=url_geojson_response,
-        json={
-            "type": "FeatureCollection",
-            "name": "bundle6m",
-            "crs": {
-                "type": "name",
-                "properties": {"name": "urn:ogc:def:crs:OGC:1.3:CRS84"},
-            },
-            "features": [
-                {
-                    "type": "Feature",
-                    "properties": {},
-                    "geometry": {"type": "MultiPolygon", "coordinates": []},
-                }
-            ],
-        },
-    )
-    coverage = tools_mock.get_block_coverage(block_id=block_id)
-    assert isinstance(coverage, dict)
-    assert "features" in coverage
-
-
-@pytest.mark.live
-def test_get_block_coverage_live(tools_live):
-    block_id = "625fd923-8ae6-4ac3-8e13-f51d3c977222"
-    coverage = tools_live.get_block_coverage(block_id=block_id)
-    assert isinstance(coverage, dict)
-    assert "features" in coverage
-
-
-@pytest.mark.live
-def test_get_block_coverage_noresults_live(tools_live):
-    # pylint: disable=unused-variable
-    try:
-        block_id = "045019bb-06fc-4fa1-b703-318725b4d8af"
-        coverage = tools_live.get_block_coverage(block_id=block_id)
-    except requests.exceptions.RequestException as err:
-        assert True
-        return
-    assert False
-
-
-def test_get_credits_balance(tools_mock):
-    balance = tools_mock.get_credits_balance()
-    assert isinstance(balance, dict)
-    assert "balance" in balance
-
-
-@pytest.mark.live
-def test_get_credits_balance_live(tools_live):
-    balance = tools_live.get_credits_balance()
-    assert isinstance(balance, dict)
-    assert "balance" in balance
-
-
-def test_get_credits_history(credits_history_mock):
-    credits_history = credits_history_mock.get_credits_history()
-    assert isinstance(credits_history, dict)
-    assert "content" in credits_history
-    assert isinstance(credits_history["content"], list)
-    assert len(credits_history["content"]) == 10
-
-
-def test_get_credits_history_pagination(credits_history_pagination_mock):
-    credits_history = credits_history_pagination_mock.get_credits_history()
-    assert isinstance(credits_history, dict)
-    assert "content" in credits_history
-    assert isinstance(credits_history["content"], list)
-    assert len(credits_history["content"]) == 2500
-
-
-@pytest.mark.parametrize(
-    "start_date,end_date",
-    [(None, "2014-01-01"), ("2014-01-01", None)],
-)
-def test_get_credits_history_no_bounds(credits_history_mock, start_date, end_date):
-    balance_history_no_enddate = credits_history_mock.get_credits_history(
-        start_date=start_date
-    )
-    assert isinstance(balance_history_no_enddate, dict)
-    assert "content" in balance_history_no_enddate
-    assert isinstance(balance_history_no_enddate["content"], list)
-    balance_history_no_startdate = credits_history_mock.get_credits_history(
-        end_date=end_date
-    )
-    assert isinstance(balance_history_no_startdate, dict)
-    assert "content" in balance_history_no_startdate
-    assert isinstance(balance_history_no_startdate["content"], list)
-
-
-@pytest.mark.live
-def test_get_credits_history_live(tools_live):
-    balance_history = tools_live.get_credits_history(
-        start_date="2022-03-01", end_date="2022-03-02"
-    )
-    assert isinstance(balance_history, dict)
-    assert "content" in balance_history
-    assert len(balance_history["content"]) == 32
-    assert isinstance(balance_history["content"], list)
-
-
-def test_validate_manifest(tools_mock, requests_mock):
-    fp = Path(__file__).resolve().parent / "mock_data/manifest.json"
-    url_validate_mainfest = f"{tools_mock.auth._endpoint()}/validate-schema/block"
-    requests_mock.post(
-        url=url_validate_mainfest,
-        json={"data": {"valid": True, "errors": []}, "error": {}},
-    )
-
-    result = tools_mock.validate_manifest(path_or_json=fp)
-    assert result == {"valid": True, "errors": []}
-
-
-@pytest.mark.live
-def test_validate_manifest_valid_live(tools_live):
-    fp = Path(__file__).resolve().parent / "mock_data/manifest.json"
-    result = tools_live.validate_manifest(path_or_json=fp)
-    assert result == {"valid": True, "errors": []}
-
-
-@pytest.mark.live
-def test_validate_manifest_invalid_live(tools_live):
-    fp = Path(__file__).resolve().parent / "mock_data/manifest.json"
-    with open(fp) as src:
-        mainfest_json = json.load(src)
-        mainfest_json.update(
-            {
-                "_up42_specification_version": 1,
-                "input_capabilities": {
-                    "invalidtype": {"up42_standard": {"format": "GTiff"}}
-                },
-            }
-        )
-    with pytest.raises(requests.exceptions.RequestException):
-        tools_live.validate_manifest(path_or_json=mainfest_json)

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -1,27 +1,35 @@
 """
     `up42` is the base library module imported to Python. It provides the elementary
-    functionality that is not bound to a specific class of the UP42 structure (Project > Workflow > Job etc.).
-    From `up42` you can initialize other existing objects, get information about UP42 data &
-    processing blocks, read or draw vector data, and adjust the SDK settings.
+    functionality that is not bound to a specific class of the UP42 structure.
+    From `up42` you can also initialize other classes, e.g. for using the catalog, storage etc.
 
     To import the UP42 library:
     ```python
     import up42
     ```
+
+    Authenticate with UP42 via
+    ```python
+    up42.authenticate(
+        project_id="your-project-ID",
+        project_api_key="your-project-API-key"
+    )
+    ```
+
+    To initialize any lower level functionality use e.g.
+    ```python
+    catalog = up42.initialize_catalog()
+    ```
+    ```python
+    project = up42.initialize_project()
+    ```
 """
 
-import warnings
-from pathlib import Path
-from typing import Union, Tuple, List, Optional, Dict
-import logging
-from datetime import datetime
-from functools import wraps
+from up42.main import *  # defined by __all__
+from up42.initialization import *  # defined by __all__
+from up42.tools import read_vector_file, get_example_aoi
+from up42.viztools import draw_aoi
 
-from geopandas import GeoDataFrame
-
-# pylint: disable=wrong-import-position
-from up42.tools import Tools
-from up42.viztools import VizTools
 from up42.auth import Auth
 from up42.project import Project
 from up42.workflow import Workflow
@@ -33,329 +41,4 @@ from up42.tasking import Tasking
 from up42.storage import Storage
 from up42.order import Order
 from up42.asset import Asset
-from up42.webhooks import Webhooks, Webhook
-from up42.utils import get_logger
-
-logger = get_logger(__name__, level=logging.INFO)
-
-warnings.simplefilter(action="ignore", category=FutureWarning)
-
-_auth: Auth = None  # type: ignore
-
-
-def _check_auth_init(func, *args, **kwargs):
-    """
-    Some functionality of the up42 import object can theoretically be used
-    before authentication with UP42, so the auth needs to be checked first.
-    """
-    # pylint: disable=unused-argument
-    @wraps(func)  # required for mkdocstrings
-    def inner(*args, **kwargs):
-        if _auth is None:
-            raise RuntimeError("Not authenticated, call up42.authenticate() first")
-        return func(*args, **kwargs)
-
-    return inner
-
-
-def authenticate(
-    cfg_file: Union[str, Path] = None,
-    project_id: Optional[str] = None,
-    project_api_key: Optional[str] = None,
-    **kwargs,
-):
-    global _auth  # pylint: disable=global-statement
-    _auth = Auth(
-        cfg_file=cfg_file,
-        project_id=project_id,
-        project_api_key=project_api_key,
-        **kwargs,
-    )
-
-
-@_check_auth_init
-def initialize_project() -> "Project":
-    """
-    Returns the correct Project object (has to exist on UP42).
-    """
-    project = Project(auth=_auth, project_id=str(_auth.project_id))
-    logger.info(f"Initialized {project}")
-    return project
-
-
-@_check_auth_init
-def initialize_catalog() -> "Catalog":
-    """
-    Returns a Catalog object for using the catalog search.
-    """
-    return Catalog(auth=_auth)
-
-
-@_check_auth_init
-def initialize_tasking() -> "Tasking":
-    """
-    Returns a Tasking object for creating satellite tasking orders.
-    """
-    return Tasking(auth=_auth)
-
-
-@_check_auth_init
-def initialize_workflow(workflow_id: str) -> "Workflow":
-    """
-    Returns a Workflow object (has to exist on UP42).
-
-    Args:
-        workflow_id: The UP42 workflow_id
-    """
-    workflow = Workflow(
-        auth=_auth, workflow_id=workflow_id, project_id=str(_auth.project_id)
-    )
-    logger.info(f"Initialized {workflow}")
-    return workflow
-
-
-@_check_auth_init
-def initialize_job(job_id: str) -> "Job":
-    """
-    Returns a Job object (has to exist on UP42).
-
-    Args:
-        job_id: The UP42 job_id
-    """
-    job = Job(auth=_auth, job_id=job_id, project_id=str(_auth.project_id))
-    logger.info(f"Initialized {job}")
-    return job
-
-
-@_check_auth_init
-def initialize_jobtask(jobtask_id: str, job_id: str) -> "JobTask":
-    """
-    Returns a JobTask object (has to exist on UP42).
-
-    Args:
-        jobtask_id: The UP42 jobtask_id
-        job_id: The UP42 job_id
-    """
-    jobtask = JobTask(
-        auth=_auth,
-        jobtask_id=jobtask_id,
-        job_id=job_id,
-        project_id=str(_auth.project_id),
-    )
-    logger.info(f"Initialized {jobtask}")
-    return jobtask
-
-
-@_check_auth_init
-def initialize_jobcollection(job_ids: List[str]) -> "JobCollection":
-    """
-    Returns a JobCollection object (the referenced jobs have to exist on UP42).
-
-    Args:
-        job_ids: List of UP42 job_ids
-    """
-    jobs = [
-        Job(auth=_auth, job_id=job_id, project_id=str(_auth.project_id))
-        for job_id in job_ids
-    ]
-    jobcollection = JobCollection(
-        auth=_auth, project_id=str(_auth.project_id), jobs=jobs
-    )
-    logger.info(f"Initialized {jobcollection}")
-    return jobcollection
-
-
-@_check_auth_init
-def initialize_storage() -> "Storage":
-    """
-    Returns a Storage object to list orders and assets.
-    """
-    return Storage(auth=_auth)
-
-
-@_check_auth_init
-def initialize_order(order_id: str) -> "Order":
-    """
-    Returns an Order object (has to exist on UP42).
-
-    Args:
-        order_id: The UP42 order_id
-    """
-    order = Order(auth=_auth, order_id=order_id)
-    logger.info(f"Initialized {order}")
-    return order
-
-
-@_check_auth_init
-def initialize_asset(asset_id: str) -> "Asset":
-    """
-    Returns an Asset object (has to exist on UP42).
-
-    Args:
-        asset_id: The UP42 asset_id
-    """
-    asset = Asset(auth=_auth, asset_id=asset_id)
-    logger.info(f"Initialized {asset}")
-    return asset
-
-
-def get_blocks(
-    block_type=None,
-    basic: bool = True,
-    as_dataframe=False,
-):
-    tools = Tools(auth=_auth)
-    return tools.get_blocks(block_type, basic, as_dataframe)
-
-
-def get_block_details(block_id: str, as_dataframe=False) -> dict:
-    tools = Tools(auth=_auth)
-    return tools.get_block_details(block_id, as_dataframe)
-
-
-def get_block_coverage(block_id: str) -> dict:
-    tools = Tools(auth=_auth)
-    return tools.get_block_coverage(block_id)
-
-
-def get_credits_balance() -> dict:
-    tools = Tools(auth=_auth)
-    return tools.get_credits_balance()
-
-
-def get_credits_history(
-    start_date: Optional[Union[str, datetime]] = None,
-    end_date: Optional[Union[str, datetime]] = None,
-) -> Dict[str, Union[str, int, Dict]]:
-    tools = Tools(auth=_auth)
-    return tools.get_credits_history(start_date, end_date)
-
-
-def validate_manifest(path_or_json: Union[str, Path, dict]) -> dict:
-    tools = Tools(auth=_auth)
-    return tools.validate_manifest(path_or_json)
-
-
-def read_vector_file(
-    filename: str = "aoi.geojson", as_dataframe: bool = False
-) -> Union[Dict, GeoDataFrame]:
-    return Tools().read_vector_file(filename, as_dataframe)
-
-
-def get_example_aoi(
-    location: str = "Berlin", as_dataframe: bool = False
-) -> Union[Dict, GeoDataFrame]:
-    return Tools().get_example_aoi(location, as_dataframe)
-
-
-def draw_aoi() -> None:
-    return VizTools().draw_aoi()
-
-
-# pylint: disable=duplicate-code
-def plot_coverage(
-    scenes: GeoDataFrame,
-    aoi: GeoDataFrame = None,
-    legend_column: str = "sceneId",
-    figsize=(12, 16),
-) -> None:
-    VizTools().plot_coverage(
-        scenes=scenes, aoi=aoi, legend_column=legend_column, figsize=figsize
-    )
-
-
-def plot_quicklooks(
-    figsize: Tuple[int, int] = (8, 8), filepaths: Optional[list] = None
-) -> None:
-    VizTools().plot_quicklooks(figsize=figsize, filepaths=filepaths)
-
-
-def plot_results(
-    figsize: Tuple[int, int] = (8, 8),
-    filepaths: Union[List[Union[str, Path]], dict] = None,
-    titles: List[str] = None,
-) -> None:
-    VizTools().plot_results(figsize=figsize, filepaths=filepaths, titles=titles)
-
-
-def settings(log: bool = True) -> None:
-    """
-    Configures settings about logging etc. when using the up42-py package.
-
-    Args:
-        log: Activates/deactivates logging, default True is activated logging.
-    """
-    if log:
-        logger.info(
-            "Logging enabled (default) - use up42.settings(log=False) to disable."
-        )
-    else:
-        logger.info("Logging disabled - use up42.settings(log=True) to reactivate.")
-
-    for name in logging.root.manager.loggerDict:
-        setattr(logging.getLogger(name), "disabled", not log)
-
-
-def initialize_webhook(webhook_id: str) -> Webhook:
-    """
-    Returns a Webhook object (has to exist on UP42).
-
-    Args:
-        webhook_id: The UP42 webhook_id
-    """
-    if _auth is None:
-        raise RuntimeError("Not authenticated, call up42.authenticate() first")
-    webhook = Webhook(auth=_auth, webhook_id=webhook_id)
-    logger.info(f"Initialized {webhook}")
-    return webhook
-
-
-def get_webhooks(return_json: bool = False) -> List[Webhook]:
-    """
-    Gets all registered webhooks for this workspace.
-
-    Args:
-        return_json: If true returns the webhooks information as json instead of webhook class objects.
-
-    Returns:
-        A list of the registered webhooks for this workspace.
-    """
-    webhooks = Webhooks(auth=_auth).get_webhooks(return_json=return_json)
-    return webhooks
-
-
-def create_webhook(
-    name: str,
-    url: str,
-    events: List[str],
-    active: bool = False,
-    secret: Optional[str] = None,
-):
-    """
-    Registers a new webhook in the system.
-
-    Args:
-        name: Webhook name
-        url: Unique URL where the webhook will send the message (HTTPS required)
-        events: List of event types (order status / job task status)
-        active: Webhook status.
-        secret: String that acts as signature to the https request sent to the url.
-
-    Returns:
-        A dict with details of the registered webhook.
-    """
-    webhook = Webhooks(auth=_auth).create_webhook(
-        name=name, url=url, events=events, active=active, secret=secret
-    )
-    return webhook
-
-
-def get_webhook_events() -> dict:
-    """
-    Gets all available webhook events.
-
-    Returns:
-        A dict of the available webhook events.
-    """
-    webhook_events = Webhooks(auth=_auth).get_webhook_events()
-    return webhook_events
+from up42.webhooks import Webhook

--- a/up42/initialization.py
+++ b/up42/initialization.py
@@ -1,0 +1,166 @@
+__all__ = [
+    "initialize_project",
+    "initialize_catalog",
+    "initialize_tasking",
+    "initialize_workflow",
+    "initialize_job",
+    "initialize_jobtask",
+    "initialize_jobcollection",
+    "initialize_storage",
+    "initialize_order",
+    "initialize_asset",
+    "initialize_webhook",
+]
+
+import logging
+from typing import List
+
+from up42 import main
+from up42.main import _check_auth
+from up42.utils import get_logger
+from up42.project import Project
+from up42.workflow import Workflow
+from up42.job import Job
+from up42.jobtask import JobTask
+from up42.jobcollection import JobCollection
+from up42.catalog import Catalog
+from up42.tasking import Tasking
+from up42.storage import Storage
+from up42.order import Order
+from up42.asset import Asset
+from up42.webhooks import Webhook
+
+
+logger = get_logger(__name__, level=logging.INFO)
+
+
+@_check_auth
+def initialize_project() -> "Project":
+    """
+    Returns the correct Project object (has to exist on UP42).
+    """
+    project = Project(auth=main._auth, project_id=str(main._auth.project_id))
+    logger.info(f"Initialized {project}")
+    return project
+
+
+@_check_auth
+def initialize_catalog() -> "Catalog":
+    """
+    Returns a Catalog object for using the catalog search.
+    """
+    return Catalog(auth=main._auth)
+
+
+@_check_auth
+def initialize_tasking() -> "Tasking":
+    """
+    Returns a Tasking object for creating satellite tasking orders.
+    """
+    return Tasking(auth=main._auth)
+
+
+@_check_auth
+def initialize_workflow(workflow_id: str) -> "Workflow":
+    """
+    Returns a Workflow object (has to exist on UP42).
+    Args:
+        workflow_id: The UP42 workflow_id
+    """
+    workflow = Workflow(
+        auth=main._auth, workflow_id=workflow_id, project_id=str(main._auth.project_id)
+    )
+    logger.info(f"Initialized {workflow}")
+    return workflow
+
+
+@_check_auth
+def initialize_job(job_id: str) -> "Job":
+    """
+    Returns a Job object (has to exist on UP42).
+    Args:
+        job_id: The UP42 job_id
+    """
+    job = Job(auth=main._auth, job_id=job_id, project_id=str(main._auth.project_id))
+    logger.info(f"Initialized {job}")
+    return job
+
+
+@_check_auth
+def initialize_jobtask(jobtask_id: str, job_id: str) -> "JobTask":
+    """
+    Returns a JobTask object (has to exist on UP42).
+    Args:
+        jobtask_id: The UP42 jobtask_id
+        job_id: The UP42 job_id
+    """
+    jobtask = JobTask(
+        auth=main._auth,
+        jobtask_id=jobtask_id,
+        job_id=job_id,
+        project_id=str(main._auth.project_id),
+    )
+    logger.info(f"Initialized {jobtask}")
+    return jobtask
+
+
+@_check_auth
+def initialize_jobcollection(job_ids: List[str]) -> "JobCollection":
+    """
+    Returns a JobCollection object (the referenced jobs have to exist on UP42).
+    Args:
+        job_ids: List of UP42 job_ids
+    """
+    jobs = [
+        Job(auth=main._auth, job_id=job_id, project_id=str(main._auth.project_id))
+        for job_id in job_ids
+    ]
+    jobcollection = JobCollection(
+        auth=main._auth, project_id=str(main._auth.project_id), jobs=jobs
+    )
+    logger.info(f"Initialized {jobcollection}")
+    return jobcollection
+
+
+@_check_auth
+def initialize_storage() -> "Storage":
+    """
+    Returns a Storage object to list orders and assets.
+    """
+    return Storage(auth=main._auth)
+
+
+@_check_auth
+def initialize_order(order_id: str) -> "Order":
+    """
+    Returns an Order object (has to exist on UP42).
+    Args:
+        order_id: The UP42 order_id
+    """
+    order = Order(auth=main._auth, order_id=order_id)
+    logger.info(f"Initialized {order}")
+    return order
+
+
+@_check_auth
+def initialize_asset(asset_id: str) -> "Asset":
+    """
+    Returns an Asset object (has to exist on UP42).
+    Args:
+        asset_id: The UP42 asset_id
+    """
+    asset = Asset(auth=main._auth, asset_id=asset_id)
+    logger.info(f"Initialized {asset}")
+    return asset
+
+
+@_check_auth
+def initialize_webhook(webhook_id: str) -> Webhook:
+    """
+    Returns a Webhook object (has to exist on UP42).
+    Args:
+        webhook_id: The UP42 webhook_id
+    """
+    webhook = Webhook(auth=main._auth, webhook_id=webhook_id)
+    logger.info(f"Initialized {webhook}")
+    return webhook

--- a/up42/main.py
+++ b/up42/main.py
@@ -1,0 +1,337 @@
+__all__ = [
+    "authenticate",
+    "get_webhooks",
+    "create_webhook",
+    "get_webhook_events",
+    "get_blocks",
+    "get_block_details",
+    "get_block_coverage",
+    "get_credits_balance",
+    "get_credits_history",
+    "validate_manifest",
+]
+
+import warnings
+from pathlib import Path
+from typing import Union, List, Optional, Dict
+import logging
+from datetime import datetime, date, timedelta
+import json
+from functools import wraps
+
+import requests.exceptions
+import pandas as pd
+
+
+# pylint: disable=wrong-import-position
+from up42.auth import Auth
+from up42.webhooks import Webhooks, Webhook
+from up42.utils import get_logger, format_time_period
+
+logger = get_logger(__name__, level=logging.INFO)
+
+warnings.simplefilter(action="ignore", category=FutureWarning)
+
+
+# pylint: disable=global-statement
+_auth: Auth = None  # type: ignore
+
+
+def authenticate(
+    cfg_file: Union[str, Path] = None,
+    project_id: Optional[str] = None,
+    project_api_key: Optional[str] = None,
+    **kwargs,
+):
+    """
+    Authenticate with UP42, either via project_id & project_api_key, or a config json file containing both.
+    Also see the documentation https://sdk.up42.com/authentication/
+
+    Args:
+        cfg_file: A json file containing project_id & project_api_key
+        project_id: The UP42 project id.
+        project_api_key: The UP42 project api key.
+
+    Examples:
+        ```python
+        up42.authenticate(
+            project_id="your-project-ID",
+            project_api_key="your-project-API-key"
+        )
+        ```
+    """
+    global _auth
+    _auth = Auth(
+        cfg_file=cfg_file,
+        project_id=project_id,
+        project_api_key=project_api_key,
+        **kwargs,
+    )
+
+
+def _check_auth(func, *args, **kwargs):
+    """
+    Some functionality of the up42 import object can theoretically be used
+    before authentication with UP42, so the auth needs to be checked first.
+    """
+    # pylint: disable=unused-argument
+    @wraps(func)  # required for mkdocstrings
+    def inner(*args, **kwargs):
+        if _auth is None:
+            raise RuntimeError("Not authenticated, call up42.authenticate() first")
+        return func(*args, **kwargs)
+
+    return inner
+
+
+@_check_auth
+def get_webhooks(return_json: bool = False) -> List[Webhook]:
+    """
+    Gets all registered webhooks for this workspace.
+
+    Args:
+        return_json: If true returns the webhooks information as json instead of webhook class objects.
+    Returns:
+        A list of the registered webhooks for this workspace.
+    """
+    webhooks = Webhooks(auth=_auth).get_webhooks(return_json=return_json)
+    return webhooks
+
+
+@_check_auth
+def create_webhook(
+    name: str,
+    url: str,
+    events: List[str],
+    active: bool = False,
+    secret: Optional[str] = None,
+):
+    """
+    Registers a new webhook in the system.
+
+    Args:
+        name: Webhook name
+        url: Unique URL where the webhook will send the message (HTTPS required)
+        events: List of event types (order status / job task status)
+        active: Webhook status.
+        secret: String that acts as signature to the https request sent to the url.
+    Returns:
+        A dict with details of the registered webhook.
+    """
+    webhook = Webhooks(auth=_auth).create_webhook(
+        name=name, url=url, events=events, active=active, secret=secret
+    )
+    return webhook
+
+
+@_check_auth
+def get_webhook_events() -> dict:
+    """
+    Gets all available webhook events.
+
+    Returns:
+        A dict of the available webhook events.
+    """
+    webhook_events = Webhooks(auth=_auth).get_webhook_events()
+    return webhook_events
+
+
+@_check_auth
+def get_blocks(
+    block_type: Optional[str] = None,
+    basic: bool = True,
+    as_dataframe: bool = False,
+) -> Union[List[Dict], dict]:
+    """
+    Gets a list of all public blocks on the marketplace. Can not access custom blocks.
+
+    Args:
+        block_type: Optionally filters to "data" or "processing" blocks, default None.
+        basic: Optionally returns simple version {block_id : block_name}
+        as_dataframe: Returns a dataframe instead of json (default).
+
+    Returns:
+        A list of the public blocks and their metadata. Optional a simpler version
+        dict.
+    """
+    try:
+        block_type = block_type.lower()  # type: ignore
+    except AttributeError:
+        pass
+    url = f"{_auth._endpoint()}/blocks"
+    response_json = _auth._request(request_type="GET", url=url)
+    public_blocks_json = response_json["data"]
+
+    if block_type == "data":
+        logger.info("Getting only data blocks.")
+        blocks_json = [block for block in public_blocks_json if block["type"] == "DATA"]
+    elif block_type == "processing":
+        logger.info("Getting only processing blocks.")
+        blocks_json = [
+            block for block in public_blocks_json if block["type"] == "PROCESSING"
+        ]
+    else:
+        blocks_json = public_blocks_json
+
+    if basic:
+        logger.info(
+            "Getting blocks name and id, use basic=False for all block details."
+        )
+        blocks_basic = {block["name"]: block["id"] for block in blocks_json}
+        if as_dataframe:
+            return pd.DataFrame.from_dict(blocks_basic, orient="index")
+        else:
+            return blocks_basic
+
+    else:
+        if as_dataframe:
+            return pd.DataFrame(blocks_json)
+        else:
+            return blocks_json
+
+
+@_check_auth
+def get_block_details(block_id: str, as_dataframe: bool = False) -> dict:
+    """
+    Gets the detailed information about a specific public block from
+    the server, includes all manifest.json and marketplace.json contents.
+    Can not access custom blocks.
+
+    Args:
+        block_id: The block id.
+        as_dataframe: Returns a dataframe instead of json (default).
+
+    Returns:
+        A dict of the block details metadata for the specific block.
+    """
+    url = f"{_auth._endpoint()}/blocks/{block_id}"  # public blocks
+    response_json = _auth._request(request_type="GET", url=url)
+    details_json = response_json["data"]
+
+    if as_dataframe:
+        return pd.DataFrame.from_dict(details_json, orient="index").transpose()
+    else:
+        return details_json
+
+
+@_check_auth
+def get_block_coverage(block_id: str) -> dict:
+    # pylint: disable=unused-argument
+    """
+    Gets the spatial coverage of a data/processing block as
+    url or GeoJson Feature Collection.
+
+    Args:
+        block_id: The block id.
+
+    Returns:
+        A dict of the spatial coverage for the specific block.
+    """
+    url = f"{_auth._endpoint()}/blocks/{block_id}/coverage"
+    response_json = _auth._request(request_type="GET", url=url)
+    details_json = response_json["data"]
+    response_coverage = requests.get(details_json["url"]).json()
+    return response_coverage
+
+
+@_check_auth
+def get_credits_balance() -> dict:
+    """
+    Display the overall credits available in your account.
+
+    Returns:
+        A dict with the balance of credits available in your account.
+    """
+    endpoint_url = f"{_auth._endpoint()}/accounts/me/credits/balance"
+    response_json = _auth._request(request_type="GET", url=endpoint_url)
+    details_json = response_json["data"]
+    return details_json
+
+
+@_check_auth
+def get_credits_history(
+    start_date: Optional[Union[str, datetime]] = None,
+    end_date: Optional[Union[str, datetime]] = None,
+) -> Dict[str, Union[str, int, Dict]]:
+    """
+    Display the overall credits history consumed in your account.
+    The consumption history will be returned for all workspace_ids on your account.
+
+    Args:
+        start_date: The start date for the credit consumption search e.g.
+            2021-12-01. Default start_date None uses 2000-01-01.
+        end_date: The end date for the credit consumption search e.g.
+            2021-12-31. Default end_date None uses current date.
+
+    Returns:
+        A dict with the information of the credit consumption records for
+        all the users linked by the account_id.
+        (see https://docs.up42.com/developers/api#operation/getHistory for
+        output description)
+    """
+    if start_date is None:
+        start_date = "2000-01-01"
+    if end_date is None:
+        tomorrow_date = date.today() + timedelta(days=1)
+        tomorrow_datetime = datetime(
+            year=tomorrow_date.year,
+            month=tomorrow_date.month,
+            day=tomorrow_date.day,
+        )
+        end_date = tomorrow_datetime.strftime("%Y-%m-%d")
+
+    [start_formatted_date, end_formatted_date] = format_time_period(
+        start_date=start_date, end_date=end_date
+    ).split("/")
+    search_parameters = dict(
+        {
+            "from": start_formatted_date,
+            "to": end_formatted_date,
+            "size": 2000,  # 2000 is the maximum page size for this call
+            "page": 0,
+        }
+    )
+    endpoint_url = f"{_auth._endpoint()}/accounts/me/credits/history"
+    response_json: dict = _auth._request(
+        request_type="GET", url=endpoint_url, querystring=search_parameters
+    )
+    isLastPage = response_json["data"]["last"]
+    credit_history = response_json["data"]["content"].copy()
+    result = dict(response_json["data"])
+    del result["content"]
+    while not isLastPage:
+        search_parameters["page"] += 1
+        response_json = _auth._request(
+            request_type="GET", url=endpoint_url, querystring=search_parameters
+        )
+        isLastPage = response_json["data"]["last"]
+        credit_history.extend(response_json["data"]["content"].copy())
+    result["content"] = credit_history
+    return result
+
+
+@_check_auth
+def validate_manifest(path_or_json: Union[str, Path, dict]) -> dict:
+    """
+    Validates a block manifest json.
+
+    The block manifest is required to build a custom block on UP42 and contains
+    the metadata about the block as well as block input and output capabilities.
+    Also see the
+    [manifest chapter in the UP42 documentation](https://docs.up42.com/reference/block-manifest.html).
+
+    Args:
+        path_or_json: The input manifest, either a filepath or json string, see example.
+
+    Returns:
+        A dictionary with the validation results and potential validation errors.
+    """
+    if isinstance(path_or_json, (str, Path)):
+        with open(path_or_json) as src:
+            manifest_json = json.load(src)
+    else:
+        manifest_json = path_or_json
+    url = f"{_auth._endpoint()}/validate-schema/block"
+    response_json = _auth._request(request_type="POST", url=url, data=manifest_json)
+    logger.info("The manifest is valid.")
+    return response_json["data"]

--- a/up42/tools.py
+++ b/up42/tools.py
@@ -1,324 +1,109 @@
 """
-Base functionality that is made available on the up42 import object (in the init) and
-not bound to a specific higher level UP42 object.
+SDK conveniance functionality that is made available on the up42 import object (in the init) and is not directly
+related to API calls.
 """
 
-import json
-from functools import wraps
 from pathlib import Path
-from typing import List, Union, Dict, Optional
-from datetime import date, datetime, timedelta
+from typing import Union
+import logging
 
-import requests.exceptions
 import geopandas as gpd
 from geopandas import GeoDataFrame
 import pandas as pd
 import shapely
 
-from up42.utils import get_logger, format_time_period
+from up42.utils import get_logger
 
 logger = get_logger(__name__)
 
 
-def check_auth_tools(func, *args, **kwargs):
+def read_vector_file(
+    filename: str = "aoi.geojson", as_dataframe: bool = False
+) -> Union[dict, GeoDataFrame]:
     """
-    Some functionality of the up42 import object (which integrates Tools functions) can theoretically be used
-    before authentication with UP42, so the auth needs to be checked first.
+    Reads vector files (geojson, shapefile, kml, wkt) to a feature collection,
+    for use as the aoi geometry in the workflow input parameters
+    (see get_input_parameters).
+
+    Example aoi fiels are provided, e.g. example/data/aoi_Berlin.geojson
+
+    Args:
+        filename: File path of the vector file.
+        as_dataframe: Return type, default FeatureCollection, GeoDataFrame if True.
+
+    Returns:
+        Feature Collection
     """
-    # pylint: disable=unused-argument
-    @wraps(func)  # required for mkdocstrings
-    def inner(self, *args, **kwargs):
-        if not hasattr(self, "auth"):
-            raise RuntimeError(
-                "Requires authentication with UP42, use up42.authenticate()!"
-            )
-        return func(self, *args, **kwargs)
+    suffix = Path(filename).suffix
 
-    return inner
+    if suffix == ".kml":
+        # pylint: disable=no-member
+        gpd.io.file.fiona.drvsupport.supported_drivers["KML"] = "rw"
+        df = gpd.read_file(filename, driver="KML")
+    elif suffix == ".wkt":
+        with open(filename) as wkt_file:
+            wkt = wkt_file.read()
+            df = pd.DataFrame({"geometry": [wkt]})
+            df["geometry"] = df["geometry"].apply(shapely.wkt.loads)
+            df = GeoDataFrame(df, geometry="geometry", crs=4326)
+    else:
+        df = gpd.read_file(filename)
+
+    if df.crs.to_string() != "EPSG:4326":
+        df = df.to_crs(epsg=4326)
+    if as_dataframe:
+        return df
+    else:
+        return df.__geo_interface__
 
 
-# pylint: disable=no-member, duplicate-code
-class Tools:
-    def __init__(self, auth=None):
-        """
-        The tools class contains the base functionality that is not bound to a specific
-        higher level UP42 object.
-        """
-        if auth:
-            self.auth = auth
-        self.quicklooks = None
-        self.results = None
+def get_example_aoi(
+    location: str = "Berlin", as_dataframe: bool = False
+) -> Union[dict, GeoDataFrame]:
+    """
+    Gets predefined, small, rectangular example aoi for the selected location.
 
-    # pylint: disable=no-self-use
-    def read_vector_file(
-        self, filename: str = "aoi.geojson", as_dataframe: bool = False
-    ) -> Union[dict, GeoDataFrame]:
-        """
-        Reads vector files (geojson, shapefile, kml, wkt) to a feature collection,
-        for use as the aoi geometry in the workflow input parameters
-        (see get_input_parameters).
+    Args:
+        location: Location, one of Berlin, Washington.
+        as_dataframe: Returns a dataframe instead of dict FeatureColletions
+            (default).
 
-        Example aoi fiels are provided, e.g. example/data/aoi_Berlin.geojson
-
-        Args:
-            filename: File path of the vector file.
-            as_dataframe: Return type, default FeatureCollection, GeoDataFrame if True.
-
-        Returns:
-            Feature Collection
-        """
-        suffix = Path(filename).suffix
-
-        if suffix == ".kml":
-            gpd.io.file.fiona.drvsupport.supported_drivers["KML"] = "rw"
-            df = gpd.read_file(filename, driver="KML")
-        elif suffix == ".wkt":
-            with open(filename) as wkt_file:
-                wkt = wkt_file.read()
-                df = pd.DataFrame({"geometry": [wkt]})
-                df["geometry"] = df["geometry"].apply(shapely.wkt.loads)
-                df = GeoDataFrame(df, geometry="geometry", crs=4326)
-        else:
-            df = gpd.read_file(filename)
-
-        if df.crs.to_string() != "EPSG:4326":
-            df = df.to_crs(epsg=4326)
-        if as_dataframe:
-            return df
-        else:
-            return df.__geo_interface__
-
-    def get_example_aoi(
-        self, location: str = "Berlin", as_dataframe: bool = False
-    ) -> Union[dict, GeoDataFrame]:
-        """
-        Gets predefined, small, rectangular example aoi for the selected location.
-
-        Args:
-            location: Location, one of Berlin, Washington.
-            as_dataframe: Returns a dataframe instead of dict FeatureColletions
-                (default).
-
-        Returns:
-            Feature collection json with the selected aoi.
-        """
-        logger.info(f"Getting small example aoi in location '{location}'.")
-        if location == "Berlin":
-            example_aoi = self.read_vector_file(
-                f"{str(Path(__file__).resolve().parent)}/data/aoi_berlin.geojson"
-            )
-        elif location == "Washington":
-            example_aoi = self.read_vector_file(
-                f"{str(Path(__file__).resolve().parent)}/data/aoi_washington.geojson"
-            )
-        else:
-            raise ValueError(
-                "Please select one of 'Berlin' or 'Washington' as the location!"
-            )
-
-        if as_dataframe:
-            df = GeoDataFrame.from_features(example_aoi, crs=4326)
-            return df
-        else:
-            return example_aoi
-
-    @check_auth_tools
-    def get_blocks(
-        self,
-        block_type: Optional[str] = None,
-        basic: bool = True,
-        as_dataframe: bool = False,
-    ) -> Union[List[Dict], dict]:
-        """
-        Gets a list of all public blocks on the marketplace. Can not access custom blocks.
-
-        Args:
-            block_type: Optionally filters to "data" or "processing" blocks, default None.
-            basic: Optionally returns simple version {block_id : block_name}
-            as_dataframe: Returns a dataframe instead of json (default).
-
-        Returns:
-            A list of the public blocks and their metadata. Optional a simpler version
-            dict.
-        """
-        try:
-            block_type = block_type.lower()  # type: ignore
-        except AttributeError:
-            pass
-        url = f"{self.auth._endpoint()}/blocks"
-        response_json = self.auth._request(request_type="GET", url=url)
-        public_blocks_json = response_json["data"]
-
-        if block_type == "data":
-            logger.info("Getting only data blocks.")
-            blocks_json = [
-                block for block in public_blocks_json if block["type"] == "DATA"
-            ]
-        elif block_type == "processing":
-            logger.info("Getting only processing blocks.")
-            blocks_json = [
-                block for block in public_blocks_json if block["type"] == "PROCESSING"
-            ]
-        else:
-            blocks_json = public_blocks_json
-
-        if basic:
-            logger.info(
-                "Getting blocks name and id, use basic=False for all block details."
-            )
-            blocks_basic = {block["name"]: block["id"] for block in blocks_json}
-            if as_dataframe:
-                return pd.DataFrame.from_dict(blocks_basic, orient="index")
-            else:
-                return blocks_basic
-
-        else:
-            if as_dataframe:
-                return pd.DataFrame(blocks_json)
-            else:
-                return blocks_json
-
-    @check_auth_tools
-    def get_block_details(self, block_id: str, as_dataframe: bool = False) -> dict:
-        """
-        Gets the detailed information about a specific public block from
-        the server, includes all manifest.json and marketplace.json contents.
-        Can not access custom blocks.
-
-        Args:
-            block_id: The block id.
-            as_dataframe: Returns a dataframe instead of json (default).
-
-        Returns:
-            A dict of the block details metadata for the specific block.
-        """
-        url = f"{self.auth._endpoint()}/blocks/{block_id}"  # public blocks
-        response_json = self.auth._request(request_type="GET", url=url)
-        details_json = response_json["data"]
-
-        if as_dataframe:
-            return pd.DataFrame.from_dict(details_json, orient="index").transpose()
-        else:
-            return details_json
-
-    @check_auth_tools
-    def get_block_coverage(self, block_id: str) -> dict:
-        # pylint: disable=unused-argument
-        """
-        Gets the spatial coverage of a data/processing block as
-        url or GeoJson Feature Collection.
-
-        Args:
-            block_id: The block id.
-
-        Returns:
-            A dict of the spatial coverage for the specific block.
-        """
-        url = f"{self.auth._endpoint()}/blocks/{block_id}/coverage"
-        response_json = self.auth._request(request_type="GET", url=url)
-        details_json = response_json["data"]
-        response_coverage = requests.get(details_json["url"]).json()
-        return response_coverage
-
-    @check_auth_tools
-    def get_credits_balance(self) -> dict:
-        """
-        Display the overall credits available in your account.
-
-        Returns:
-            A dict with the balance of credits available in your account.
-        """
-        endpoint_url = f"{self.auth._endpoint()}/accounts/me/credits/balance"
-        response_json = self.auth._request(request_type="GET", url=endpoint_url)
-        details_json = response_json["data"]
-        return details_json
-
-    @check_auth_tools
-    def get_credits_history(
-        self,
-        start_date: Optional[Union[str, datetime]] = None,
-        end_date: Optional[Union[str, datetime]] = None,
-    ) -> Dict[str, Union[str, int, Dict]]:
-        """
-        Display the overall credits history consumed in your account.
-        The consumption history will be returned for all workspace_ids on your
-        account.
-        Args:
-            start_date: The start date for the credit consumption search e.g.
-                2021-12-01. Default start_date None uses 2000-01-01.
-            end_date: The end date for the credit consumption search e.g.
-                2021-12-31. Default end_date None uses current date.
-
-        Returns:
-            A dict with the information of the credit consumption records for
-            all the users linked by the account_id.
-            (see https://docs.up42.com/developers/api#operation/getHistory for
-            output description)
-        """
-        if start_date is None:
-            start_date = "2000-01-01"
-        if end_date is None:
-            tomorrow_date = date.today() + timedelta(days=1)
-            tomorrow_datetime = datetime(
-                year=tomorrow_date.year,
-                month=tomorrow_date.month,
-                day=tomorrow_date.day,
-            )
-            end_date = tomorrow_datetime.strftime("%Y-%m-%d")
-
-        [start_formatted_date, end_formatted_date] = format_time_period(
-            start_date=start_date, end_date=end_date
-        ).split("/")
-        search_parameters = dict(
-            {
-                "from": start_formatted_date,
-                "to": end_formatted_date,
-                "size": 2000,  # 2000 is the maximum page size for this call
-                "page": 0,
-            }
+    Returns:
+        Feature collection json with the selected aoi.
+    """
+    logger.info(f"Getting small example aoi in location '{location}'.")
+    if location == "Berlin":
+        example_aoi = read_vector_file(
+            f"{str(Path(__file__).resolve().parent)}/data/aoi_berlin.geojson"
         )
-        endpoint_url = f"{self.auth._endpoint()}/accounts/me/credits/history"
-        response_json: dict = self.auth._request(
-            request_type="GET", url=endpoint_url, querystring=search_parameters
+    elif location == "Washington":
+        example_aoi = read_vector_file(
+            f"{str(Path(__file__).resolve().parent)}/data/aoi_washington.geojson"
         )
-        isLastPage = response_json["data"]["last"]
-        credit_history = response_json["data"]["content"].copy()
-        result = dict(response_json["data"])
-        del result["content"]
-        while not isLastPage:
-            search_parameters["page"] += 1
-            response_json = self.auth._request(
-                request_type="GET", url=endpoint_url, querystring=search_parameters
-            )
-            isLastPage = response_json["data"]["last"]
-            credit_history.extend(response_json["data"]["content"].copy())
-        result["content"] = credit_history
-        return result
-
-    @check_auth_tools
-    def validate_manifest(self, path_or_json: Union[str, Path, dict]) -> dict:
-        """
-        Validates a block manifest json.
-
-        The block manifest is required to build a custom block on UP42 and contains
-        the metadata about the block as well as block input and output capabilities.
-        Also see the
-        [manifest chapter in the UP42 documentation](https://docs.up42.com/reference/block-manifest.html).
-
-        Args:
-            path_or_json: The input manifest, either a filepath or json string, see example.
-
-        Returns:
-            A dictionary with the validation results and potential validation errors.
-        """
-        if isinstance(path_or_json, (str, Path)):
-            with open(path_or_json) as src:
-                manifest_json = json.load(src)
-        else:
-            manifest_json = path_or_json
-        url = f"{self.auth._endpoint()}/validate-schema/block"
-        response_json = self.auth._request(
-            request_type="POST", url=url, data=manifest_json
+    else:
+        raise ValueError(
+            "Please select one of 'Berlin' or 'Washington' as the location!"
         )
-        logger.info("The manifest is valid.")
-        return response_json["data"]
+
+    if as_dataframe:
+        df = GeoDataFrame.from_features(example_aoi, crs=4326)
+        return df
+    else:
+        return example_aoi
+
+
+def settings(log: bool = True) -> None:
+    """
+    Configures settings about logging etc. when using the up42-py package.
+    Args:
+        log: Activates/deactivates logging, default True is activated logging.
+    """
+    if log:
+        logger.info(
+            "Logging enabled (default) - use up42.settings(log=False) to disable."
+        )
+    else:
+        logger.info("Logging disabled - use up42.settings(log=True) to reactivate.")
+
+    for name in logging.root.manager.loggerDict:
+        setattr(logging.getLogger(name), "disabled", not log)

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -6,9 +6,9 @@ import tempfile
 import tarfile
 import zipfile
 import warnings
-import functools
 from datetime import datetime
 from datetime import time as datetime_time
+from functools import wraps
 
 from geopandas import GeoDataFrame
 import shapely
@@ -62,7 +62,7 @@ def deprecation(
     """
 
     def actual_decorator(func):
-        @functools.wraps(func)
+        @wraps(func)
         def wrapper(*args, **kwargs):
             message = (
                 f"`{func.__name__}` will be deprecated in version {version}, "

--- a/up42/viztools.py
+++ b/up42/viztools.py
@@ -69,6 +69,33 @@ def requires_viz(func):
     return wrapper_func
 
 
+@requires_viz
+def draw_aoi() -> "folium.Map":
+    """
+    Displays an interactive map to draw an aoi by hand, returns the folium object if
+    not run in a Jupyter notebook.
+
+    Export the drawn aoi via the export button, then read the geometries via
+    read_aoi_file().
+    """
+    m = folium_base_map(layer_control=True)
+    DrawFoliumOverride(
+        export=True,
+        filename="aoi.geojson",
+        position="topleft",
+        draw_options={
+            "rectangle": {"repeatMode": False, "showArea": True},
+            "polygon": {"showArea": True, "allowIntersection": False},
+            "polyline": False,
+            "circle": False,
+            "marker": False,
+            "circlemarker": False,
+        },
+        edit_options={"polygon": {"allowIntersection": False}},
+    ).add_to(m)
+    return m
+
+
 # pylint: disable=no-member, duplicate-code
 class VizTools:
     def __init__(self):
@@ -482,33 +509,6 @@ class VizTools:
             ) from e
         ax.set_axis_off()
         plt.show()
-
-    @staticmethod
-    @requires_viz
-    def draw_aoi() -> "folium.Map":
-        """
-        Displays an interactive map to draw an aoi by hand, returns the folium object if
-        not run in a Jupyter notebook.
-
-        Export the drawn aoi via the export button, then read the geometries via
-        read_aoi_file().
-        """
-        m = folium_base_map(layer_control=True)
-        DrawFoliumOverride(
-            export=True,
-            filename="aoi.geojson",
-            position="topleft",
-            draw_options={
-                "rectangle": {"repeatMode": False, "showArea": True},
-                "polygon": {"showArea": True, "allowIntersection": False},
-                "polyline": False,
-                "circle": False,
-                "marker": False,
-                "circlemarker": False,
-            },
-            edit_options={"polygon": {"allowIntersection": False}},
-        ).add_to(m)
-        return m
 
 
 if _viz_installed:

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -17,7 +17,6 @@ from up42.job import Job
 from up42.estimation import Estimation
 from up42.jobcollection import JobCollection
 from up42.asset import Asset
-from up42.tools import Tools
 from up42.utils import (
     get_logger,
     any_vector_to_fc,
@@ -25,6 +24,7 @@ from up42.utils import (
     filter_jobs_on_mode,
     format_time_period,
 )
+import up42.main as main
 
 logger = get_logger(__name__)
 
@@ -102,11 +102,9 @@ class Workflow:
         if not tasks:
             logger.info("The workflow is empty, returning all data blocks.")
 
-            logging.getLogger("up42.tools").setLevel(logging.CRITICAL)
-            data_blocks = Tools(auth=self.auth).get_blocks(
-                block_type="data", basic=True
-            )
-            logging.getLogger("up42.tools").setLevel(logging.INFO)
+            logging.getLogger("up42.main").setLevel(logging.CRITICAL)
+            data_blocks = main.get_blocks(block_type="data", basic=True)
+            logging.getLogger("up42.main").setLevel(logging.INFO)
             return data_blocks  # type: ignore
 
         last_task = list(tasks.keys())[-1]
@@ -145,9 +143,8 @@ class Workflow:
         else:
             return tasks
 
-    def _construct_full_workflow_tasks_dict(
-        self, input_tasks: Union[List]
-    ) -> List[dict]:
+    @staticmethod
+    def _construct_full_workflow_tasks_dict(input_tasks: Union[List]) -> List[dict]:
         """
         Constructs the full workflow task definition from a simplified version.
         Accepts blocks ids, block names, block display names & combinations of them.
@@ -177,9 +174,9 @@ class Workflow:
         full_input_tasks_definition = []
 
         # Get public + custom blocks.
-        logging.getLogger("up42.tools").setLevel(logging.CRITICAL)
-        blocks: dict = Tools(auth=self.auth).get_blocks(basic=False)  # type: ignore
-        logging.getLogger("up42.tools").setLevel(logging.INFO)
+        logging.getLogger("up42.main").setLevel(logging.CRITICAL)
+        blocks: dict = main.get_blocks(basic=False)  # type: ignore
+        logging.getLogger("up42.main").setLevel(logging.INFO)
 
         # Get ids of the input tasks, regardless of the specified format.
         blocks_id_name = {block["id"]: block["name"] for block in blocks}


### PR DESCRIPTION
Restructures package init, moves functions into separate modules (main and initialization). Easier to read & test, and avoids that package unrelated imports are available at `up42` object level, thanks @janchrizz for feedback. 
Also removes the Tools class, which structurally did not make sense, now direct functions in main/viztools/remaining direct functions in tools module.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
