### PR TITLE
Adapt to storage 2.0 API changes

### DIFF
--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -14,13 +14,13 @@ def asset_mock(auth_mock, requests_mock):
 
     # asset info
     url_asset_info = (
-        f"{auth_mock._endpoint()}/workspaces/{auth_mock.workspace_id}/assets/{ASSET_ID}"
+        f"{auth_mock._endpoint()}/v2/assets/{ASSET_ID}/metadata"
     )
     requests_mock.get(url=url_asset_info, json=JSON_ASSET)
 
     # download url
     requests_mock.get(
-        url=f"{auth_mock._endpoint()}/workspaces/{auth_mock.workspace_id}/assets/{ASSET_ID}/downloadUrl",
+        url=f"{auth_mock._endpoint()}/v2/assets/{ASSET_ID}/download-url",
         json={"data": {"url": DOWNLOAD_URL}},
     )
 

--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -18,6 +18,12 @@ def asset_mock(auth_mock, requests_mock):
     )
     requests_mock.get(url=url_asset_info, json=JSON_ASSET)
 
+    # asset update
+    updated_json_asset = JSON_ASSET.copy()
+    updated_json_asset["title"] = "some_other_title"
+    updated_json_asset["tags"] = ["othertag1", "othertag2"]
+    requests_mock.post(url=url_asset_info, json=updated_json_asset)
+
     # download url
     requests_mock.get(
         url=f"{auth_mock._endpoint()}/v2/assets/{ASSET_ID}/download-url",

--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -23,7 +23,7 @@ def asset_mock(auth_mock, requests_mock):
     requests_mock.post(url=url_asset_info, json=updated_json_asset)
 
     # download url
-    requests_mock.get(
+    requests_mock.post(
         url=f"{auth_mock._endpoint()}/v2/assets/{ASSET_ID}/download-url",
         json={"data": {"url": DOWNLOAD_URL}},
     )

--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -25,7 +25,7 @@ def asset_mock(auth_mock, requests_mock):
     # download url
     requests_mock.post(
         url=f"{auth_mock._endpoint()}/v2/assets/{ASSET_ID}/download-url",
-        json={"data": {"url": DOWNLOAD_URL}},
+        json={"url": DOWNLOAD_URL},
     )
 
     asset = Asset(auth=auth_mock, asset_id=ASSET_ID)

--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -13,9 +13,7 @@ from ..context import (
 def asset_mock(auth_mock, requests_mock):
 
     # asset info
-    url_asset_info = (
-        f"{auth_mock._endpoint()}/v2/assets/{ASSET_ID}/metadata"
-    )
+    url_asset_info = f"{auth_mock._endpoint()}/v2/assets/{ASSET_ID}/metadata"
     requests_mock.get(url=url_asset_info, json=JSON_ASSET)
 
     # asset update

--- a/tests/fixtures/fixtures_globals.py
+++ b/tests/fixtures/fixtures_globals.py
@@ -147,7 +147,6 @@ JSON_WORKFLOW_ESTIMATION = {
 }
 
 JSON_ASSET = {
-    "data": {
         "id": ASSET_ID,
         "workspaceId": WORKSPACE_ID,
         "createdAt": "2020-12-17T10:41:24.774111Z",
@@ -157,14 +156,11 @@ JSON_ASSET = {
         "size": 3920650,
         "createdBy": {"id": "system", "type": "INTERNAL"},
         "updatedBy": {"id": "system", "type": "INTERNAL"},
-        "updatedAt": "2020-12-17T10:41:24.774111Z",
-    },
-    "error": None,
+        "updatedAt": "2020-12-17T10:41:24.774111Z"
 }
 
 JSON_ASSETS = {
-    "data": {
-        "content": [JSON_ASSET["data"]],
+        "content": [JSON_ASSET],
         "pageable": {
             "sort": {"sorted": True, "unsorted": False, "empty": False},
             "pageNumber": 0,
@@ -182,8 +178,6 @@ JSON_ASSETS = {
         "size": 10,
         "number": 0,
         "empty": False,
-    },
-    "error": None,
 }
 
 JSON_ORDER = {

--- a/tests/fixtures/fixtures_globals.py
+++ b/tests/fixtures/fixtures_globals.py
@@ -147,37 +147,37 @@ JSON_WORKFLOW_ESTIMATION = {
 }
 
 JSON_ASSET = {
-        "id": ASSET_ID,
-        "workspaceId": WORKSPACE_ID,
-        "createdAt": "2020-12-17T10:41:24.774111Z",
-        "type": "ARCHIVED",
-        "source": "BLOCK",
-        "name": "DS_PHR1B_201903161028440_FR1_PX_E008N47_0606_04372",
-        "size": 3920650,
-        "createdBy": {"id": "system", "type": "INTERNAL"},
-        "updatedBy": {"id": "system", "type": "INTERNAL"},
-        "updatedAt": "2020-12-17T10:41:24.774111Z"
+    "id": ASSET_ID,
+    "workspaceId": WORKSPACE_ID,
+    "createdAt": "2020-12-17T10:41:24.774111Z",
+    "type": "ARCHIVED",
+    "source": "BLOCK",
+    "name": "DS_PHR1B_201903161028440_FR1_PX_E008N47_0606_04372",
+    "size": 3920650,
+    "createdBy": {"id": "system", "type": "INTERNAL"},
+    "updatedBy": {"id": "system", "type": "INTERNAL"},
+    "updatedAt": "2020-12-17T10:41:24.774111Z",
 }
 
 JSON_ASSETS = {
-        "content": [JSON_ASSET],
-        "pageable": {
-            "sort": {"sorted": True, "unsorted": False, "empty": False},
-            "pageNumber": 0,
-            "pageSize": 10,
-            "offset": 0,
-            "paged": True,
-            "unpaged": False,
-        },
-        "totalPages": 1,
-        "totalElements": 1,
-        "last": True,
+    "content": [JSON_ASSET],
+    "pageable": {
         "sort": {"sorted": True, "unsorted": False, "empty": False},
-        "numberOfElements": 1,
-        "first": True,
-        "size": 10,
-        "number": 0,
-        "empty": False,
+        "pageNumber": 0,
+        "pageSize": 10,
+        "offset": 0,
+        "paged": True,
+        "unpaged": False,
+    },
+    "totalPages": 1,
+    "totalElements": 1,
+    "last": True,
+    "sort": {"sorted": True, "unsorted": False, "empty": False},
+    "numberOfElements": 1,
+    "first": True,
+    "size": 10,
+    "number": 0,
+    "empty": False,
 }
 
 JSON_ORDER = {

--- a/tests/fixtures/fixtures_globals.py
+++ b/tests/fixtures/fixtures_globals.py
@@ -148,15 +148,20 @@ JSON_WORKFLOW_ESTIMATION = {
 
 JSON_ASSET = {
     "id": ASSET_ID,
+    "accountId": "69353acb-f942-423f-8f32-11d6d67caa77",
     "workspaceId": WORKSPACE_ID,
-    "createdAt": "2020-12-17T10:41:24.774111Z",
-    "type": "ARCHIVED",
-    "source": "BLOCK",
-    "name": "DS_PHR1B_201903161028440_FR1_PX_E008N47_0606_04372",
-    "size": 3920650,
-    "createdBy": {"id": "system", "type": "INTERNAL"},
-    "updatedBy": {"id": "system", "type": "INTERNAL"},
-    "updatedAt": "2020-12-17T10:41:24.774111Z",
+    "size": 256248634,
+    "name": "string",
+    "created": "2022-12-07T14:25:34.968Z",
+    "updated": "2022-12-07T14:25:34.968Z",
+    "contentType": "string",
+    "producerName": "string",
+    "collectionName": "string",
+    "productId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "source": "ARCHIVE",
+    "order": {"id": "string", "status": "string", "hostId": "string"},
+    "title": "string",
+    "tags": ["string"],
 }
 
 JSON_ASSETS = {

--- a/tests/fixtures/fixtures_storage.py
+++ b/tests/fixtures/fixtures_storage.py
@@ -17,15 +17,11 @@ from ..context import (
 @pytest.fixture()
 def storage_mock(auth_mock, requests_mock):
     # assets
-    url_storage_assets = (
-        f"{auth_mock._endpoint()}/workspaces/{auth_mock.workspace_id}/assets"
-    )
+    url_storage_assets = f"{auth_mock._endpoint()}/v2/assets"
     requests_mock.get(url=url_storage_assets, json=JSON_ASSETS)
 
     # asset info
-    url_asset_info = (
-        f"{auth_mock._endpoint()}/workspaces/{auth_mock.workspace_id}/assets/{ASSET_ID}"
-    )
+    url_asset_info = f"{auth_mock._endpoint()}/v2/assets/{ASSET_ID}/metadata"
     requests_mock.get(url=url_asset_info, json=JSON_ASSET)
 
     # orders

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -24,7 +24,7 @@ def test_init(asset_mock):
 def test_asset_info(asset_mock):
     assert asset_mock.info
     assert asset_mock.info["id"] == ASSET_ID
-    assert asset_mock.info["name"] == JSON_ASSET["data"]["name"]
+    assert asset_mock.info["name"] == JSON_ASSET["name"]
 
 
 @pytest.mark.live

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -39,6 +39,7 @@ def test_asset_update_metadata(asset_mock):
         title="some_other_title", tags=["othertag1", "othertag2"]
     )
     assert updated_info["title"] == "some_other_title"
+    assert updated_info["tags"] == ["othertag1", "othertag2"]
 
 
 def test_asset_get_download_url(asset_mock):

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -35,7 +35,9 @@ def test_asset_info_live(asset_live):
 
 
 def test_asset_update_metadata(asset_mock):
-    updated_info = asset_mock.update_metadata(title="some_other_title", tags=["othertag1", "othertag2"])
+    updated_info = asset_mock.update_metadata(
+        title="some_other_title", tags=["othertag1", "othertag2"]
+    )
     assert updated_info["title"] == "some_other_title"
 
 

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -34,13 +34,9 @@ def test_asset_info_live(asset_live):
     assert asset_live.info["name"]
 
 
-def test_asset_source(asset_mock):
-    assert asset_mock.source == "BLOCK"
-
-
-@pytest.mark.live
-def test_asset_source_live(asset_live):
-    assert asset_live.source == "BLOCK"
+def test_asset_update_metadata(asset_mock):
+    updated_info = asset_mock.update_metadata(title="some_other_title", tags=["othertag1", "othertag2"])
+    assert updated_info["title"] == "some_other_title"
 
 
 def test_asset_get_download_url(asset_mock):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -146,7 +146,7 @@ def test_get_assets_pagination(auth_mock, requests_mock):
 
     # assets pages
     url_storage_assets_paginated = (
-        f"{auth_mock._endpoint()}/v2/assets?format=paginated&sort=created,asc&size=50"
+        f"{auth_mock._endpoint()}/v2/assets?sort=created,asc&size=50"
     )
     requests_mock.get(url=url_storage_assets_paginated, json=json_assets_paginated)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -113,7 +113,7 @@ def test_get_assets_live(storage_live):
     """
     assets = storage_live.get_assets()
     assert len(assets) >= 2
-    dates = [asset.info["createdAt"] for asset in assets]
+    dates = [asset.info["created"] for asset in assets]
     # default descending, newest to oldest.
     descending_dates = sorted(dates)[::-1]
     assert descending_dates == dates

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -157,11 +157,6 @@ def test_get_assets_pagination(auth_mock, requests_mock):
     assert assets[0].asset_id == ASSET_ID
 
 
-def test_get_assets_raises_with_illegal_sorting_criteria(storage_mock):
-    with pytest.raises(ValueError):
-        storage_mock.get_assets(sortby="notavailable")
-
-
 def test_get_orders(storage_mock):
     orders = storage_mock.get_orders()
     assert len(orders) == 1

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -124,38 +124,34 @@ def test_get_assets_pagination(auth_mock, requests_mock):
     Mock result holds 2 pages, each with 50 results.
     """
     json_assets_paginated = {
-        "data": {
-            "content": [JSON_ASSET["data"]] * 50,
-            "pageable": {
-                "sort": {"sorted": True, "unsorted": False, "empty": False},
-                "pageNumber": 0,
-                "pageSize": 50,
-                "offset": 0,
-                "paged": True,
-                "unpaged": False,
-            },
-            "totalPages": 2,
-            "totalElements": 100,
-            "last": True,
+        "content": [JSON_ASSET] * 50,
+        "pageable": {
             "sort": {"sorted": True, "unsorted": False, "empty": False},
-            "numberOfElements": 100,
-            "first": True,
-            "size": 50,
-            "number": 0,
-            "empty": False,
+            "pageNumber": 0,
+            "pageSize": 50,
+            "offset": 0,
+            "paged": True,
+            "unpaged": False,
         },
-        "error": None,
+        "totalPages": 2,
+        "totalElements": 100,
+        "last": True,
+        "sort": {"sorted": True, "unsorted": False, "empty": False},
+        "numberOfElements": 100,
+        "first": True,
+        "size": 50,
+        "number": 0,
+        "empty": False,
     }
 
     # assets pages
     url_storage_assets_paginated = (
-        f"{auth_mock._endpoint()}/workspaces/{auth_mock.workspace_id}/"
-        f"assets?format=paginated&sort=createdAt,asc&size=50"
+        f"{auth_mock._endpoint()}/v2/assets?format=paginated&sort=created,asc&size=50"
     )
     requests_mock.get(url=url_storage_assets_paginated, json=json_assets_paginated)
 
     storage = Storage(auth=auth_mock)
-    assets = storage.get_assets(limit=74, sortby="createdAt", descending=False)
+    assets = storage.get_assets(limit=74, sortby="created", descending=False)
     assert len(assets) == 74
     assert isinstance(assets[0], Asset)
     assert assets[0].asset_id == ASSET_ID

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -32,8 +32,10 @@ class Asset:
             self._info = self.info
 
     def __repr__(self):
-        repr = f"Asset(name: {self._info['name']}, asset_id: {self.asset_id}, created: {self._info['created']}, " \
-               f"size: {self._info['size']})"
+        repr = (
+            f"Asset(name: {self._info['name']}, asset_id: {self.asset_id}, created: {self._info['created']}, "
+            f"size: {self._info['size']})"
+        )
         if "source" in self._info:
             repr += f", source: {self._info['source']}"
         if "contentType" in self._info:

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -32,15 +32,15 @@ class Asset:
             self._info = self.info
 
     def __repr__(self):
-        repr = (
+        representation = (
             f"Asset(name: {self._info['name']}, asset_id: {self.asset_id}, created: {self._info['created']}, "
             f"size: {self._info['size']})"
         )
         if "source" in self._info:
-            repr += f", source: {self._info['source']}"
+            representation += f", source: {self._info['source']}"
         if "contentType" in self._info:
-            repr += f", contentType: {self._info['contentType']}"
-        return repr
+            representation += f", contentType: {self._info['contentType']}"
+        return representation
 
     @property
     def info(self) -> dict:

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -52,14 +52,12 @@ class Asset:
         self._info = response_json
         return self._info
 
-    def update_metadata(self, title: str=None, tags: List[str] = None, **kwargs):
+    def update_metadata(self, title: str = None, tags: List[str] = None, **kwargs):
         url = f"{self.auth._endpoint()}/v2/assets/{self.asset_id}/metadata"
-        body_update = {
-            "title": title,
-            "tags": tags,
-            **kwargs
-        }
-        response_json = self.auth._request(request_type="POST", url=url, data=body_update)
+        body_update = {"title": title, "tags": tags, **kwargs}
+        response_json = self.auth._request(
+            request_type="POST", url=url, data=body_update
+        )
         self._info = response_json
         return self._info
 

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -63,7 +63,7 @@ class Asset:
 
     def _get_download_url(self) -> str:
         url = f"{self.auth._endpoint()}/v2/assets/{self.asset_id}/download-url"
-        response_json = self.auth._request(request_type="GET", url=url)
+        response_json = self.auth._request(request_type="POST", url=url)
         download_url = response_json["data"]["url"]
         return download_url
 

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -32,11 +32,13 @@ class Asset:
             self._info = self.info
 
     def __repr__(self):
-        return (
-            f"Asset(name: {self._info['name']}, asset_id: {self.asset_id}, type: {self._info['type']}, "
-            f"source: {self._info['source']}, createdAt: {self._info['createdAt']}, "
-            f"size: {self._info['size']})"
-        )
+        repr = f"Asset(name: {self._info['name']}, asset_id: {self.asset_id}, created: {self._info['created']}, " \
+               f"size: {self._info['size']})"
+        if "source" in self._info:
+            repr += f", source: {self._info['source']}"
+        if "contentType" in self._info:
+            repr += f", contentType: {self._info['contentType']}"
+        return repr
 
     @property
     def info(self) -> dict:

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -52,16 +52,22 @@ class Asset:
         self._info = response_json
         return self._info
 
+    def update_metadata(self, title: str=None, tags: List[str] = None, **kwargs):
+        url = f"{self.auth._endpoint()}/v2/assets/{self.asset_id}/metadata"
+        body_update = {
+            "title": title,
+            "tags": tags,
+            **kwargs
+        }
+        response_json = self.auth._request(request_type="POST", url=url, data=body_update)
+        self._info = response_json
+        return self._info
+
     def _get_download_url(self) -> str:
         url = f"{self.auth._endpoint()}/v2/assets/{self.asset_id}/download-url"
         response_json = self.auth._request(request_type="GET", url=url)
         download_url = response_json["data"]["url"]
         return download_url
-
-    def update_metadata(self):
-        # TODO
-        # Any checks in place etc? Overwrite anything? also size?
-        pass
 
     def download(
         self, output_directory: Union[str, Path, None] = None, unpacking: bool = True

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -64,7 +64,7 @@ class Asset:
     def _get_download_url(self) -> str:
         url = f"{self.auth._endpoint()}/v2/assets/{self.asset_id}/download-url"
         response_json = self.auth._request(request_type="POST", url=url)
-        download_url = response_json["data"]["url"]
+        download_url = response_json["url"]
         return download_url
 
     def download(

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -24,7 +24,6 @@ class Asset:
 
     def __init__(self, auth: Auth, asset_id: str, asset_info: Optional[dict] = None):
         self.auth = auth
-        self.workspace_id = auth.workspace_id
         self.asset_id = asset_id
         self.results: Union[List[str], None] = None
         if asset_info is not None:
@@ -44,9 +43,9 @@ class Asset:
         """
         Gets and updates the asset metadata information.
         """
-        url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/assets/{self.asset_id}"
+        url = f"{self.auth._endpoint()}/v2/assets/{self.asset_id}/metadata"
         response_json = self.auth._request(request_type="GET", url=url)
-        self._info = response_json["data"]
+        self._info = response_json
         return self._info
 
     @property

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -52,20 +52,16 @@ class Asset:
         self._info = response_json
         return self._info
 
-    @property
-    def source(self) -> dict:
-        """
-        Gets the source of the Asset. One of `TASKING`, `ORDER`, `BLOCK`, `UPLOAD`.
-        """
-        source = self.info["source"]
-        logger.info(f"Asset source is {source}")
-        return source
-
     def _get_download_url(self) -> str:
         url = f"{self.auth._endpoint()}/v2/assets/{self.asset_id}/download-url"
         response_json = self.auth._request(request_type="GET", url=url)
         download_url = response_json["data"]["url"]
         return download_url
+
+    def update_metadata(self):
+        # TODO
+        # Any checks in place etc? Overwrite anything? also size?
+        pass
 
     def download(
         self, output_directory: Union[str, Path, None] = None, unpacking: bool = True

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -62,7 +62,7 @@ class Asset:
         return source
 
     def _get_download_url(self) -> str:
-        url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/assets/{self.asset_id}/downloadUrl"
+        url = f"{self.auth._endpoint()}/v2/assets/{self.asset_id}/download-url"
         response_json = self.auth._request(request_type="GET", url=url)
         download_url = response_json["data"]["url"]
         return download_url

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -93,27 +93,16 @@ class Storage:
                 your own workspace.
             limit: Optional, only return n first assets by sorting criteria and order.
                 Optimal to select if your workspace contains many assets.
-            sortby: The sorting criteria, one of "created", "updated", "workspaceId", "name", "size".
+            sortby: The sorting criteria, one of "created", "updated", "title", "name", "size", "contentType",
+                "collectionName", "producerName", "workspaceId", "accountId", "id"
             descending: The sorting order, True for descending (default), False for ascending.
             return_json: If set to True, returns json object.
 
         Returns:
             Asset objects in the workspace or alternatively json info of the assets.
         """
-        allowed_sorting_criteria = [
-            "created",
-            "updated",
-            "workspaceId",
-            "type",
-            "name",
-            "size",
-        ]
-        if sortby not in allowed_sorting_criteria:
-            raise ValueError(
-                f"sortby parameter must be one of {allowed_sorting_criteria}!"
-            )
         sort = f"{sortby},{'desc' if descending else 'asc'}"
-        url = f"{self.auth._endpoint()}/v2/assets?format=paginated&sort={sort}"
+        url = f"{self.auth._endpoint()}/v2/assets?sort={sort}"
         if created_after is not None:
             url += f"&{created_after}"
         if created_before is not None:

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -82,7 +82,7 @@ class Storage:
         return_json: bool = False,
     ) -> Union[List[Asset], dict]:
         """
-        Gets all assets in the workspace as Asset objects or json.
+        Gets all assets in all your accessible workspaces as Asset objects or json.
 
         Args:
             created_after: Only assets that are created strictly after the provided timestamp, e.g. "2020-01-01",

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -46,7 +46,9 @@ class Storage:
         url = url + f"&size={size}"
 
         first_page_response = self.auth._request(request_type="GET", url=url)
-        if "data" in first_page_response: #UP42 API v2 convention without data key, but still in e.g. get order
+        if (
+            "data" in first_page_response
+        ):  # UP42 API v2 convention without data key, but still in e.g. get order
             # endpoint
             first_page_response = first_page_response["data"]
         num_pages = first_page_response["totalPages"]

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -100,7 +100,7 @@ class Storage:
                 f"sortby parameter must be one of {allowed_sorting_criteria}!"
             )
         sort = f"{sortby},{'desc' if descending else 'asc'}"
-        url = f"{self.auth._endpoint()}/workspaces/{self.workspace_id}/assets?format=paginated&sort={sort}"
+        url = f"{self.auth._endpoint()}/assets?format=paginated&sort={sort}"
         assets_json = self._query_paginated(url=url, limit=limit)
         logger.info(f"Got {len(assets_json)} assets for workspace {self.workspace_id}.")
 

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -114,6 +114,12 @@ class Storage:
             )
         sort = f"{sortby},{'desc' if descending else 'asc'}"
         url = f"{self.auth._endpoint()}/v2/assets?format=paginated&sort={sort}"
+        if created_after is not None:
+            url += f"&{created_after}"
+        if created_before is not None:
+            url += f"{created_before}"
+        if workspace_id is not None:
+            url += f"{workspace_id}"
         assets_json = self._query_paginated(url=url, limit=limit)
         logger.info(f"Got {len(assets_json)} assets for workspace {self.workspace_id}.")
 

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -68,6 +68,8 @@ class Storage:
             response_json = self.auth._request(
                 request_type="GET", url=url + f"&page={page}"
             )
+            if "data" in response_json:
+                response_json = response_json["data"]
             results_list += response_json["content"]
         return results_list[:limit]
 

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -88,8 +88,10 @@ class Storage:
         Gets all assets in all your accessible workspaces as Asset objects or json.
 
         Args:
-            created_after: Only assets that are created strictly after the provided timestamp, e.g. "2020-01-01",
-            created_before: Only assets that are created strictly before the provided timestamp, e.g. "2020-01-30"
+            created_after: Only assets that are created strictly after the provided timestamp, datetime or
+                isoformat string e.g. "2022-01-01",
+            created_before: Only assets that are created strictly before the provided timestamp, datetime or
+                isoformat string e.g. "2022-01-30"
             workspace_id: Only assets that belong to the provided workspace. You can use `storage.workspace_id` here
                 to limit to your own workspace.
             limit: Optional, only return n first assets by sorting criteria and order.
@@ -113,9 +115,13 @@ class Storage:
 
         assets_json = self._query_paginated(url=url, limit=limit)
         if workspace_id is not None:
-            logger.info(f"Queried {len(assets_json)} assets for workspace {self.workspace_id}.")
+            logger.info(
+                f"Queried {len(assets_json)} assets for workspace {self.workspace_id}."
+            )
         else:
-            logger.info(f"Queried {len(assets_json)} assets from all workspaces in account.")
+            logger.info(
+                f"Queried {len(assets_json)} assets from all workspaces in account."
+            )
 
         if return_json:
             return assets_json  # type: ignore

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -177,6 +177,13 @@ def download_gcs_not_unpack(
     return out_filepaths
 
 
+def format_time(date: Optional[Union[str, datetime]]):
+    formatting = "%Y-%m-%dT%H:%M:%S"
+    if not isinstance(date, datetime):
+        date: datetime = datetime.fromisoformat(date)
+    return f"{date.strftime(formatting)}Z"
+
+
 def format_time_period(
     start_date: Optional[Union[str, datetime]], end_date: Optional[Union[str, datetime]]
 ):

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -180,7 +180,7 @@ def download_gcs_not_unpack(
 def format_time(date: Optional[Union[str, datetime]]):
     formatting = "%Y-%m-%dT%H:%M:%S"
     if not isinstance(date, datetime):
-        date: datetime = datetime.fromisoformat(date)
+        date = datetime.fromisoformat(date)  # type: ignore
     return f"{date.strftime(formatting)}Z"
 
 


### PR DESCRIPTION
Updates to the Storage 2.0 API revamp
- Adjusts endpoints for get-assets, asset-info, asset-download-url
- Adds asset-update-metadata
- Adjusts to new asset metadata conventions

Items:
* [x] Ran tests
* [] Ran live-tests
* [x] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
