### PR TITLE
Asset stac info call

### DIFF
--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from .fixtures_globals import ASSET_ID, JSON_ASSET, DOWNLOAD_URL
+from .fixtures_globals import ASSET_ID, JSON_ASSET, DOWNLOAD_URL, JSON_STORAGE_STAC
 
 from ..context import (
     Asset,
@@ -14,6 +14,10 @@ def asset_mock(auth_mock, requests_mock):
     # asset info
     url_asset_info = f"{auth_mock._endpoint()}/v2/assets/{ASSET_ID}/metadata"
     requests_mock.get(url=url_asset_info, json=JSON_ASSET)
+
+    # asset stac info
+    url_asset_stac_info = f"{auth_mock._endpoint()}/v2/assets/stac/search"
+    requests_mock.post(url=url_asset_stac_info, json=JSON_STORAGE_STAC)
 
     # asset update
     updated_json_asset = JSON_ASSET.copy()

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -34,6 +34,23 @@ def test_asset_info_live(asset_live):
     assert asset_live.info["name"]
 
 
+def test_asset_stac_info(asset_mock):
+    assert asset_mock.stac_info
+    assert (
+        asset_mock.stac_info["features"][0]["properties"]["up42-system:asset_id"]
+        == ASSET_ID
+    )
+
+
+@pytest.mark.live
+# TODO
+def test_asset_stac_info_live(asset_live):
+    assert asset_live.info
+    assert asset_live.info["features"][0]["properties"][
+        "up42-system:asset_id"
+    ] == os.getenv("TEST_UP42_ASSET_ID")
+
+
 def test_asset_update_metadata(asset_mock):
     updated_info = asset_mock.update_metadata(
         title="some_other_title", tags=["othertag1", "othertag2"]

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -52,6 +52,32 @@ class Asset:
         self._info = response_json
         return self._info
 
+    @property
+    def stac_info(self) -> Union[dict, None]:
+        """
+        Gets the storage STAC information for the asset as a FeatureCollection.
+
+        One asset can contain multiple STAC items (e.g. the pan- and multispectral images).
+        """
+        stac_search_parameters = {
+            "max_items": 50,
+            "limit": 50,
+            "filter": {
+                "op": "=",
+                "args": [{"property": "asset_id"}, self.asset_id],
+            },
+        }
+        url = f"{self.auth._endpoint()}/v2/assets/stac/search"
+        stac_results = self.auth._request(
+            request_type="POST", url=url, data=stac_search_parameters
+        )
+        stac_results.pop("links", None)
+        if not stac_results["features"]:
+            logger.info(
+                "No STAC metadata information available for this asset's items!"
+            )
+        return stac_results
+
     def update_metadata(
         self, title: str = None, tags: List[str] = None, **kwargs
     ) -> dict:


### PR DESCRIPTION
Adds the asset stac info call. Equivalent to `asset.info` for up42 platform specific metadata but for the  stac conform metadata of the asset's items.

- TODO: Livetest needs to finally adjusted when all stac items are correctly extracted on prod.

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
