### PR TITLE
At 3031 change stac info

### DIFF
--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -115,7 +115,7 @@ def asset_mock(auth_mock, requests_mock):
     mock_client = CollectionClient(
         id="up42-storage",
         description="UP42 Storage STAC API",
-        extra_fields={"up42-system:asset_id": os.getenv("TEST_UP42_ASSET_ID")},
+        extra_fields={"up42-system:asset_id": ASSET_ID},
         extent=Extent(
             spatial=SpatialExtent(
                 bboxes=[

--- a/tests/fixtures/fixtures_asset.py
+++ b/tests/fixtures/fixtures_asset.py
@@ -3,9 +3,17 @@ import os
 
 import pytest
 from pystac import Item, ItemCollection
+from pystac.collection import Extent, SpatialExtent, TemporalExtent
+from pystac_client import CollectionClient
 
 from ..context import Asset
-from .fixtures_globals import ASSET_ID, DOWNLOAD_URL, JSON_ASSET, JSON_STORAGE_STAC
+from .fixtures_globals import (
+    ASSET_ID,
+    DOWNLOAD_URL,
+    JSON_ASSET,
+    JSON_STORAGE_STAC,
+    STAC_COLLECTION_ID,
+)
 
 
 @pytest.fixture()
@@ -101,6 +109,34 @@ def asset_mock(auth_mock, requests_mock):
     requests_mock.post(
         url=f"{auth_mock._endpoint()}/v2/assets/{ASSET_ID}/download-url",
         json={"url": DOWNLOAD_URL},
+    )
+
+    # stac_info url
+    mock_client = CollectionClient(
+        id="up42-storage",
+        description="UP42 Storage STAC API",
+        extra_fields={"up42-system:asset_id": os.getenv("TEST_UP42_ASSET_ID")},
+        extent=Extent(
+            spatial=SpatialExtent(
+                bboxes=[
+                    [
+                        13.3783333333333,
+                        52.4976111111112,
+                        13.3844444444445,
+                        52.5017222222223,
+                    ]
+                ]
+            ),
+            temporal=TemporalExtent(
+                intervals=[
+                    [datetime.datetime(2021, 5, 31), datetime.datetime(2021, 5, 31)]
+                ]
+            ),
+        ),
+    )
+    requests_mock.get(
+        url=f"{auth_mock._endpoint()}/v2/assets/stac/collections/{STAC_COLLECTION_ID}",
+        json=mock_client.to_dict(),
     )
 
     asset = Asset(auth=auth_mock, asset_id=ASSET_ID)

--- a/tests/fixtures/fixtures_globals.py
+++ b/tests/fixtures/fixtures_globals.py
@@ -27,6 +27,7 @@ DATA_PRODUCT_ID = "data_product_id_123"
 
 ORDER_ID = "order_id_123"
 ASSET_ID = "asset_id_123"
+STAC_COLLECTION_ID = "collection_id_123"
 
 WEBHOOK_ID = "123"
 
@@ -279,7 +280,7 @@ JSON_STORAGE_STAC = {
             "type": "Feature",
             "stac_version": "1.0.0",
             "id": "e986e18a-0392-4b82-93c9-7a0af15846d0",
-            "collection": "69ce89b4-fa35-4a1a-bcd8-1c2e5bbd2ee6",
+            "collection": STAC_COLLECTION_ID,
         }
     ],
 }

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -37,10 +37,9 @@ def test_asset_info_live(asset_live):
 
 
 def test_asset_stac_info(asset_mock):
-    assert asset_mock.stac_info
-    assert asset_mock.stac_info.extra_fields["up42-system:asset_id"] == os.getenv(
-        "TEST_UP42_ASSET_ID"
-    )
+    results_stac_asset = asset_mock.stac_info
+    assert results_stac_asset
+    assert results_stac_asset.extra_fields["up42-system:asset_id"] == ASSET_ID
     pystac_items = asset_mock.stac_items
     assert isinstance(pystac_items, pystac.ItemCollection)
 

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -38,21 +38,19 @@ def test_asset_info_live(asset_live):
 
 def test_asset_stac_info(asset_mock):
     assert asset_mock.stac_info
-    assert (
-        asset_mock.stac_info["features"][0]["properties"]["up42-system:asset_id"]
-        == ASSET_ID
+    assert asset_mock.stac_info.extra_fields["up42-system:asset_id"] == os.getenv(
+        "TEST_UP42_ASSET_ID"
     )
     pystac_items = asset_mock.stac_items
     assert isinstance(pystac_items, pystac.ItemCollection)
 
 
 @pytest.mark.live
-# TODO
 def test_asset_stac_info_live(asset_live):
     assert asset_live.stac_info
-    assert asset_live.stac_info["features"][0]["properties"][
-        "up42-system:asset_id"
-    ] == os.getenv("TEST_UP42_ASSET_ID")
+    assert asset_live.stac_info.extra_fields["up42-system:asset_id"] == os.getenv(
+        "TEST_UP42_ASSET_ID"
+    )
     pystac_items = asset_live.stac_items
     assert isinstance(pystac_items, pystac.ItemCollection)
 

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 import pystac
-from pystac_client import Client
+from pystac_client import Client, ItemSearch
 
 from up42.auth import Auth
 from up42.stac_client import pystac_auth_client
@@ -56,7 +56,7 @@ class Asset:
         return self._info
 
     @property
-    def _stac_search(self) -> tuple(Client, dict):
+    def _stac_search(self) -> tuple[Client, ItemSearch]:
         url = f"{self.auth._endpoint()}/v2/assets/stac"
         pystac_client_aux = pystac_auth_client(auth=self.auth).open(url=url)
         stac_search_parameters = {
@@ -74,7 +74,7 @@ class Asset:
         return (pystac_client_aux, pystac_asset_search)
 
     @property
-    def stac_info(self) -> pystac.Collection:
+    def stac_info(self) -> Optional[pystac.Collection]:
         """
         Gets the storage STAC information for the asset as a FeatureCollection.
         One asset can contain multiple STAC items (e.g. the pan- and multispectral images).

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -80,9 +80,7 @@ class Asset:
         One asset can contain multiple STAC items (e.g. the PAN and multispectral images).
         """
         pystac_client_aux, pystac_asset_search = self._stac_search
-        resulting_item = next(
-            pystac_asset_search.get_item_collections(), None
-        )  # up42:asset_id unique, we expect only one results
+        resulting_item = pystac_asset_search.item_collection()
         if resulting_item is None:
             raise ValueError(
                 f"No STAC metadata information available for this asset {self.asset_id}"
@@ -97,8 +95,8 @@ class Asset:
         """
         try:
             _, pystac_asset_search = self._stac_search
-            resulting_items = pystac_asset_search.get_all_items()
-            return resulting_item
+            resulting_items = pystac_asset_search.item_collection()
+            return resulting_items
         except Exception as exc:
             raise ValueError(
                 f"No STAC metadata information available for this asset {self.asset_id}"

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -97,7 +97,7 @@ class Asset:
         """
         try:
             _, pystac_asset_search = self._stac_search
-            resulting_item = pystac_asset_search.get_all_items()
+            resulting_items = pystac_asset_search.get_all_items()
             return resulting_item
         except Exception as exc:
             raise ValueError(

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import pystac
 from pystac_client import Client, ItemSearch
@@ -56,7 +56,7 @@ class Asset:
         return self._info
 
     @property
-    def _stac_search(self) -> tuple[Client, ItemSearch]:
+    def _stac_search(self) -> Tuple[Client, ItemSearch]:
         url = f"{self.auth._endpoint()}/v2/assets/stac"
         pystac_client_aux = pystac_auth_client(auth=self.auth).open(url=url)
         stac_search_parameters = {

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -77,7 +77,7 @@ class Asset:
     def stac_info(self) -> Optional[pystac.Collection]:
         """
         Gets the storage STAC information for the asset as a FeatureCollection.
-        One asset can contain multiple STAC items (e.g. the pan- and multispectral images).
+        One asset can contain multiple STAC items (e.g. the PAN and multispectral images).
         """
         pystac_client_aux, pystac_asset_search = self._stac_search
         resulting_item = next(

--- a/up42/asset.py
+++ b/up42/asset.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 import pystac
+from pystac_client import Client
 
 from up42.auth import Auth
 from up42.stac_client import pystac_auth_client
@@ -55,7 +56,7 @@ class Asset:
         return self._info
 
     @property
-    def _stac_search(self) -> dict:
+    def _stac_search(self) -> tuple(Client, dict):
         url = f"{self.auth._endpoint()}/v2/assets/stac"
         pystac_client_aux = pystac_auth_client(auth=self.auth).open(url=url)
         stac_search_parameters = {


### PR DESCRIPTION
**Description**

This PR modifies the stac_item and stac_info methods from the Asset class to consistenly use pystac_client and format their outputs as pystac.ItemCollection, and pystac.Collection objects.

Items:
* [X] Ran test & live-tests
* [X] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
