### PR TITLE
Simplify geometry handling point

### DIFF
--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -417,21 +417,12 @@ class Catalog(CatalogBase, VizTools):
         schema = self.get_data_product_schema(data_product_id)
         order_parameters = autocomplete_order_parameters(order_parameters, schema)
 
-        if "aoi" in order_parameters["params"]:
-            if aoi is None:
-                logger.info(
-                    "This data product requires selecting `aoi` parameter, a Polygon geometry."
-                )
-            else:
-                aoi = any_vector_to_fc(vector=aoi)
-                aoi = fc_to_query_geometry(fc=aoi, geometry_operation="intersects")
-                order_parameters["params"]["aoi"] = aoi  # type: ignore
-        else:
-            # Some catalog orders, e.g. Capella don't require aoi (full image order)
-            # Also will raise API error when creating an order for this case.
-            logger.info(
-                "This data product is a full image order, no `aoi` parameter required!"
-            )
+        # Some catalog orders, e.g. Capella don't require aoi (full image order)
+        # Handled on API level, don't manipulate in SDK, providers might accept geometries in the future.
+        if aoi is not None:
+            aoi = any_vector_to_fc(vector=aoi)
+            aoi = fc_to_query_geometry(fc=aoi, geometry_operation="intersects")
+            order_parameters["params"]["aoi"] = aoi  # type: ignore
 
         return order_parameters
 


### PR DESCRIPTION
Removes the overcomplicated handling of geometry edge cases for catalog - full image orders & tasking - point geometry.
Wrong parameters here should be handled on API level. Now allows providing a Point geometry for tasking, but does not validate the order_parameters.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
