### PR TITLE
fix initialization test - set auth to none

### DIFF
--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1,5 +1,3 @@
-import importlib
-
 import pytest
 
 # pylint: disable=unused-import
@@ -36,11 +34,10 @@ from .fixtures import (
 # pylint: disable=wrong-import-order
 import up42
 
-# pylint: disable=wrong-import-order
-importlib.reload(up42)  # global auth attached from other tests
-
 
 def test_initialize_object_without_auth_raises():
+    up42.main._auth = None
+
     with pytest.raises(RuntimeError):
         up42.initialize_project()
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
fix initialization test - set auth to none

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
