### PR TITLE
DOC-631: Update Tasking SDK tutorial

### DIFF
--- a/docs/tasking.md
+++ b/docs/tasking.md
@@ -153,5 +153,7 @@ Check the status of your order:
 ```python
 order.status
 ```
+The following statuses mean you can [download assets from storage](storage.md):
 
-When the order is completed, [download its assets from storage](storage.md).
+- `BEING_FULFILLED`: some order assets are delivered
+- `FULFILLED`: all order assets are delivered

--- a/docs/tasking.md
+++ b/docs/tasking.md
@@ -155,5 +155,5 @@ order.status
 ```
 The following statuses mean you can [download assets from storage](storage.md):
 
-- `BEING_FULFILLED`: some order assets are delivered
-- `FULFILLED`: all order assets are delivered
+- `BEING_FULFILLED`: Some order assets are delivered.
+- `FULFILLED`: All order assets are delivered.

--- a/examples/tasking/tasking-example.ipynb
+++ b/examples/tasking/tasking-example.ipynb
@@ -370,8 +370,8 @@
       "source": [
         "The following statuses mean you can [download assets from storage](https://sdk.up42.com/storage/):\n",
         "\n",
-        "- `BEING_FULFILLED`: some order assets are delivered\n",
-        "- `FULFILLED`: all order assets are delivered"
+        "- `BEING_FULFILLED`: Some order assets are delivered.\n",
+        "- `FULFILLED`: All order assets are delivered."
       ]
     }
   ],

--- a/examples/tasking/tasking-example.ipynb
+++ b/examples/tasking/tasking-example.ipynb
@@ -364,10 +364,14 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "When the order is completed, [download its assets from storage](https://sdk.up42.com/storage/)."
+        "The following statuses mean you can [download assets from storage](https://sdk.up42.com/storage/):\n",
+        "\n",
+        "- `BEING_FULFILLED`: some order assets are delivered\n",
+        "- `FULFILLED`: all order assets are delivered"
       ]
     }
   ],


### PR DESCRIPTION
Documentation changes made to tasking.md and tasking-example.ipynb:

Replaced this sentence:

“When the order is completed, download its assets from storage.”
→ 
The following statuses mean you can download assets from storage:
- `BEING_FULFILLED`: some order assets are delivered
- `FULFILLED`: all order assets are delivered

