### PR TITLE
Docs reference fixes

### DIFF
--- a/docs/reference/up42-reference.md
+++ b/docs/reference/up42-reference.md
@@ -1,11 +1,5 @@
 # up42
 
-::: up42.__init__
-    rendering:
-        show_root_toc_entry: False
-        show_if_no_docstring: False
-        group_by_category: False
-
 ::: up42.main
     selection:
         members:
@@ -15,7 +9,7 @@
        show_if_no_docstring: False
        group_by_category: False
 
-::: up42.initialization
+::: up42.tools
     rendering:
         show_root_toc_entry: False
         show_if_no_docstring: False
@@ -26,6 +20,13 @@
         filters:
             - "!authenticate"
             - "!^_"
+    rendering:
+        show_root_toc_entry: False
+        show_if_no_docstring: False
+        group_by_category: False
+
+
+::: up42.initialization
     rendering:
         show_root_toc_entry: False
         show_if_no_docstring: False

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -52,7 +52,19 @@ class Asset:
         self._info = response_json
         return self._info
 
-    def update_metadata(self, title: str = None, tags: List[str] = None, **kwargs):
+    def update_metadata(
+        self, title: str = None, tags: List[str] = None, **kwargs
+    ) -> dict:
+        """
+        Update the metadata of the asset.
+
+        Args:
+            title: The title string to be assigned to the asset.
+            tags: A list of tag strings to be assigned to the asset.
+
+        Returns:
+            The updated asset metadata information
+        """
         url = f"{self.auth._endpoint()}/v2/assets/{self.asset_id}/metadata"
         body_update = {"title": title, "tags": tags, **kwargs}
         response_json = self.auth._request(

--- a/up42/viztools.py
+++ b/up42/viztools.py
@@ -76,7 +76,7 @@ def draw_aoi() -> "folium.Map":
     not run in a Jupyter notebook.
 
     Export the drawn aoi via the export button, then read the geometries via
-    read_aoi_file().
+    up42.read_aoi_file().
     """
     m = folium_base_map(layer_control=True)
     DrawFoliumOverride(


### PR DESCRIPTION
Fixes `up42.read_vector_geometry` and `asset.change_metadata` not showing up in docs reference.

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
