### PR TITLE
Handle required non default workflow.construct_parameters

### DIFF
--- a/tests/fixtures/fixtures_globals.py
+++ b/tests/fixtures/fixtures_globals.py
@@ -39,8 +39,8 @@ JSON_WORKFLOW_TASKS = {
                 "name": "esa-s2-l2a-gtiff-visual",
                 "displayName": "Sentinel-2 L2A Visual (GeoTIFF)",
                 "parameters": {
-                    "ids": {"type": "array", "default": "None"},
-                    "bbox": {"type": "array", "default": "None"},
+                    "ids": {"type": "array", "default": None},
+                    "bbox": {"type": "array", "default": None},
                     "time": {
                         "type": "dateRange",
                         "default": "2018-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
@@ -50,7 +50,7 @@ JSON_WORKFLOW_TASKS = {
                 "isDryRunSupported": True,
                 "version": "1.0.1",
             },
-            "environment": "None",
+            "environment": None,
         },
         {
             "id": "24375b2a-288b-46c8-b404-53e48d4e7b25",
@@ -65,7 +65,7 @@ JSON_WORKFLOW_TASKS = {
                 "parameters": {
                     "nodata": {
                         "type": "number",
-                        "default": "None",
+                        "default": None,
                         "required": False,
                         "description": "Value representing ...",
                     },

--- a/tests/fixtures/fixtures_globals.py
+++ b/tests/fixtures/fixtures_globals.py
@@ -39,12 +39,13 @@ JSON_WORKFLOW_TASKS = {
                 "name": "esa-s2-l2a-gtiff-visual",
                 "displayName": "Sentinel-2 L2A Visual (GeoTIFF)",
                 "parameters": {
-                    "ids": {"type": "array", "default": None},
-                    "bbox": {"type": "array", "default": None},
                     "time": {
                         "type": "dateRange",
                         "default": "2018-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
                     },
+                    "ids": {"type": "array", "default": None},
+                    "bbox": {"type": "array", "default": None},
+                    "intersects": {"type": "geometry"},
                 },
                 "type": "DATA",
                 "isDryRunSupported": True,
@@ -74,6 +75,16 @@ JSON_WORKFLOW_TASKS = {
                         "default": 768,
                         "required": True,
                         "description": "Width of a tile in pixels",
+                    },
+                    "required_but_no_default": {
+                        "type": "number",
+                        "required": True,
+                        "description": "case for tests",
+                    },
+                    "not_required_no_default": {
+                        "type": "number",
+                        "required": False,
+                        "description": "2nd case for tests",
                     },
                 },
                 "type": "PROCESSING",

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -182,12 +182,19 @@ def test_get_default_parameters(workflow_mock):
         x in list(default_parameters.keys())
         for x in ["tiling:1", "esa-s2-l2a-gtiff-visual:1"]
     )
-    assert default_parameters["tiling:1"] == {"nodata": None, "tile_width": 768}
+    assert default_parameters["tiling:1"] == {
+        "nodata": None,
+        "tile_width": 768,
+        "required_but_no_default": None,
+    }
+    assert "not_required_no_default" not in default_parameters["tiling:1"]
+
     assert default_parameters["esa-s2-l2a-gtiff-visual:1"] == {
         "ids": None,
         "bbox": None,
         "time": "2018-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
     }
+    assert "intersects" not in default_parameters["esa-s2-l2a-gtiff-visual:1"]
 
 
 def test_construct_parameters_scene_ids(workflow_mock):
@@ -203,7 +210,11 @@ def test_construct_parameters_scene_ids(workflow_mock):
             "bbox": [0.99999, 2.99999, 1.00001, 3.00001],
             "limit": 1,
         },
-        "tiling:1": {"nodata": "None", "tile_width": 768},
+        "tiling:1": {
+            "nodata": None,
+            "tile_width": 768,
+            "required_but_no_default": None,
+        },
     }
 
 
@@ -215,10 +226,14 @@ def test_construct_parameter_scene_ids_without_geometry(workflow_mock):
     assert parameters == {
         "esa-s2-l2a-gtiff-visual:1": {
             "ids": ["s2_123223"],
-            "bbox": "None",
+            "bbox": None,
             "limit": 1,
         },
-        "tiling:1": {"nodata": "None", "tile_width": 768},
+        "tiling:1": {
+            "nodata": None,
+            "tile_width": 768,
+            "required_but_no_default": None,
+        },
     }
 
 
@@ -227,7 +242,11 @@ def test_construct_parameter_assets(workflow_mock, asset_mock):
     assert isinstance(parameters, dict)
     assert parameters == {
         "esa-s2-l2a-gtiff-visual:1": {"asset_ids": [asset_mock.asset_id]},
-        "tiling:1": {"nodata": "None", "tile_width": 768},
+        "tiling:1": {
+            "nodata": None,
+            "tile_width": 768,
+            "required_but_no_default": None,
+        },
     }
 
     parameters = workflow_mock.construct_parameters(asset_ids=[ASSET_ID, ASSET_ID])
@@ -236,15 +255,23 @@ def test_construct_parameter_assets(workflow_mock, asset_mock):
         "esa-s2-l2a-gtiff-visual:1": {
             "asset_ids": [asset_mock.asset_id, asset_mock.asset_id]
         },
-        "tiling:1": {"nodata": "None", "tile_width": 768},
+        "tiling:1": {
+            "nodata": None,
+            "tile_width": 768,
+            "required_but_no_default": None,
+        },
     }
 
-    # To be deprecated
+    # Use of asset object to be deprecated
     parameters = workflow_mock.construct_parameters(assets=[asset_mock])
     assert isinstance(parameters, dict)
     assert parameters == {
         "esa-s2-l2a-gtiff-visual:1": {"asset_ids": [asset_mock.asset_id]},
-        "tiling:1": {"nodata": "None", "tile_width": 768},
+        "tiling:1": {
+            "nodata": None,
+            "tile_width": 768,
+            "required_but_no_default": None,
+        },
     }
 
 
@@ -261,12 +288,16 @@ def test_construct_parameters_parallel(workflow_mock):
     assert len(parameters_list) == 2
     assert parameters_list[0] == {
         "esa-s2-l2a-gtiff-visual:1": {
-            "ids": "None",
+            "ids": None,
             "bbox": [0.99999, 2.99999, 1.00001, 3.00001],
             "time": "2014-01-01T00:00:00Z/2016-12-31T23:59:59Z",
             "limit": 1,
         },
-        "tiling:1": {"nodata": "None", "tile_width": 768},
+        "tiling:1": {
+            "nodata": None,
+            "tile_width": 768,
+            "required_but_no_default": None,
+        },
     }
 
 
@@ -282,12 +313,16 @@ def test_construct_parameters_parallel_multiple_intervals(workflow_mock):
     assert len(parameters_list) == 4
     assert parameters_list[0] == {
         "esa-s2-l2a-gtiff-visual:1": {
-            "ids": "None",
+            "ids": None,
             "bbox": [0.99999, 2.99999, 1.00001, 3.00001],
             "time": "2014-01-01T00:00:00Z/2016-12-31T23:59:59Z",
             "limit": 1,
         },
-        "tiling:1": {"nodata": "None", "tile_width": 768},
+        "tiling:1": {
+            "nodata": None,
+            "tile_width": 768,
+            "required_but_no_default": None,
+        },
     }
 
     with pytest.raises(ValueError):
@@ -300,8 +335,12 @@ def test_construct_parameters_parallel_scene_ids(workflow_mock):
     )
     assert len(parameters_list) == 2
     assert parameters_list[0] == {
-        "esa-s2-l2a-gtiff-visual:1": {"ids": ["S2abc"], "bbox": "None", "limit": 1},
-        "tiling:1": {"nodata": "None", "tile_width": 768},
+        "esa-s2-l2a-gtiff-visual:1": {"ids": ["S2abc"], "bbox": None, "limit": 1},
+        "tiling:1": {
+            "nodata": None,
+            "tile_width": 768,
+            "required_but_no_default": None,
+        },
     }
 
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -182,10 +182,10 @@ def test_get_default_parameters(workflow_mock):
         x in list(default_parameters.keys())
         for x in ["tiling:1", "esa-s2-l2a-gtiff-visual:1"]
     )
-    assert default_parameters["tiling:1"] == {"nodata": "None", "tile_width": 768}
+    assert default_parameters["tiling:1"] == {"nodata": None, "tile_width": 768}
     assert default_parameters["esa-s2-l2a-gtiff-visual:1"] == {
-        "ids": "None",
-        "bbox": "None",
+        "ids": None,
+        "bbox": None,
         "time": "2018-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
     }
 

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -315,12 +315,13 @@ class Workflow:
         for task in workflow_tasks:
             task_name = task["name"]
             task_parameters = task["block"]["parameters"]
-
             default_task_parameters = {}
 
             for param_name, param_values in task_parameters.items():
-                if "default" in param_values and param_values["default"] is not None:
+                if "default" in param_values:
                     default_task_parameters[param_name] = param_values["default"]
+                else:
+                    default_task_parameters[param_name] = None
 
             default_workflow_parameters[task_name] = default_task_parameters
         return default_workflow_parameters
@@ -340,7 +341,7 @@ class Workflow:
         start_date: Optional[Union[str, datetime]] = None,
         end_date: Optional[Union[str, datetime]] = None,
         limit: Optional[int] = None,
-        scene_ids: Optional[list] = None,
+        scene_ids: Optional[List[str]] = None,
         asset_ids: Optional[List[str]] = None,
         **kwargs,
     ) -> dict:

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -305,7 +305,7 @@ class Workflow:
     def _get_default_parameters(self) -> dict:
         """
         Gets the default parameters for the workflow that can be directly used to
-        run a job. Excludes geometry operation and geometry of the data block.
+        run a job.
         """
         default_workflow_parameters = {}
 
@@ -315,13 +315,19 @@ class Workflow:
         for task in workflow_tasks:
             task_name = task["name"]
             task_parameters = task["block"]["parameters"]
-            default_task_parameters = {}
 
+            default_task_parameters = {}
+            # Add parameters if they have non-None default or are required (use default or otherwise None)
             for param_name, param_values in task_parameters.items():
                 if "default" in param_values:
                     default_task_parameters[param_name] = param_values["default"]
-                else:
-                    default_task_parameters[param_name] = None
+                if (
+                    "required" in param_values
+                    and param_name not in default_task_parameters
+                ):
+                    # required without default key, add as placeholder
+                    if param_values["required"]:
+                        default_task_parameters[param_name] = None
 
             default_workflow_parameters[task_name] = default_task_parameters
         return default_workflow_parameters
@@ -366,6 +372,10 @@ class Workflow:
         Returns:
             Dictionary of constructed input parameters.
         """
+        logger.info(
+            "See `workflow.get_workflow_tasks() for more detail on the parameters options."
+        )
+
         input_parameters = self._get_default_parameters()
         try:
             data_block_name = list(input_parameters.keys())[0]
@@ -404,7 +414,6 @@ class Workflow:
                     fc=aoi_fc,
                     geometry_operation=geometry_operation,  # type: ignore
                 )
-
                 input_parameters[data_block_name][geometry_operation] = aoi_feature
         return input_parameters
 

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -387,8 +387,6 @@ class Workflow:
                 input_parameters[data_block_name]["limit"] = limit
 
             if scene_ids is not None:
-                if not isinstance(scene_ids, list):
-                    scene_ids = [scene_ids]
                 input_parameters[data_block_name]["ids"] = scene_ids
                 input_parameters[data_block_name]["limit"] = len(scene_ids)
                 input_parameters[data_block_name].pop("time")


### PR DESCRIPTION
Changes behaviour of `workflow.construct_parameters` to be more user friendly.

- In workflow.construct_parameters, adds any parameters with `None` default, previously only non-None parameters were added.
- If a parameter is required but has no default value, now adds that value as `None` to inform the user about this parameter. Previously parameters without defaults were not added.

- Refactor `_get_default_parameters`
- Adds test cases for the different parameter conditions
- Fixes fixture values which were "None" strings instead of actual strings

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
