### PR TITLE
Integrate pystac client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tenacity
 tqdm
 geojson
 geopandas
+pystac-client

--- a/tests/fixtures/fixtures_globals.py
+++ b/tests/fixtures/fixtures_globals.py
@@ -279,6 +279,56 @@ JSON_STORAGE_STAC = {
     ],
 }
 
+PYSTAC_MOCK_CLIENT = mock_pystac_client = {
+    "conformsTo": [
+        "https://api.stacspec.org/v1.0.0-rc.1/item-search#sort",
+        "https://api.stacspec.org/v1.0.0-rc.1/collections",
+        "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter",
+        "http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/simpletx",
+        "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:basic-cql",
+        "https://api.stacspec.org/v1.0.0-rc.1/item-search",
+        "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features/extensions/transaction",
+        "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-text",
+        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
+        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
+        "https://api.stacspec.org/v1.0.0-rc.1/core",
+        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+        "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features",
+        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
+    ],
+    "links": [
+        {
+            "href": "https://api.up42.com/v2/assets/stac/",
+            "rel": "self",
+            "type": "application/json",
+        },
+        {
+            "href": "https://api.up42.com/v2/assets/stac/",
+            "rel": "root",
+            "type": "application/json",
+        },
+        {
+            "href": "https://api.up42.com/v2/assets/stac/collections",
+            "rel": "data",
+            "type": "application/json",
+        },
+        {
+            "href": "https://api.up42.com/v2/assets/stac/search",
+            "rel": "search",
+            "type": "application/json",
+            "method": "POST",
+        },
+    ],
+    "stac_extensions": [],
+    "title": "UP42 Storage",
+    "description": "UP42 Storage STAC API",
+    "stac_version": "1.0.0",
+    "id": "up42-storage",
+    "type": "Catalog",
+}
+
+
 JSON_ORDER = {
     "data": {
         "id": ORDER_ID,

--- a/tests/fixtures/fixtures_storage.py
+++ b/tests/fixtures/fixtures_storage.py
@@ -8,6 +8,7 @@ from .fixtures_globals import (
     JSON_ORDERS,
     JSON_ORDER,
     ORDER_ID,
+    PYSTAC_MOCK_CLIENT,
 )
 
 from ..context import (
@@ -17,6 +18,11 @@ from ..context import (
 
 @pytest.fixture()
 def storage_mock(auth_mock, requests_mock):
+
+    # pystac client authentication
+    url_pystac_client = "https://api.up42.com/v2/assets/stac"
+    requests_mock.get(url=url_pystac_client, json=PYSTAC_MOCK_CLIENT)
+
     # assets
     url_storage_assets = f"{auth_mock._endpoint()}/v2/assets"
     requests_mock.get(url=url_storage_assets, json=JSON_ASSETS)

--- a/tests/fixtures/fixtures_storage.py
+++ b/tests/fixtures/fixtures_storage.py
@@ -20,7 +20,7 @@ from ..context import (
 def storage_mock(auth_mock, requests_mock):
 
     # pystac client authentication
-    url_pystac_client = "https://api.up42.com/v2/assets/stac"
+    url_pystac_client = f"{auth_mock._endpoint()}/v2/assets/stac"
     requests_mock.get(url=url_pystac_client, json=PYSTAC_MOCK_CLIENT)
 
     # assets

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,11 @@
+"""
+Note: The additional monkeypatching of the auth module in this module's tests is neccessary if running all tests
+in one pytest chain.
+They work without the monkeypatching when run independent of each other. However, when running all together via pytest,
+e.g. `make test`, the auth module fixture is otherwise not properly attached to the class object mocks for each test,
+or would need to be recreated for each test.
+"""
+
 import json
 from pathlib import Path
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,7 @@
 import datetime
 import copy
 
+import pystac_client
 import pytest
 import requests
 
@@ -23,6 +24,22 @@ from .fixtures import (
 def test_init(storage_mock):
     assert isinstance(storage_mock, Storage)
     assert storage_mock.workspace_id == WORKSPACE_ID
+
+
+def test_pystac_client_property(storage_mock):
+    up42_pystac_client = storage_mock.pystac_client
+    isinstance(up42_pystac_client, pystac_client.Client)
+
+
+@pytest.mark.live
+def test_pystac_client_property_live(storage_live):
+    up42_pystac_client = storage_live.pystac_client
+    isinstance(up42_pystac_client, pystac_client.Client)
+
+
+def test_pystac_client_property_invalid_auth_token(storage_mock):
+    pass
+    # TODO
 
 
 def _mock_one_page_reponse(page_nr, size, total_pages, total_elements):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,6 +4,7 @@ import copy
 import pystac_client
 import pytest
 import requests
+import mock
 
 # pylint: disable=unused-import
 from .context import Storage, Asset, Order
@@ -37,9 +38,15 @@ def test_pystac_client_property_live(storage_live):
     isinstance(up42_pystac_client, pystac_client.Client)
 
 
-def test_pystac_client_property_invalid_auth_token():
-    pass
-    # TODO
+@mock.patch("pystac_client.Client.open")
+def test_pystac_client_property_invalid_auth_token(pystac_open_mock, storage_mock):
+    pystac_open_mock.side_effect = pystac_client.exceptions.APIError()
+    with pytest.raises(pystac_client.exceptions.APIError):
+        storage_mock.pystac_client  # pylint: disable=pointless-statement
+
+    pystac_open_mock.side_effect = [pystac_client.exceptions.APIError(), mock.DEFAULT]
+    up42_pystac_client = storage_mock.pystac_client
+    isinstance(up42_pystac_client, pystac_client.Client)
 
 
 def _mock_one_page_reponse(page_nr, size, total_pages, total_elements):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -37,7 +37,7 @@ def test_pystac_client_property_live(storage_live):
     isinstance(up42_pystac_client, pystac_client.Client)
 
 
-def test_pystac_client_property_invalid_auth_token(storage_mock):
+def test_pystac_client_property_invalid_auth_token():
     pass
     # TODO
 

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -38,6 +38,8 @@ class Storage:
     def pystac_client(self):
         """
         Pystac Client authenticated for accessing the UP42 Storage.
+
+        See https://pystac-client.readthedocs.io/
         """
 
         def _authenticate_client():

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from geopandas import GeoDataFrame
 from shapely.geometry import Polygon
 from geojson import Feature, FeatureCollection
+import pystac_client
 
 from up42.auth import Auth
 from up42.order import Order
@@ -32,6 +33,30 @@ class Storage:
     def __repr__(self):
         env = ", env: dev" if self.auth.env == "dev" else ""
         return f"Storage(workspace_id: {self.workspace_id}{env})"
+
+    @property
+    def pystac_client(self):
+        """
+        Pystac Client authenticated for accessing the UP42 Storage.
+        """
+
+        def _authenticate_client():
+            url = f"{self.auth._endpoint()}/v2/assets/stac"
+            authenticated_client = pystac_client.Client.open(
+                url=url,
+                headers={
+                    "Authorization": f"Bearer {self.auth.token}",
+                },
+            )
+            return authenticated_client
+
+        try:
+            up42_pystac_client = _authenticate_client()
+        except pystac_client.exceptions.APIError:
+            self.auth._get_token()
+            up42_pystac_client = _authenticate_client()
+
+        return up42_pystac_client
 
     def _query_paginated_endpoints(
         self, url: str, limit: Optional[int] = None, size: int = 50


### PR DESCRIPTION
Draft for integrating pystac client that is authenticated with the UP42 storage access. Automatically reauthenticates the token.

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
