### PR TITLE
Updating privacy policy to point to the UP42 link.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,10 +63,10 @@ nav:
         - JobCollection: reference/jobcollection-reference.md
         - JobTask: reference/jobtask-reference.md
         - Webhooks: reference/webhooks-reference.md
-    -  Changelog & FAQ:
+    - Changelog & FAQ:
         - Changelog: CHANGELOG.md
         - FAQ & Support: support-faq.md
-        - Privacy Policy: privacy-policy.md
+        - Privacy Policy: 'https://up42.com/legal/privacy'
 
 ## Configuration
 theme:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,6 @@
 mkdocs-material==8.5.11
 mkdocstrings==0.19.1
+mkdocstrings-python
 mkdocs-exclude==1.0.2
 mkdocs-jupyter==0.22.0
 mkdocs-autolinks-plugin==0.6.0


### PR DESCRIPTION
Pointing the privacy policy to the main UP42 privacy policy page https://up42.com/legal/privacy
Adding the mkdocstrings-python requirement to avoid the python handler error.

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [X] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
