### PR TITLE
Format time util

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -10,7 +10,6 @@ from up42.tools import read_vector_file, get_example_aoi
 from up42.viztools import folium_base_map, VizTools
 from up42.utils import (
     format_time,
-    format_time_period,
     any_vector_to_fc,
     fc_to_query_geometry,
     download_from_gcs_unpack,

--- a/tests/context.py
+++ b/tests/context.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../u
 from up42.tools import read_vector_file, get_example_aoi
 from up42.viztools import folium_base_map, VizTools
 from up42.utils import (
+    format_time,
     format_time_period,
     any_vector_to_fc,
     fc_to_query_geometry,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ import pytest
 from shapely.geometry import Polygon, LinearRing
 
 from .context import (
+    format_time,
     format_time_period,
     any_vector_to_fc,
     fc_to_query_geometry,
@@ -20,6 +21,22 @@ from .context import (
 
 
 POLY = Polygon([(0, 0), (1, 1), (1, 0)])
+
+
+@pytest.mark.parametrize(
+    "date,result_time",
+    [
+        ("2014-01-01", "2014-01-01T00:00:00Z"),
+        ("2014-01-01T00:00:00", "2014-01-01T00:00:00Z"),
+        (parse("2014-01-01"), "2014-01-01T00:00:00Z"),
+    ],
+)
+def test_format_time(date, result_time):
+    formatted_time = format_time(
+        date=date,
+    )
+    assert isinstance(formatted_time, str)
+    assert formatted_time == result_time
 
 
 @pytest.mark.parametrize(

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -18,9 +18,9 @@ from up42.utils import (
     get_logger,
     any_vector_to_fc,
     fc_to_query_geometry,
-    format_time_period,
     deprecation,
     autocomplete_order_parameters,
+    format_time,
 )
 
 logger = get_logger(__name__)
@@ -247,7 +247,9 @@ class Catalog(CatalogBase, VizTools):
         Returns:
             The constructed parameters dictionary.
         """
-        time_period = format_time_period(start_date=start_date, end_date=end_date)
+        time_period = (
+            f"{format_time(start_date)}/{format_time(end_date, set_end_of_day=True)}"
+        )
         aoi_fc = any_vector_to_fc(
             vector=geometry,
         )

--- a/up42/main.py
+++ b/up42/main.py
@@ -26,7 +26,7 @@ import pandas as pd
 # pylint: disable=wrong-import-position
 from up42.auth import Auth
 from up42.webhooks import Webhooks, Webhook
-from up42.utils import get_logger, format_time_period
+from up42.utils import get_logger, format_time
 
 logger = get_logger(__name__, level=logging.INFO)
 
@@ -258,16 +258,14 @@ def get_credits_history(
     The consumption history will be returned for all workspace_ids on your account.
 
     Args:
-        start_date: The start date for the credit consumption search e.g.
+        start_date: The start date for the credit consumption search, datetime or isoformat string e.g.
             2021-12-01. Default start_date None uses 2000-01-01.
-        end_date: The end date for the credit consumption search e.g.
+        end_date: The end date for the credit consumption search, datetime or isoformat string e.g.
             2021-12-31. Default end_date None uses current date.
 
     Returns:
-        A dict with the information of the credit consumption records for
-        all the users linked by the account_id.
-        (see https://docs.up42.com/developers/api#operation/getHistory for
-        output description)
+        A dict with the information of the credit consumption records for all the users linked by the account_id.
+        (see https://docs.up42.com/developers/api#operation/getHistory for output description)
     """
     if start_date is None:
         start_date = "2000-01-01"
@@ -280,13 +278,10 @@ def get_credits_history(
         )
         end_date = tomorrow_datetime.strftime("%Y-%m-%d")
 
-    [start_formatted_date, end_formatted_date] = format_time_period(
-        start_date=start_date, end_date=end_date
-    ).split("/")
     search_parameters = dict(
         {
-            "from": start_formatted_date,
-            "to": end_formatted_date,
+            "from": format_time(start_date),
+            "to": format_time(end_date, set_end_of_day=True),
             "size": 2000,  # 2000 is the maximum page size for this call
             "page": 0,
         }

--- a/up42/tasking.py
+++ b/up42/tasking.py
@@ -1,7 +1,8 @@
 """
 Tasking functionality
 """
-from typing import Union
+from typing import Union, Optional
+from datetime import datetime
 
 from geopandas import GeoDataFrame
 from shapely.geometry import Polygon
@@ -11,7 +12,7 @@ from up42.auth import Auth
 from up42.catalog import CatalogBase
 from up42.utils import (
     get_logger,
-    format_time_period,
+    format_time,
     any_vector_to_fc,
     fc_to_query_geometry,
     autocomplete_order_parameters,
@@ -39,8 +40,8 @@ class Tasking(CatalogBase):
         self,
         data_product_id: str,
         name: str,
-        acquisition_start: str,
-        acquisition_end: str,
+        acquisition_start: Union[str, datetime],
+        acquisition_end: Union[str, datetime],
         geometry: Union[dict, Feature, FeatureCollection, list, GeoDataFrame, Polygon],
     ):
         """
@@ -51,8 +52,8 @@ class Tasking(CatalogBase):
         Args:
             data_product_id: Id of the desired UP42 data product, see `tasking.get_data_products`
             name: Name of the tasking order project.
-            acquisition_start: Start date of the acquisition period, e.g. "2022-11-01"
-            acquisition_end: End date of the acquisition period, e.g. "2022-11-01"
+            acquisition_start: Start date of the acquisition period, datetime or isoformat string e.g. "2022-11-01"
+            acquisition_end: End date of the acquisition period, datetime or isoformat string e.g. "2022-11-01"
             geometry: Geometry of the area to be captured, default a Polygon. Allows Point feature for specific
                 data products.
 
@@ -75,16 +76,12 @@ class Tasking(CatalogBase):
                 )
             ```
         """
-        start_date, end_date = format_time_period(
-            start_date=acquisition_start, end_date=acquisition_end
-        ).split("/")
-
         order_parameters = {
             "dataProduct": data_product_id,
             "params": {
                 "displayName": name,
-                "acquisitionStart": start_date,
-                "acquisitionEnd": end_date,
+                "acquisitionStart": format_time(acquisition_start),
+                "acquisitionEnd": format_time(acquisition_end, set_end_of_day=True),
             },
         }
 

--- a/up42/tasking.py
+++ b/up42/tasking.py
@@ -1,7 +1,7 @@
 """
 Tasking functionality
 """
-from typing import Union, Optional
+from typing import Union
 from datetime import datetime
 
 from geopandas import GeoDataFrame

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -187,9 +187,9 @@ def format_time(date: Optional[Union[str, datetime]], set_end_of_day=False):
             type date string without time, e.g. "YYYY-MM-DD", not explicit datetime object or time of day.
     """
     if isinstance(date, str):
-        has_time_of_date = len(date) > 11
+        has_time_of_day = len(date) > 11
         date = datetime.fromisoformat(date)  # type: ignore
-        if not has_time_of_date and set_end_of_day:
+        if not has_time_of_day and set_end_of_day:
             date = datetime.combine(date.date(), datetime_time(23, 59, 59, 999999))
     elif isinstance(date, datetime):
         pass

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -177,58 +177,26 @@ def download_gcs_not_unpack(
     return out_filepaths
 
 
-def format_time(date: Optional[Union[str, datetime]]):
-    formatting = "%Y-%m-%dT%H:%M:%S"
-    if not isinstance(date, datetime):
-        date = datetime.fromisoformat(date)  # type: ignore
-    return f"{date.strftime(formatting)}Z"
-
-
-def format_time_period(
-    start_date: Optional[Union[str, datetime]], end_date: Optional[Union[str, datetime]]
-):
+def format_time(date: Optional[Union[str, datetime]], set_end_of_day=False):
     """
-    Formats a time period string from start date and end date.
+    Formats date isostring to datetime string format
 
     Args:
-        start_date: Query period starting day as iso-format string or datetime object,
-            e.g. "YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS".
-        end_date: Query period ending day as iso-format or datetime object,
-            e.g. "YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS".
-
-    Returns:
-        Time period string in the format "2014-01-01T00:00:00Z/2016-12-31T10:11:12Z"
+        date: datetime object or isodatetime string e.g. "YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS".
+        set_end_of_day: Sets the date to end of day, as required for most image archive searches. Only applies for
+            type date string without time, e.g. "YYYY-MM-DD", not explicit datetime object or time of day.
     """
-    if start_date is None or end_date is None:
-        raise ValueError(
-            "When using dates, both start_date and end_date need to be provided."
-        )
-    # Start and end date can be any combination of str ("YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS")
-    # or datetime objects.
-    if not isinstance(start_date, datetime):
-        start_dt: datetime = datetime.fromisoformat(start_date)
+    if isinstance(date, str):
+        has_time_of_date = len(date) > 11
+        date = datetime.fromisoformat(date)  # type: ignore
+        if not has_time_of_date and set_end_of_day:
+            date = datetime.combine(date.date(), datetime_time(23, 59, 59, 999999))
+    elif isinstance(date, datetime):
+        pass
     else:
-        start_dt = start_date
+        raise ValueError("date needs to be of type datetime or isoformat date string!")
 
-    if not isinstance(end_date, datetime):
-        end_dt: datetime = datetime.fromisoformat(end_date)
-        try:
-            # For "YYYY-MM-DD" string the default datetime conversion sets to
-            # start of day, but image archive query requires end of day.
-            datetime.strptime(end_date, "%Y-%m-%d")  # format validation
-            end_dt = datetime.combine(end_dt.date(), datetime_time(23, 59, 59, 999999))
-        except ValueError:
-            pass
-    else:
-        end_dt = end_date
-
-    if start_dt > end_dt:
-        raise ValueError("The start_date can not be later than the end_date!")
-
-    formatting = "%Y-%m-%dT%H:%M:%S"
-    time_period = f"{start_dt.strftime(formatting)}Z/{end_dt.strftime(formatting)}Z"
-
-    return time_period
+    return date.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def any_vector_to_fc(

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -177,6 +177,13 @@ def download_gcs_not_unpack(
     return out_filepaths
 
 
+def format_time(date: Optional[Union[str, datetime]]):
+    formatting = "%Y-%m-%dT%H:%M:%S"
+    if not isinstance(date, datetime):
+        date = datetime.fromisoformat(date)  # type: ignore
+    return f"{date.strftime(formatting)}Z"
+
+
 def format_time_period(
     start_date: Optional[Union[str, datetime]], end_date: Optional[Union[str, datetime]]
 ):

--- a/up42/workflow.py
+++ b/up42/workflow.py
@@ -22,7 +22,7 @@ from up42.utils import (
     any_vector_to_fc,
     fc_to_query_geometry,
     filter_jobs_on_mode,
-    format_time_period,
+    format_time,
 )
 import up42.main as main
 
@@ -401,9 +401,11 @@ class Workflow:
                 input_parameters[data_block_name]["limit"] = len(scene_ids)
                 input_parameters[data_block_name].pop("time")
             elif start_date is not None or end_date is not None:
-                time_period = format_time_period(
-                    start_date=start_date, end_date=end_date
-                )
+                if start_date is None or end_date is None:
+                    raise ValueError(
+                        "If using dates both `start_date` and `end_date` need to be provided!"
+                    )
+                time_period = f"{format_time(start_date)}/{format_time(end_date, set_end_of_day=True)}"
                 input_parameters[data_block_name]["time"] = time_period
 
             if geometry is not None:


### PR DESCRIPTION
Replaces internal `utils.format_time_period` with `utils.format_time` for more flexibility to adjust single dates & explicit communication when setting end of day time. Also fixes some Python types for dates.

Required for https://github.com/up42/up42-py/pull/391

Items:
* [x] Ran test & live-tests
* [x] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
