### PR TITLE
Fix data product filter with basic=False

### DIFF
--- a/tests/mock_data/data_products.json
+++ b/tests/mock_data/data_products.json
@@ -123,5 +123,37 @@
     },
     "collectionName": "test_not_integrated",
     "isIntegrated": false
+  },
+  {
+    "id": "123_tasking_should_be_filtered_in_catalog_test",
+    "productConfiguration": {
+      "host": {
+        "name": "tasking_a",
+        "isIntegrated": true
+      },
+      "hostName": "taskingName",
+      "title": "tasking_b",
+      "configuration": {},
+      "isIntegrated": true
+    },
+    "productConfigurationId": "654321",
+    "collection": {
+      "name": "tasking_c",
+      "title": "tasking_should_be_filtered_in_catalog_test",
+      "type": "TASKING",
+      "restricted": false,
+      "host": {
+        "name": "not",
+        "isIntegrated": true
+      },
+      "hostName": "sometaskingprovider",
+      "producer": {
+        "name": "tasking_e",
+        "isIntegrated": true
+      },
+      "producerName": "taskingproducer"
+    },
+    "collectionName": "taskingname",
+    "isIntegrated": true
   }
 ]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -67,6 +67,7 @@ def test_get_data_products_basic(catalog_mock):
         for k in basic_keys
     )
 
+    assert "tasking_should_be_filtered_in_catalog_test" not in data_products_basic
     assert "test_not_integrated" not in data_products_basic
     assert len(data_products_basic) == 2
 
@@ -75,6 +76,13 @@ def test_get_data_products(catalog_mock):
     data_products = catalog_mock.get_data_products(basic=False)
     assert isinstance(data_products, list)
     assert data_products[0]["id"]
+
+    for product in data_products:
+        assert product["collection"]["title"] not in [
+            "tasking_should_be_filtered_in_catalog_test",
+            "test_not_integrated",
+        ]
+    assert len(data_products) == 2
 
 
 @pytest.mark.live


### PR DESCRIPTION
Applies the filter for `type` and `isintegrated` in get_data_products also on `basic=False` configuration. Thanks @perusio for the catch!

Items:
* [x] Ran test & live-tests
* [x] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
