### PR TITLE
STAC Item retrieval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     working_directory: *workspace-dir
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - attach_workspace:
           at: *workspace-dir
@@ -60,7 +60,7 @@ jobs:
           command: python -m pytest --runlive --durations=5
   deploy:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - checkout
       - run:

--- a/pylintrc
+++ b/pylintrc
@@ -23,7 +23,10 @@ disable=
     logging-fstring-interpolation,
     logging-format-interpolation,
     too-many-lines,
-    unexpected-keyword-arg
+    unexpected-keyword-arg,
+    argument-error,
+    multiple-values-for-keyword-argument,
+    signature
     
 [FORMAT]
 max-line-length=120

--- a/pylintrc
+++ b/pylintrc
@@ -13,6 +13,7 @@ disable=
     super-init-not-called,
     inconsistent-return-statements,
     too-many-arguments,
+    too-many-ancestors,
     too-many-locals,
     protected-access,
     no-else-continue,
@@ -22,11 +23,7 @@ disable=
     duplicate-code,
     logging-fstring-interpolation,
     logging-format-interpolation,
-    too-many-lines,
-    unexpected-keyword-arg,
-    argument-error,
-    multiple-values-for-keyword-argument,
-    signature
+    too-many-lines
     
 [FORMAT]
 max-line-length=120

--- a/pylintrc
+++ b/pylintrc
@@ -22,7 +22,8 @@ disable=
     duplicate-code,
     logging-fstring-interpolation,
     logging-format-interpolation,
-    too-many-lines
+    too-many-lines,
+    unexpected-keyword-arg
     
 [FORMAT]
 max-line-length=120

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,4 @@
 [pytest]
-log_cli = true
-log_cli_level = INFO
 filterwarnings =
     ignore:.*importing.*ABCs.*'collections'.*:DeprecationWarning
 markers =

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+log_cli = true
+log_cli_level = INFO
 filterwarnings =
     ignore:.*importing.*ABCs.*'collections'.*:DeprecationWarning
 markers =

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 parent_dir = Path(__file__).resolve().parent
 
@@ -34,5 +35,5 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )

--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -38,7 +38,7 @@ def asset_mock(auth_mock, requests_mock):
     )
 
     # asset stac item
-    url_asset_stac_info = f"{auth_mock._endpoint()}/v2/assets/stac"
+    url_asset_stac = f"{auth_mock._endpoint()}/v2/assets/stac"
     catalog = {
         "type": "Catalog",
         "id": "up42-storage",
@@ -88,7 +88,7 @@ def asset_mock(auth_mock, requests_mock):
         ],
         "title": "UP42 Storage",
     }
-    requests_mock.get(url=url_asset_stac_info, json=catalog)
+    requests_mock.get(url=url_asset_stac, json=catalog)
 
     # asset update
     updated_json_asset = JSON_ASSET.copy()

--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import os
 
 import pytest
@@ -39,6 +40,7 @@ def asset_mock(auth_mock, requests_mock):
 
     # asset stac item
     url_asset_stac = f"{auth_mock._endpoint()}/v2/assets/stac"
+    logging.info(f"url {url_asset_stac}")
     catalog = {
         "type": "Catalog",
         "id": "up42-storage",

--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 import os
 
 import pytest
@@ -40,7 +39,6 @@ def asset_mock(auth_mock, requests_mock):
 
     # asset stac item
     url_asset_stac = f"{auth_mock._endpoint()}/v2/assets/stac"
-    logging.info(f"url {url_asset_stac}")
     catalog = {
         "type": "Catalog",
         "id": "up42-storage",

--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -1,12 +1,11 @@
+import datetime
 import os
 
 import pytest
+from pystac import Item, ItemCollection
 
-from .fixtures_globals import ASSET_ID, JSON_ASSET, DOWNLOAD_URL, JSON_STORAGE_STAC
-
-from ..context import (
-    Asset,
-)
+from ..context import Asset
+from .fixtures_globals import ASSET_ID, DOWNLOAD_URL, JSON_ASSET, JSON_STORAGE_STAC
 
 
 @pytest.fixture()
@@ -15,9 +14,81 @@ def asset_mock(auth_mock, requests_mock):
     url_asset_info = f"{auth_mock._endpoint()}/v2/assets/{ASSET_ID}/metadata"
     requests_mock.get(url=url_asset_info, json=JSON_ASSET)
 
-    # asset stac info
+    mock_item_collection = ItemCollection(
+        items=[
+            Item(
+                id="test",
+                geometry=None,
+                properties={},
+                bbox=None,
+                datetime=datetime.datetime.now(),
+            )
+        ]
+    )
+
     url_asset_stac_info = f"{auth_mock._endpoint()}/v2/assets/stac/search"
-    requests_mock.post(url=url_asset_stac_info, json=JSON_STORAGE_STAC)
+
+    requests_mock.post(
+        url_asset_stac_info,
+        [
+            {"json": JSON_STORAGE_STAC},
+            {"json": JSON_STORAGE_STAC},
+            {"json": mock_item_collection.to_dict()},
+        ],
+    )
+
+    # asset stac item
+    url_asset_stac_info = f"{auth_mock._endpoint()}/v2/assets/stac"
+    catalog = {
+        "type": "Catalog",
+        "id": "up42-storage",
+        "stac_version": "1.0.0",
+        "description": "UP42 Storage STAC API",
+        "links": [
+            {
+                "rel": "root",
+                "href": "https://api.up42.com/v2/assets/stac/",
+                "type": "application/json",
+                "title": "UP42 Storage",
+            },
+            {
+                "rel": "data",
+                "href": "https://api.up42.com/v2/assets/stac/collections",
+                "type": "application/json",
+            },
+            {
+                "rel": "search",
+                "href": "https://api.up42.com/v2/assets/stac/search",
+                "type": "application/json",
+                "method": "POST",
+            },
+            {
+                "rel": "self",
+                "href": "https://api.up42.com/v2/assets/stac/",
+                "type": "application/json",
+            },
+        ],
+        "stac_extensions": [],
+        "conformsTo": [
+            "https://api.stacspec.org/v1.0.0-rc.1/collections",
+            "https://api.stacspec.org/v1.0.0-rc.1/core",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
+            "http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/simpletx",
+            "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter",
+            "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text",
+            "https://api.stacspec.org/v1.0.0-rc.1/item-search",
+            "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features/extensions/transaction",
+            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
+            "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
+            "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features",
+            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+            "https://api.stacspec.org/v1.0.0-rc.1/item-search#sort",
+            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
+        ],
+        "title": "UP42 Storage",
+    }
+    requests_mock.get(url=url_asset_stac_info, json=catalog)
 
     # asset update
     updated_json_asset = JSON_ASSET.copy()

--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -39,6 +39,7 @@ def asset_mock(auth_mock, requests_mock):
 
     # asset stac item
     url_asset_stac = f"{auth_mock._endpoint()}/v2/assets/stac"
+
     catalog = {
         "type": "Catalog",
         "id": "up42-storage",
@@ -47,7 +48,7 @@ def asset_mock(auth_mock, requests_mock):
         "links": [
             {
                 "rel": "root",
-                "href": "https://api.up42.com/v2/assets/stac/",
+                "href": "https://api.up42.com/v2/assets/stac",
                 "type": "application/json",
                 "title": "UP42 Storage",
             },
@@ -64,7 +65,7 @@ def asset_mock(auth_mock, requests_mock):
             },
             {
                 "rel": "self",
-                "href": "https://api.up42.com/v2/assets/stac/",
+                "href": "https://api.up42.com/v2/assets/stac",
                 "type": "application/json",
             },
         ],

--- a/tests/fixtures/fixtures_globals.py
+++ b/tests/fixtures/fixtures_globals.py
@@ -194,12 +194,12 @@ JSON_ASSETS = {
 JSON_STORAGE_STAC = {
     "links": [
         {
-            "href": "https://api.up42.dev/v2/assets/stac/",
+            "href": "https://api.up42.com/v2/assets/stac/",
             "rel": "root",
             "type": "application/json",
         },
         {
-            "href": "https://api.up42.dev/v2/assets/stac/search",
+            "href": "https://api.up42.com/v2/assets/stac/search",
             "rel": "next",
             "type": "application/json",
             "body": {
@@ -215,28 +215,28 @@ JSON_STORAGE_STAC = {
         {
             "assets": {
                 "data": {
-                    "href": "https://api.up42.dev/v2/assets/01ad657e-12f7-4046-a94c-abc90d86106a"
+                    "href": "https://api.up42.com/v2/assets/01ad657e-12f7-4046-a94c-abc90d86106a"
                 }
             },
             "links": [
                 {
-                    "href": "https://api.up42.dev/v2/assets/stac/collections/69ce89b4-fa35-4a1a-bcd8-1c2e5bbd2ee6/"
+                    "href": "https://api.up42.com/v2/assets/stac/collections/69ce89b4-fa35-4a1a-bcd8-1c2e5bbd2ee6/"
                     "items/e986e18a-0392-4b82-93c9-7a0af15846d0",
                     "rel": "self",
                     "type": "application/geo+json",
                 },
                 {
-                    "href": "https://api.up42.dev/v2/assets/stac/collections/69ce89b4-fa35-4a1a-bcd8-1c2e5bbd2ee6",
+                    "href": "https://api.up42.com/v2/assets/stac/collections/69ce89b4-fa35-4a1a-bcd8-1c2e5bbd2ee6",
                     "rel": "parent",
                     "type": "application/json",
                 },
                 {
-                    "href": "https://api.up42.dev/v2/assets/stac/collections/69ce89b4-fa35-4a1a-bcd8-1c2e5bbd2ee6",
+                    "href": "https://api.up42.com/v2/assets/stac/collections/69ce89b4-fa35-4a1a-bcd8-1c2e5bbd2ee6",
                     "rel": "collection",
                     "type": "application/json",
                 },
                 {
-                    "href": "https://api.up42.dev/v2/assets/stac/",
+                    "href": "https://api.up42.com/v2/assets/stac/",
                     "rel": "root",
                     "type": "application/json",
                 },

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -1,6 +1,8 @@
 import os
-from pathlib import Path
 import tempfile
+from pathlib import Path
+
+import pystac
 import pytest
 
 # pylint: disable=unused-import
@@ -9,10 +11,10 @@ from .fixtures import (
     ASSET_ID,
     DOWNLOAD_URL,
     JSON_ASSET,
-    auth_mock,
-    auth_live,
-    asset_mock,
     asset_live,
+    asset_mock,
+    auth_live,
+    auth_mock,
 )
 
 
@@ -49,6 +51,8 @@ def test_asset_stac_info_live(asset_live):
     assert asset_live.stac_info["features"][0]["properties"][
         "up42-system:asset_id"
     ] == os.getenv("TEST_UP42_ASSET_ID")
+    pystac_items = asset_live.stac_items
+    assert isinstance(pystac_items, pystac.ItemCollection)
 
 
 def test_asset_update_metadata(asset_mock):

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -42,6 +42,8 @@ def test_asset_stac_info(asset_mock):
         asset_mock.stac_info["features"][0]["properties"]["up42-system:asset_id"]
         == ASSET_ID
     )
+    pystac_items = asset_mock.stac_items
+    assert isinstance(pystac_items, pystac.ItemCollection)
 
 
 @pytest.mark.live

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -39,7 +39,7 @@ def test_pystac_client_property_live(storage_live):
     isinstance(up42_pystac_client, pystac_client.Client)
     time.sleep(1)
     stac_collections = up42_pystac_client.get_collections()
-    assert isinstance(stac_collections, pystac.Collection)
+    assert isinstance(stac_collections.__next__(), pystac.Collection)
 
 
 def _mock_one_page_reponse(page_nr, size, total_pages, total_elements):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,5 @@
 import copy
 import datetime
-import time
 
 import pystac
 import pystac_client
@@ -37,7 +36,6 @@ def test_pystac_client_property(storage_mock):
 def test_pystac_client_property_live(storage_live):
     up42_pystac_client = storage_live.pystac_client
     isinstance(up42_pystac_client, pystac_client.Client)
-    time.sleep(1)
     stac_collections = up42_pystac_client.get_collections()
     assert isinstance(stac_collections.__next__(), pystac.Collection)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,7 +1,8 @@
 import copy
 import datetime
+import time
 
-import mock
+import pystac
 import pystac_client
 import pytest
 import requests
@@ -36,17 +37,9 @@ def test_pystac_client_property(storage_mock):
 def test_pystac_client_property_live(storage_live):
     up42_pystac_client = storage_live.pystac_client
     isinstance(up42_pystac_client, pystac_client.Client)
-
-
-@mock.patch("pystac_client.Client.open")
-def test_pystac_client_property_invalid_auth_token(pystac_open_mock, storage_mock):
-    pystac_open_mock.side_effect = pystac_client.exceptions.APIError()
-    with pytest.raises(pystac_client.exceptions.APIError):
-        storage_mock.pystac_client  # pylint: disable=pointless-statement
-
-    pystac_open_mock.side_effect = [pystac_client.exceptions.APIError(), mock.DEFAULT]
-    up42_pystac_client = storage_mock.pystac_client
-    isinstance(up42_pystac_client, pystac_client.Client)
+    time.sleep(1)
+    stac_collections = up42_pystac_client.get_collections()
+    isinstance(stac_collections, pystac.Collection)
 
 
 def _mock_one_page_reponse(page_nr, size, total_pages, total_elements):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -39,7 +39,7 @@ def test_pystac_client_property_live(storage_live):
     isinstance(up42_pystac_client, pystac_client.Client)
     time.sleep(1)
     stac_collections = up42_pystac_client.get_collections()
-    isinstance(stac_collections, pystac.Collection)
+    assert isinstance(stac_collections, pystac.Collection)
 
 
 def _mock_one_page_reponse(page_nr, size, total_pages, total_elements):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,23 +1,22 @@
 import json
-from pathlib import Path
 import tempfile
-from dateutil.parser import parse
+from pathlib import Path
 
 import geopandas as gpd
-from geopandas import GeoDataFrame
 import pandas as pd
 import pytest
-from shapely.geometry import Polygon, LinearRing
+from dateutil.parser import parse
+from geopandas import GeoDataFrame
+from shapely.geometry import LinearRing, Polygon
 
 from .context import (
-    format_time,
     any_vector_to_fc,
-    fc_to_query_geometry,
-    download_from_gcs_unpack,
-    filter_jobs_on_mode,
     autocomplete_order_parameters,
+    download_from_gcs_unpack,
+    fc_to_query_geometry,
+    filter_jobs_on_mode,
+    format_time,
 )
-
 
 POLY = Polygon([(0, 0), (1, 1), (1, 0)])
 

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -9,6 +9,9 @@ from up42.utils import download_from_gcs_unpack, download_gcs_not_unpack, get_lo
 
 logger = get_logger(__name__)
 
+MAX_ITEM = 50
+LIMIT = 50
+
 
 class Asset:
     """
@@ -59,8 +62,8 @@ class Asset:
         One asset can contain multiple STAC items (e.g. the pan- and multispectral images).
         """
         stac_search_parameters = {
-            "max_items": 50,
-            "limit": 50,
+            "max_items": MAX_ITEM,
+            "limit": LIMIT,
             "filter": {
                 "op": "=",
                 "args": [{"property": "asset_id"}, self.asset_id],
@@ -82,8 +85,8 @@ class Asset:
         url = f"{self.auth._endpoint()}/v2/assets/stac"
         pystac_client_aux = pystac_auth_client(auth=self.auth).open(url=url)
         stac_search_parameters = {
-            "max_items": 50,
-            "limit": 50,
+            "max_items": MAX_ITEM,
+            "limit": LIMIT,
             "filter": {
                 "op": "=",
                 "args": [

--- a/up42/stac_client.py
+++ b/up42/stac_client.py
@@ -5,7 +5,12 @@ from up42.auth import Auth
 
 class pystac_auth_client(Client):
     def __init__(
-        self, *args, id="id", description="description", auth: Auth = None, **kwargs
+        self,
+        *args,
+        id="id",
+        description="description",
+        auth: Auth = None,
+        **kwargs,
     ):  # pylint: disable=redefined-builtin
         super().__init__(id=id, description=description, *args, **kwargs)  # type: ignore
         self.auth = auth

--- a/up42/stac_client.py
+++ b/up42/stac_client.py
@@ -2,23 +2,21 @@ from pystac_client import Client
 
 from up42.auth import Auth
 
-# pylint: skip-file
-
 
 class pystac_auth_client(Client):
     def __init__(
-        self, id="id", description="description", auth: Auth = None, *args, **kwargs
-    ):
-        super().__init__(id=id, description=description, *args, **kwargs)
+        self, *args, id="id", description="description", auth: Auth = None, **kwargs
+    ):  # pylint: disable=redefined-builtin
+        super().__init__(id=id, description=description, *args, **kwargs)  # type: ignore
         self.auth = auth
 
     def _auth_modifier(self, request):
         self.auth._get_token()
         request.headers["Authorization"] = f"Bearer {self.auth.token}"
 
-    def open(self, *args, **kwargs) -> Client:
+    def open(self, *args, **kwargs) -> Client:  # type: ignore # pylint: disable=arguments-differ
         return super().open(
             request_modifier=self._auth_modifier,
             *args,
             **kwargs,
-        )
+        )  # type: ignore

--- a/up42/stac_client.py
+++ b/up42/stac_client.py
@@ -14,7 +14,7 @@ class pystac_auth_client(Client):
         self.auth._get_token()
         request.headers["Authorization"] = f"Bearer {self.auth.token}"
 
-    def open(self, *args, **kwargs) -> Client:  # type: ignore
+    def open(self, *args, **kwargs) -> Client:  # type: ignore # pylint: disable=arguments-differ
         return super().open(  # type: ignore
             request_modifier=self._auth_modifier,
             *args,

--- a/up42/stac_client.py
+++ b/up42/stac_client.py
@@ -14,9 +14,9 @@ class pystac_auth_client(Client):
         self.auth._get_token()
         request.headers["Authorization"] = f"Bearer {self.auth.token}"
 
-    def open(self, *args, **kwargs) -> Client:  # type: ignore # pylint: disable=arguments-differ
-        return super().open(
+    def open(self, *args, **kwargs) -> Client:  # type: ignore
+        return super().open(  # type: ignore
             request_modifier=self._auth_modifier,
             *args,
             **kwargs,
-        )  # type: ignore
+        )

--- a/up42/stac_client.py
+++ b/up42/stac_client.py
@@ -2,6 +2,8 @@ from pystac_client import Client
 
 from up42.auth import Auth
 
+# pylint: skip-file
+
 
 class pystac_auth_client(Client):
     def __init__(

--- a/up42/stac_client.py
+++ b/up42/stac_client.py
@@ -1,0 +1,22 @@
+from pystac_client import Client
+
+from up42.auth import Auth
+
+
+class pystac_auth_client(Client):
+    def __init__(
+        self, id="id", description="description", auth: Auth = None, *args, **kwargs
+    ):
+        super().__init__(id=id, description=description, *args, **kwargs)
+        self.auth = auth
+
+    def _auth_modifier(self, request):
+        self.auth._get_token()
+        request.headers["Authorization"] = f"Bearer {self.auth.token}"
+
+    def open(self, *args, **kwargs) -> Client:
+        return super().open(
+            request_modifier=self._auth_modifier,
+            *args,
+            **kwargs,
+        )

--- a/up42/storage.py
+++ b/up42/storage.py
@@ -2,7 +2,6 @@ import math
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
-import pystac_client
 from geojson import Feature, FeatureCollection
 from geopandas import GeoDataFrame
 from shapely.geometry import Polygon
@@ -10,6 +9,7 @@ from shapely.geometry import Polygon
 from up42.asset import Asset
 from up42.auth import Auth
 from up42.order import Order
+from up42.stac_client import pystac_auth_client
 from up42.utils import any_vector_to_fc, fc_to_query_geometry, format_time, get_logger
 
 logger = get_logger(__name__)
@@ -36,28 +36,9 @@ class Storage:
 
     @property
     def pystac_client(self):
-        """
-        PySTAC client, a Python package for working with UP42 STAC API and accessing storage assets.
-        For more information, see [PySTAC Client Documentation](https://pystac-client.readthedocs.io/).
-        """
-
-        def _authenticate_client():
-            url = f"{self.auth._endpoint()}/v2/assets/stac"
-            authenticated_client = pystac_client.Client.open(
-                url=url,
-                headers={
-                    "Authorization": f"Bearer {self.auth.token}",
-                },
-            )
-            return authenticated_client
-
-        try:
-            up42_pystac_client = _authenticate_client()
-        except pystac_client.exceptions.APIError:
-            self.auth._get_token()
-            up42_pystac_client = _authenticate_client()
-
-        return up42_pystac_client
+        url = f"{self.auth._endpoint()}/v2/assets/stac"
+        pystac_client_auth = pystac_auth_client(auth=self.auth).open(url=url)
+        return pystac_client_auth
 
     def _query_paginated_endpoints(
         self, url: str, limit: Optional[int] = None, size: int = 50

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -371,7 +371,9 @@ def autocomplete_order_parameters(order_parameters: dict, schema: dict):
             if param in ["aoi", "geometry"]:
                 continue
             elif "allOf" in schema["properties"][param]:  # has further definitions key
-                potential_values = [x["const"] for x in schema["definitions"][param]["anyOf"]]
+                potential_values = [
+                    x["const"] for x in schema["definitions"][param]["anyOf"]
+                ]
                 logger.info(f"As `{param}` select one of {potential_values}")
             else:
                 # Full information for simple parameters


### PR DESCRIPTION
This PR adds the stac_item property to the assets Class.
For doing this we refactored the pystac_client authenticated against the UP42 account and removed support for Python 3.7.

Items:
* [x] Ran test & live-tests
* [x] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
