### PR TITLE
New ci context for package publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ workflows:
             branches:
               only: master
       - deploy:
+          context: pypi-python-package-publishing
           requires:
             - hold_before_deploy
           filters:


### PR DESCRIPTION
Use new ci context to consolodiate publishing of up42 python packages

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
