### PR TITLE
[AT-2999] Remove failing live tests

### DIFF
--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 from pathlib import Path
 

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -30,31 +30,12 @@ def test_asset_info(asset_mock):
     assert asset_mock.info["name"] == JSON_ASSET["name"]
 
 
-# #NOTE: Given asset doesn't exist anymore
-# @pytest.mark.live
-# def test_asset_info_live(asset_live):
-#     assert asset_live.info
-#     assert asset_live.info["id"] == os.getenv("TEST_UP42_ASSET_ID")
-#     assert asset_live.info["name"]
-
-
 def test_asset_stac_info(asset_mock):
     results_stac_asset = asset_mock.stac_info
     assert results_stac_asset
     assert results_stac_asset.extra_fields["up42-system:asset_id"] == ASSET_ID
     pystac_items = asset_mock.stac_items
     assert isinstance(pystac_items, pystac.ItemCollection)
-
-
-# # NOTE: given asset doesn't exist anymore
-# @pytest.mark.live
-# def test_asset_stac_info_live(asset_live):
-#     assert asset_live.stac_info
-#     assert asset_live.stac_info.extra_fields["up42-system:asset_id"] == os.getenv(
-#         "TEST_UP42_ASSET_ID"
-#     )
-#     pystac_items = asset_live.stac_items
-#     assert isinstance(pystac_items, pystac.ItemCollection)
 
 
 def test_asset_update_metadata(asset_mock):
@@ -76,13 +57,6 @@ def test_asset_get_download_url(asset_fixture, download_url, request):
     asset_fixture = request.getfixturevalue(asset_fixture)
     url = asset_fixture._get_download_url()
     assert url == download_url
-
-
-# # NOTE: given asset doesn't exist anymore
-# @pytest.mark.live
-# def test_asset_get_download_url_live(asset_live):
-#     url = asset_live._get_download_url()
-#     assert url
 
 
 def test_asset_download(asset_mock, requests_mock):
@@ -112,32 +86,6 @@ def test_asset_download(asset_mock, requests_mock):
         assert out_paths[0] != out_paths[1]
         assert out_paths[1].parent.exists()
         assert out_paths[1].parent.is_dir()
-
-
-# # NOTE: given asset doesn't exist anymore
-# @pytest.mark.live
-# def test_asset_download_live(asset_live):
-#     """
-#     tgz from block (storage)
-#     """
-#     with tempfile.TemporaryDirectory() as tempdir:
-#         out_files = asset_live.download(Path(tempdir))
-#         for file in out_files:
-#             assert Path(file).exists()
-#         assert len(out_files) == 44
-
-# #NOTE: Given asset doesn't exist anymore
-# @pytest.mark.live
-# def test_asset_download_live_2(asset_live):
-#     """
-#     zip from order (storage)
-#     """
-#     asset_live.asset_id = os.getenv("TEST_UP42_ASSET_ID_2_zip")
-#     with tempfile.TemporaryDirectory() as tempdir:
-#         out_files = asset_live.download(Path(tempdir))
-#         for file in out_files:
-#             assert Path(file).exists()
-#         assert len(out_files) == 42
 
 
 @pytest.mark.parametrize(

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -31,11 +31,12 @@ def test_asset_info(asset_mock):
     assert asset_mock.info["name"] == JSON_ASSET["name"]
 
 
-@pytest.mark.live
-def test_asset_info_live(asset_live):
-    assert asset_live.info
-    assert asset_live.info["id"] == os.getenv("TEST_UP42_ASSET_ID")
-    assert asset_live.info["name"]
+# #NOTE: Given asset doesn't exist anymore
+# @pytest.mark.live
+# def test_asset_info_live(asset_live):
+#     assert asset_live.info
+#     assert asset_live.info["id"] == os.getenv("TEST_UP42_ASSET_ID")
+#     assert asset_live.info["name"]
 
 
 def test_asset_stac_info(asset_mock):
@@ -46,14 +47,15 @@ def test_asset_stac_info(asset_mock):
     assert isinstance(pystac_items, pystac.ItemCollection)
 
 
-@pytest.mark.live
-def test_asset_stac_info_live(asset_live):
-    assert asset_live.stac_info
-    assert asset_live.stac_info.extra_fields["up42-system:asset_id"] == os.getenv(
-        "TEST_UP42_ASSET_ID"
-    )
-    pystac_items = asset_live.stac_items
-    assert isinstance(pystac_items, pystac.ItemCollection)
+# # NOTE: given asset doesn't exist anymore
+# @pytest.mark.live
+# def test_asset_stac_info_live(asset_live):
+#     assert asset_live.stac_info
+#     assert asset_live.stac_info.extra_fields["up42-system:asset_id"] == os.getenv(
+#         "TEST_UP42_ASSET_ID"
+#     )
+#     pystac_items = asset_live.stac_items
+#     assert isinstance(pystac_items, pystac.ItemCollection)
 
 
 def test_asset_update_metadata(asset_mock):
@@ -77,10 +79,11 @@ def test_asset_get_download_url(asset_fixture, download_url, request):
     assert url == download_url
 
 
-@pytest.mark.live
-def test_asset_get_download_url_live(asset_live):
-    url = asset_live._get_download_url()
-    assert url
+# # NOTE: given asset doesn't exist anymore
+# @pytest.mark.live
+# def test_asset_get_download_url_live(asset_live):
+#     url = asset_live._get_download_url()
+#     assert url
 
 
 def test_asset_download(asset_mock, requests_mock):
@@ -112,29 +115,30 @@ def test_asset_download(asset_mock, requests_mock):
         assert out_paths[1].parent.is_dir()
 
 
-@pytest.mark.live
-def test_asset_download_live(asset_live):
-    """
-    tgz from block (storage)
-    """
-    with tempfile.TemporaryDirectory() as tempdir:
-        out_files = asset_live.download(Path(tempdir))
-        for file in out_files:
-            assert Path(file).exists()
-        assert len(out_files) == 44
+# # NOTE: given asset doesn't exist anymore
+# @pytest.mark.live
+# def test_asset_download_live(asset_live):
+#     """
+#     tgz from block (storage)
+#     """
+#     with tempfile.TemporaryDirectory() as tempdir:
+#         out_files = asset_live.download(Path(tempdir))
+#         for file in out_files:
+#             assert Path(file).exists()
+#         assert len(out_files) == 44
 
-
-@pytest.mark.live
-def test_asset_download_live_2(asset_live):
-    """
-    zip from order (storage)
-    """
-    asset_live.asset_id = os.getenv("TEST_UP42_ASSET_ID_2_zip")
-    with tempfile.TemporaryDirectory() as tempdir:
-        out_files = asset_live.download(Path(tempdir))
-        for file in out_files:
-            assert Path(file).exists()
-        assert len(out_files) == 42
+# #NOTE: Given asset doesn't exist anymore
+# @pytest.mark.live
+# def test_asset_download_live_2(asset_live):
+#     """
+#     zip from order (storage)
+#     """
+#     asset_live.asset_id = os.getenv("TEST_UP42_ASSET_ID_2_zip")
+#     with tempfile.TemporaryDirectory() as tempdir:
+#         out_files = asset_live.download(Path(tempdir))
+#         for file in out_files:
+#             assert Path(file).exists()
+#         assert len(out_files) == 42
 
 
 @pytest.mark.parametrize(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -168,16 +168,6 @@ def test_job_download_result(job_mock, requests_mock):
         assert out_paths[1].parent.is_dir()
 
 
-# # NOTE: This job doesn't exist anymore; is it even possible to remove/delete jobs
-# # @pytest.mark.live
-# def test_job_download_result_live(job_live):
-#     with tempfile.TemporaryDirectory() as tempdir:
-#         out_files = job_live.download_results(Path(tempdir))
-#         for file in out_files:
-#             assert Path(file).exists()
-#         assert len(out_files) == 2
-
-
 def test_job_download_gcs_no_unpacking(job_mock, requests_mock):
     out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
     with open(out_tgz, "rb") as src_tgz:
@@ -251,14 +241,6 @@ def test_job_get_credits(job_mock):
 
     assert isinstance(out_files, dict)
     assert out_files == {"creditsUsed": 100}
-
-
-# # NOTE: This job doesn't exist anymore
-# @pytest.mark.live
-# def test_job_get_credits_live(job_live):
-#     out_files = job_live.get_credits()
-#     assert isinstance(out_files, dict)
-#     assert out_files == {"creditsUsed": 5}
 
 
 @pytest.mark.skip(reason="Sometimes takes quite long to cancel the job on the server.")

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -168,13 +168,14 @@ def test_job_download_result(job_mock, requests_mock):
         assert out_paths[1].parent.is_dir()
 
 
-@pytest.mark.live
-def test_job_download_result_live(job_live):
-    with tempfile.TemporaryDirectory() as tempdir:
-        out_files = job_live.download_results(Path(tempdir))
-        for file in out_files:
-            assert Path(file).exists()
-        assert len(out_files) == 2
+# # NOTE: This job doesn't exist anymore; is it even possible to remove/delete jobs
+# # @pytest.mark.live
+# def test_job_download_result_live(job_live):
+#     with tempfile.TemporaryDirectory() as tempdir:
+#         out_files = job_live.download_results(Path(tempdir))
+#         for file in out_files:
+#             assert Path(file).exists()
+#         assert len(out_files) == 2
 
 
 def test_job_download_gcs_no_unpacking(job_mock, requests_mock):
@@ -252,11 +253,12 @@ def test_job_get_credits(job_mock):
     assert out_files == {"creditsUsed": 100}
 
 
-@pytest.mark.live
-def test_job_get_credits_live(job_live):
-    out_files = job_live.get_credits()
-    assert isinstance(out_files, dict)
-    assert out_files == {"creditsUsed": 5}
+# # NOTE: This job doesn't exist anymore
+# @pytest.mark.live
+# def test_job_get_credits_live(job_live):
+#     out_files = job_live.get_credits()
+#     assert isinstance(out_files, dict)
+#     assert out_files == {"creditsUsed": 5}
 
 
 @pytest.mark.skip(reason="Sometimes takes quite long to cancel the job on the server.")

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -206,15 +206,16 @@ def test_jobcollection_iterator(jobcollection_multiple_mock):
         assert isinstance(job, Job)
 
 
-@pytest.mark.live
-def test_jobcollection_download_results_live(jobcollection_live):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        out_files_dict = jobcollection_live.download_results(Path(tmpdir), merge=False)
-        jobid_1, jobid_2 = jobcollection_live.jobs_id
-        for _, value in out_files_dict.items():
-            for p in value:
-                assert Path(p).exists()
-        assert jobid_1 in out_files_dict
-        assert jobid_2 in out_files_dict
-        assert len(out_files_dict[jobid_1]) == 2
-        assert len(out_files_dict[jobid_2]) == 2
+# #NOTE: this job does not exist anymore
+# # @pytest.mark.live
+# def test_jobcollection_download_results_live(jobcollection_live):
+#     with tempfile.TemporaryDirectory() as tmpdir:
+#         out_files_dict = jobcollection_live.download_results(Path(tmpdir), merge=False)
+#         jobid_1, jobid_2 = jobcollection_live.jobs_id
+#         for _, value in out_files_dict.items():
+#             for p in value:
+#                 assert Path(p).exists()
+#         assert jobid_1 in out_files_dict
+#         assert jobid_2 in out_files_dict
+#         assert len(out_files_dict[jobid_1]) == 2
+#         assert len(out_files_dict[jobid_2]) == 2

--- a/tests/test_jobcollection.py
+++ b/tests/test_jobcollection.py
@@ -205,17 +205,3 @@ def test_jobcollection_iterator(jobcollection_multiple_mock):
     for job in jobcollection_multiple_mock:
         assert isinstance(job, Job)
 
-
-# #NOTE: this job does not exist anymore
-# # @pytest.mark.live
-# def test_jobcollection_download_results_live(jobcollection_live):
-#     with tempfile.TemporaryDirectory() as tmpdir:
-#         out_files_dict = jobcollection_live.download_results(Path(tmpdir), merge=False)
-#         jobid_1, jobid_2 = jobcollection_live.jobs_id
-#         for _, value in out_files_dict.items():
-#             for p in value:
-#                 assert Path(p).exists()
-#         assert jobid_1 in out_files_dict
-#         assert jobid_2 in out_files_dict
-#         assert len(out_files_dict[jobid_1]) == 2
-#         assert len(out_files_dict[jobid_2]) == 2

--- a/tests/test_jobtask.py
+++ b/tests/test_jobtask.py
@@ -2,11 +2,10 @@ from pathlib import Path
 import tempfile
 import shutil
 
-import pytest
 
 # pylint: disable=unused-import
 from .context import JobTask
-from .fixtures import auth_mock, auth_live, jobtask_mock, jobtask_live
+from .fixtures import auth_mock, auth_live, jobtask_mock
 from .fixtures import DOWNLOAD_URL
 
 

--- a/tests/test_jobtask.py
+++ b/tests/test_jobtask.py
@@ -21,14 +21,6 @@ def test_get_results_json(jobtask_mock):
     }
 
 
-# # NOTE: this job doesn't exist anymore
-# @pytest.mark.live
-# def test_get_result_json_live(jobtask_live):
-#     result_json = jobtask_live.get_results_json()
-#     assert result_json["type"] == "FeatureCollection"
-#     assert len(result_json["features"][0]["bbox"]) == 4
-
-
 def test_jobtask_download_result(jobtask_mock, requests_mock):
     out_tgz = Path(__file__).resolve().parent / "mock_data/result_tif.tgz"
     with open(out_tgz, "rb") as src_tgz:
@@ -63,18 +55,6 @@ def test_jobtask_download_result(jobtask_mock, requests_mock):
     shutil.rmtree(default_outdir)
 
 
-# # NOTE: this job doesn't exist anymore
-# @pytest.mark.live
-# def test_jobtask_download_result_live(jobtask_live):
-    # with tempfile.TemporaryDirectory() as tempdir:
-    #     out_files = jobtask_live.download_results(output_directory=tempdir)
-    #     for file in out_files:
-    #         assert Path(file).exists()
-    #     assert len(out_files) == 2
-    #     assert ".tif" in [Path(of).suffix for of in out_files]
-    #     assert "data.json" in [Path(of).name for of in out_files]
-
-
 def test_download_quicklook(jobtask_mock, requests_mock):
     url_download_quicklooks = (
         f"{jobtask_mock.auth._endpoint()}/projects/{jobtask_mock.project_id}/"
@@ -91,13 +71,3 @@ def test_download_quicklook(jobtask_mock, requests_mock):
         assert len(quick) == 1
         assert Path(quick[0]).exists()
         assert Path(quick[0]).suffix == ".png"
-
-
-# # NOTE: this job doesn't exist anymore
-# @pytest.mark.live
-# def test_download_quicklook_live(jobtask_live):
-#     with tempfile.TemporaryDirectory() as tempdir:
-#         out_files = jobtask_live.download_quicklooks(output_directory=tempdir)
-#         assert len(out_files) == 1
-#         assert Path(out_files[0]).exists()
-#         assert Path(out_files[0]).suffix == ".png"

--- a/tests/test_jobtask.py
+++ b/tests/test_jobtask.py
@@ -22,11 +22,12 @@ def test_get_results_json(jobtask_mock):
     }
 
 
-@pytest.mark.live
-def test_get_result_json_live(jobtask_live):
-    result_json = jobtask_live.get_results_json()
-    assert result_json["type"] == "FeatureCollection"
-    assert len(result_json["features"][0]["bbox"]) == 4
+# # NOTE: this job doesn't exist anymore
+# @pytest.mark.live
+# def test_get_result_json_live(jobtask_live):
+#     result_json = jobtask_live.get_results_json()
+#     assert result_json["type"] == "FeatureCollection"
+#     assert len(result_json["features"][0]["bbox"]) == 4
 
 
 def test_jobtask_download_result(jobtask_mock, requests_mock):
@@ -63,15 +64,16 @@ def test_jobtask_download_result(jobtask_mock, requests_mock):
     shutil.rmtree(default_outdir)
 
 
-@pytest.mark.live
-def test_jobtask_download_result_live(jobtask_live):
-    with tempfile.TemporaryDirectory() as tempdir:
-        out_files = jobtask_live.download_results(output_directory=tempdir)
-        for file in out_files:
-            assert Path(file).exists()
-        assert len(out_files) == 2
-        assert ".tif" in [Path(of).suffix for of in out_files]
-        assert "data.json" in [Path(of).name for of in out_files]
+# # NOTE: this job doesn't exist anymore
+# @pytest.mark.live
+# def test_jobtask_download_result_live(jobtask_live):
+    # with tempfile.TemporaryDirectory() as tempdir:
+    #     out_files = jobtask_live.download_results(output_directory=tempdir)
+    #     for file in out_files:
+    #         assert Path(file).exists()
+    #     assert len(out_files) == 2
+    #     assert ".tif" in [Path(of).suffix for of in out_files]
+    #     assert "data.json" in [Path(of).name for of in out_files]
 
 
 def test_download_quicklook(jobtask_mock, requests_mock):
@@ -92,10 +94,11 @@ def test_download_quicklook(jobtask_mock, requests_mock):
         assert Path(quick[0]).suffix == ".png"
 
 
-@pytest.mark.live
-def test_download_quicklook_live(jobtask_live):
-    with tempfile.TemporaryDirectory() as tempdir:
-        out_files = jobtask_live.download_quicklooks(output_directory=tempdir)
-        assert len(out_files) == 1
-        assert Path(out_files[0]).exists()
-        assert Path(out_files[0]).suffix == ".png"
+# # NOTE: this job doesn't exist anymore
+# @pytest.mark.live
+# def test_download_quicklook_live(jobtask_live):
+#     with tempfile.TemporaryDirectory() as tempdir:
+#         out_files = jobtask_live.download_quicklooks(output_directory=tempdir)
+#         assert len(out_files) == 1
+#         assert Path(out_files[0]).exists()
+#         assert Path(out_files[0]).suffix == ".png"

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 # pylint: disable=unused-import
@@ -14,7 +12,6 @@ from .fixtures import (
     auth_live,
     auth_mock,
     catalog_mock,
-    order_live,
     order_mock,
 )
 

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -32,11 +32,12 @@ def test_order_info(order_mock):
     assert order_mock.info["assets"][0] == ASSET_ID
 
 
-@pytest.mark.live
-def test_order_info_live(order_live):
-    assert order_live.info
-    assert order_live.info["id"] == os.getenv("TEST_UP42_ORDER_ID")
-    assert order_live.info["dataProductId"] == "4f1b2f62-98df-4c74-81f4-5dce45deee99"
+# # NOTE: This order id does not exist anymore
+# @pytest.mark.live
+# def test_order_info_live(order_live):
+#     assert order_live.info
+#     assert order_live.info["id"] == os.getenv("TEST_UP42_ORDER_ID")
+#     assert order_live.info["dataProductId"] == "4f1b2f62-98df-4c74-81f4-5dce45deee99"
 
 
 # pylint: disable=unused-argument
@@ -76,9 +77,10 @@ def test_order_parameters(order_mock):
     assert not order_mock.order_parameters
 
 
-@pytest.mark.live
-def test_order_parameters_live(order_live):
-    assert not order_live.order_parameters
+# # NOTE: This order id does not exist anymore
+# @pytest.mark.live
+# def test_order_parameters_live(order_live):
+#     assert not order_live.order_parameters
 
 
 def test_get_assets(order_mock, asset_mock):

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -29,14 +29,6 @@ def test_order_info(order_mock):
     assert order_mock.info["assets"][0] == ASSET_ID
 
 
-# # NOTE: This order id does not exist anymore
-# @pytest.mark.live
-# def test_order_info_live(order_live):
-#     assert order_live.info
-#     assert order_live.info["id"] == os.getenv("TEST_UP42_ORDER_ID")
-#     assert order_live.info["dataProductId"] == "4f1b2f62-98df-4c74-81f4-5dce45deee99"
-
-
 # pylint: disable=unused-argument
 @pytest.mark.parametrize("status", ["PLACED", "FULFILLED"])
 def test_order_status(order_mock, status, monkeypatch):
@@ -72,12 +64,6 @@ def test_is_fulfilled(order_mock, status, expected, monkeypatch):
 
 def test_order_parameters(order_mock):
     assert not order_mock.order_parameters
-
-
-# # NOTE: This order id does not exist anymore
-# @pytest.mark.live
-# def test_order_parameters_live(order_live):
-#     assert not order_live.order_parameters
 
 
 def test_get_assets(order_mock, asset_mock):

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -28,6 +28,7 @@ def test_webhook_info(webhook_mock):
 
 
 @pytest.mark.live
+#TODO: failing
 def test_webhook_info_live(webhook_live):
     assert webhook_live.info
     assert webhook_live._info["id"] == os.getenv("TEST_UP42_WEBHOOK_ID")
@@ -39,11 +40,12 @@ def test_webhook_trigger_test_event(webhook_mock):
     assert test_event_info["testsRun"] >= 1
 
 
-@pytest.mark.live
-def test_webhook_trigger_test_event_live(webhook_live):
-    test_event_info = webhook_live.trigger_test_events()
-    assert isinstance(test_event_info, dict)
-    assert test_event_info["testsRun"] >= 1
+# # NOTE: this webhook id does not exist anymore
+# @pytest.mark.live
+# def test_webhook_trigger_test_event_live(webhook_live):
+#     test_event_info = webhook_live.trigger_test_events()
+#     assert isinstance(test_event_info, dict)
+#     assert test_event_info["testsRun"] >= 1
 
 
 def test_webhook_update(webhook_mock):
@@ -52,13 +54,14 @@ def test_webhook_update(webhook_mock):
     assert updated_webhook._info["name"] == "test_info_webhook"
 
 
-@pytest.mark.live
-def test_webhook_update_live(webhook_live):
-    updated_webhook = webhook_live.update(
-        name="test_info_webhook"
-    )  # "Updates" to the old name for consistency.
-    assert isinstance(updated_webhook, Webhook)
-    assert updated_webhook._info["name"] == "test_info_webhook"
+# # NOTE: this webhook id does not exist anymore
+# @pytest.mark.live
+# def test_webhook_update_live(webhook_live):
+#     updated_webhook = webhook_live.update(
+#         name="test_info_webhook"
+#     )  # "Updates" to the old name for consistency.
+#     assert isinstance(updated_webhook, Webhook)
+#     assert updated_webhook._info["name"] == "test_info_webhook"
 
 
 def test_webhook_delete(webhook_mock):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,6 +1,4 @@
 from pathlib import Path
-import json
-import copy
 
 import pytest
 from shapely.geometry import box
@@ -13,7 +11,6 @@ from .fixtures import (
     auth_live,
     workflow_mock_empty,
     workflow_mock,
-    workflow_live,
     job_mock,
     jobcollection_single_mock,
     jobtask_mock,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -50,11 +50,12 @@ def test_get_workflow_tasks_basic(workflow_mock):
     assert tasks["tiling:1"] == "2.2.3"
 
 
-@pytest.mark.live
-def test_get_workflow_tasks_basic_live(workflow_live):
-    workflow_tasks = workflow_live.get_workflow_tasks(basic=True)
-    assert isinstance(workflow_tasks, dict)
-    assert "esa-s2-l2a-gtiff-visual:1" in list(workflow_tasks.keys())
+# # NOTE: This workflow could not be found
+# @pytest.mark.live
+# def test_get_workflow_tasks_basic_live(workflow_live):
+#     workflow_tasks = workflow_live.get_workflow_tasks(basic=True)
+#     assert isinstance(workflow_tasks, dict)
+#     assert "esa-s2-l2a-gtiff-visual:1" in list(workflow_tasks.keys())
 
 
 def test_get_compatible_blocks(workflow_mock):
@@ -63,11 +64,12 @@ def test_get_compatible_blocks(workflow_mock):
     assert "aaa" in list(compatible_blocks.keys())
 
 
-@pytest.mark.live
-def test_get_compatible_blocks_live(workflow_live):
-    compatible_blocks = workflow_live.get_compatible_blocks()
-    assert isinstance(compatible_blocks, dict)
-    assert "tiling" in list(compatible_blocks.keys())
+# # NOTE: This workflow could not be found
+# @pytest.mark.live
+# def test_get_compatible_blocks_live(workflow_live):
+#     compatible_blocks = workflow_live.get_compatible_blocks()
+#     assert isinstance(compatible_blocks, dict)
+#     assert "tiling" in list(compatible_blocks.keys())
 
 
 def test_get_compatible_blocks_empty_workflow_returns_data_blocks(workflow_mock_empty):
@@ -141,11 +143,12 @@ def test_add_workflow_tasks_full(workflow_mock, requests_mock):
     workflow_mock.add_workflow_tasks(input_tasks_full)
 
 
-@pytest.mark.live
-def test_add_workflow_tasks_simple_not_existing_block_id_raises_live(workflow_live):
-    input_tasks_simple = ["12345"]
-    with pytest.raises(Exception):
-        workflow_live.add_workflow_tasks(input_tasks_simple)
+# # NOTE: This workflow could not be found
+# @pytest.mark.live
+# def test_add_workflow_tasks_simple_not_existing_block_id_raises_live(workflow_live):
+#     input_tasks_simple = ["12345"]
+#     with pytest.raises(Exception):
+#         workflow_live.add_workflow_tasks(input_tasks_simple)
 
 
 def test_get_parameter_info(workflow_mock):
@@ -160,18 +163,19 @@ def test_get_parameter_info(workflow_mock):
     )
 
 
-@pytest.mark.live
-def test_get_parameter_info_live(workflow_live):
-    parameter_info = workflow_live.get_parameters_info()
-    assert isinstance(parameter_info, dict)
-    assert all(
-        x in list(parameter_info.keys())
-        for x in ["tiling:1", "esa-s2-l2a-gtiff-visual:1"]
-    )
-    assert all(
-        x in list(parameter_info["tiling:1"].keys())
-        for x in ["nodata", "tile_width", "match_extents"]
-    )
+# # NOTE: This workflow could not be found
+# @pytest.mark.live
+# def test_get_parameter_info_live(workflow_live):
+#     parameter_info = workflow_live.get_parameters_info()
+#     assert isinstance(parameter_info, dict)
+#     assert all(
+#         x in list(parameter_info.keys())
+#         for x in ["tiling:1", "esa-s2-l2a-gtiff-visual:1"]
+#     )
+#     assert all(
+#         x in list(parameter_info["tiling:1"].keys())
+#         for x in ["nodata", "tile_width", "match_extents"]
+#     )
 
 
 def test_get_default_parameters(workflow_mock):
@@ -368,19 +372,20 @@ def test_estimate_jobs(workflow_mock, auth_mock, requests_mock):
     assert estimation == JSON_WORKFLOW_ESTIMATION["data"]
 
 
-@pytest.mark.live
-def test_estimate_jobs_live(workflow_live):
-    input_parameters = {
-        "esa-s2-l2a-gtiff-visual:1": {
-            "time": "2018-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
-            "limit": 1,
-            "bbox": [13.33409, 52.474922, 13.38547, 52.500398],
-        },
-        "tiling:1": {"tile_width": 768, "tile_height": 768},
-    }
-    estimation = workflow_live.estimate_job(input_parameters)
+# # NOTE: This workflow could not be found
+# @pytest.mark.live
+# def test_estimate_jobs_live(workflow_live):
+#     input_parameters = {
+#         "esa-s2-l2a-gtiff-visual:1": {
+#             "time": "2018-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
+#             "limit": 1,
+#             "bbox": [13.33409, 52.474922, 13.38547, 52.500398],
+#         },
+#         "tiling:1": {"tile_width": 768, "tile_height": 768},
+#     }
+#     estimation = workflow_live.estimate_job(input_parameters)
 
-    assert estimation.keys() == JSON_WORKFLOW_ESTIMATION["data"].keys()
+#     assert estimation.keys() == JSON_WORKFLOW_ESTIMATION["data"].keys()
 
 
 def test_run_job(workflow_mock, job_mock, requests_mock):
@@ -609,97 +614,101 @@ def test_helper_run_parallel_jobs_fail_concurrent_jobs(
             )
 
 
-@pytest.mark.live
-def test_test_jobs_parallel_live(workflow_live):
-    input_parameters_list = [
-        {
-            "esa-s2-l2a-gtiff-visual:1": {
-                "time": "2019-01-01T00:00:00+00:00/2019-12-31T23:59:59+00:00",
-                "limit": 1,
-                "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
-            },
-            "tiling:1": {"tile_width": 768, "tile_height": 768},
-        },
-        {
-            "esa-s2-l2a-gtiff-visual:1": {
-                "time": "2020-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
-                "limit": 1,
-                "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
-            },
-            "tiling:1": {"tile_width": 768, "tile_height": 768},
-        },
-    ]
+# # NOTE: This workflow could not be found
+# @pytest.mark.live
+# def test_test_jobs_parallel_live(workflow_live):
+#     input_parameters_list = [
+#         {
+#             "esa-s2-l2a-gtiff-visual:1": {
+#                 "time": "2019-01-01T00:00:00+00:00/2019-12-31T23:59:59+00:00",
+#                 "limit": 1,
+#                 "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
+#             },
+#             "tiling:1": {"tile_width": 768, "tile_height": 768},
+#         },
+#         {
+#             "esa-s2-l2a-gtiff-visual:1": {
+#                 "time": "2020-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
+#                 "limit": 1,
+#                 "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
+#             },
+#             "tiling:1": {"tile_width": 768, "tile_height": 768},
+#         },
+#     ]
 
-    jb = workflow_live.test_jobs_parallel(input_parameters_list=input_parameters_list)
-    assert isinstance(jb, JobCollection)
+#     jb = workflow_live.test_jobs_parallel(input_parameters_list=input_parameters_list)
+#     assert isinstance(jb, JobCollection)
 
-    input_parameters_list = copy.deepcopy(input_parameters_list)
-    for input_parameters in input_parameters_list:
-        input_parameters.update({"config": {"mode": "DRY_RUN"}})
-    for index, job in enumerate(jb.jobs):
-        assert job.status == "SUCCEEDED"
-        assert job._info["inputs"] == input_parameters_list[index]
-        assert job._info["mode"] == "DRY_RUN"
-
-
-@pytest.mark.live
-def test_run_jobs_parallel_live(workflow_live):
-    input_parameters_list = [
-        {
-            "esa-s2-l2a-gtiff-visual:1": {
-                "time": "2019-01-01T00:00:00+00:00/2019-12-31T23:59:59+00:00",
-                "limit": 1,
-                "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
-            },
-            "tiling:1": {"tile_width": 768, "tile_height": 768},
-        },
-        {
-            "esa-s2-l2a-gtiff-visual:1": {
-                "time": "2020-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
-                "limit": 1,
-                "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
-            },
-            "tiling:1": {"tile_width": 768, "tile_height": 768},
-        },
-    ]
-
-    jb = workflow_live.run_jobs_parallel(input_parameters_list=input_parameters_list)
-    assert isinstance(jb, JobCollection)
-    for index, job in enumerate(jb.jobs):
-        assert job.status == "SUCCEEDED"
-        assert job._info["inputs"] == input_parameters_list[index]
-        assert job._info["mode"] == "DEFAULT"
+#     input_parameters_list = copy.deepcopy(input_parameters_list)
+#     for input_parameters in input_parameters_list:
+#         input_parameters.update({"config": {"mode": "DRY_RUN"}})
+#     for index, job in enumerate(jb.jobs):
+#         assert job.status == "SUCCEEDED"
+#         assert job._info["inputs"] == input_parameters_list[index]
+#         assert job._info["mode"] == "DRY_RUN"
 
 
-@pytest.mark.live
-def test_test_job_live(workflow_live):
-    input_parameters_json = (
-        Path(__file__).resolve().parent / "mock_data/input_params_simple.json"
-    )
-    jb = workflow_live.test_job(
-        input_parameters=input_parameters_json, track_status=True
-    )
-    assert isinstance(jb, Job)
-    with open(input_parameters_json) as src:
-        job_info_params = json.load(src)
-        job_info_params.update({"config": {"mode": "DRY_RUN"}})
-        assert jb._info["inputs"] == job_info_params
-        assert jb._info["mode"] == "DRY_RUN"
-    assert jb.status == "SUCCEEDED"
+# # NOTE: This workflow could not be found
+# @pytest.mark.live
+# def test_run_jobs_parallel_live(workflow_live):
+#     input_parameters_list = [
+#         {
+#             "esa-s2-l2a-gtiff-visual:1": {
+#                 "time": "2019-01-01T00:00:00+00:00/2019-12-31T23:59:59+00:00",
+#                 "limit": 1,
+#                 "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
+#             },
+#             "tiling:1": {"tile_width": 768, "tile_height": 768},
+#         },
+#         {
+#             "esa-s2-l2a-gtiff-visual:1": {
+#                 "time": "2020-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
+#                 "limit": 1,
+#                 "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
+#             },
+#             "tiling:1": {"tile_width": 768, "tile_height": 768},
+#         },
+#     ]
+
+#     jb = workflow_live.run_jobs_parallel(input_parameters_list=input_parameters_list)
+#     assert isinstance(jb, JobCollection)
+#     for index, job in enumerate(jb.jobs):
+#         assert job.status == "SUCCEEDED"
+#         assert job._info["inputs"] == input_parameters_list[index]
+#         assert job._info["mode"] == "DEFAULT"
 
 
-@pytest.mark.live
-def test_run_job_live(workflow_live):
-    input_parameters_json = (
-        Path(__file__).resolve().parent / "mock_data/input_params_simple.json"
-    )
-    jb = workflow_live.run_job(input_parameters_json, track_status=True, name=JOB_NAME)
-    assert isinstance(jb, Job)
-    with open(input_parameters_json) as src:
-        assert jb._info["inputs"] == json.load(src)
-        assert jb._info["mode"] == "DEFAULT"
-    assert jb.status == "SUCCEEDED"
-    assert jb._info["name"] == JOB_NAME + "_py"
+# # NOTE: This workflow could not be found
+# @pytest.mark.live
+# def test_test_job_live(workflow_live):
+#     input_parameters_json = (
+#         Path(__file__).resolve().parent / "mock_data/input_params_simple.json"
+#     )
+#     jb = workflow_live.test_job(
+#         input_parameters=input_parameters_json, track_status=True
+#     )
+#     assert isinstance(jb, Job)
+#     with open(input_parameters_json) as src:
+#         job_info_params = json.load(src)
+#         job_info_params.update({"config": {"mode": "DRY_RUN"}})
+#         assert jb._info["inputs"] == job_info_params
+#         assert jb._info["mode"] == "DRY_RUN"
+#     assert jb.status == "SUCCEEDED"
+
+
+# # NOTE: This workflow could not be found
+# @pytest.mark.live
+# def test_run_job_live(workflow_live):
+#     input_parameters_json = (
+#         Path(__file__).resolve().parent / "mock_data/input_params_simple.json"
+#     )
+#     jb = workflow_live.run_job(input_parameters_json, track_status=True, name=JOB_NAME)
+#     assert isinstance(jb, Job)
+#     with open(input_parameters_json) as src:
+#         assert jb._info["inputs"] == json.load(src)
+#         assert jb._info["mode"] == "DEFAULT"
+#     assert jb.status == "SUCCEEDED"
+#     assert jb._info["name"] == JOB_NAME + "_py"
 
 
 def test_get_jobs(workflow_mock, requests_mock):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -47,26 +47,10 @@ def test_get_workflow_tasks_basic(workflow_mock):
     assert tasks["tiling:1"] == "2.2.3"
 
 
-# # NOTE: This workflow could not be found
-# @pytest.mark.live
-# def test_get_workflow_tasks_basic_live(workflow_live):
-#     workflow_tasks = workflow_live.get_workflow_tasks(basic=True)
-#     assert isinstance(workflow_tasks, dict)
-#     assert "esa-s2-l2a-gtiff-visual:1" in list(workflow_tasks.keys())
-
-
 def test_get_compatible_blocks(workflow_mock):
     compatible_blocks = workflow_mock.get_compatible_blocks()
     assert isinstance(compatible_blocks, dict)
     assert "aaa" in list(compatible_blocks.keys())
-
-
-# # NOTE: This workflow could not be found
-# @pytest.mark.live
-# def test_get_compatible_blocks_live(workflow_live):
-#     compatible_blocks = workflow_live.get_compatible_blocks()
-#     assert isinstance(compatible_blocks, dict)
-#     assert "tiling" in list(compatible_blocks.keys())
 
 
 def test_get_compatible_blocks_empty_workflow_returns_data_blocks(workflow_mock_empty):
@@ -140,14 +124,6 @@ def test_add_workflow_tasks_full(workflow_mock, requests_mock):
     workflow_mock.add_workflow_tasks(input_tasks_full)
 
 
-# # NOTE: This workflow could not be found
-# @pytest.mark.live
-# def test_add_workflow_tasks_simple_not_existing_block_id_raises_live(workflow_live):
-#     input_tasks_simple = ["12345"]
-#     with pytest.raises(Exception):
-#         workflow_live.add_workflow_tasks(input_tasks_simple)
-
-
 def test_get_parameter_info(workflow_mock):
     parameter_info = workflow_mock.get_parameters_info()
     assert isinstance(parameter_info, dict)
@@ -158,21 +134,6 @@ def test_get_parameter_info(workflow_mock):
     assert all(
         x in list(parameter_info["tiling:1"].keys()) for x in ["nodata", "tile_width"]
     )
-
-
-# # NOTE: This workflow could not be found
-# @pytest.mark.live
-# def test_get_parameter_info_live(workflow_live):
-#     parameter_info = workflow_live.get_parameters_info()
-#     assert isinstance(parameter_info, dict)
-#     assert all(
-#         x in list(parameter_info.keys())
-#         for x in ["tiling:1", "esa-s2-l2a-gtiff-visual:1"]
-#     )
-#     assert all(
-#         x in list(parameter_info["tiling:1"].keys())
-#         for x in ["nodata", "tile_width", "match_extents"]
-#     )
 
 
 def test_get_default_parameters(workflow_mock):
@@ -367,22 +328,6 @@ def test_estimate_jobs(workflow_mock, auth_mock, requests_mock):
 
     estimation = workflow_mock.estimate_job(input_parameters)
     assert estimation == JSON_WORKFLOW_ESTIMATION["data"]
-
-
-# # NOTE: This workflow could not be found
-# @pytest.mark.live
-# def test_estimate_jobs_live(workflow_live):
-#     input_parameters = {
-#         "esa-s2-l2a-gtiff-visual:1": {
-#             "time": "2018-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
-#             "limit": 1,
-#             "bbox": [13.33409, 52.474922, 13.38547, 52.500398],
-#         },
-#         "tiling:1": {"tile_width": 768, "tile_height": 768},
-#     }
-#     estimation = workflow_live.estimate_job(input_parameters)
-
-#     assert estimation.keys() == JSON_WORKFLOW_ESTIMATION["data"].keys()
 
 
 def test_run_job(workflow_mock, job_mock, requests_mock):
@@ -609,103 +554,6 @@ def test_helper_run_parallel_jobs_fail_concurrent_jobs(
             workflow_mock._helper_run_parallel_jobs(
                 input_parameters_list, max_concurrent_jobs=10
             )
-
-
-# # NOTE: This workflow could not be found
-# @pytest.mark.live
-# def test_test_jobs_parallel_live(workflow_live):
-#     input_parameters_list = [
-#         {
-#             "esa-s2-l2a-gtiff-visual:1": {
-#                 "time": "2019-01-01T00:00:00+00:00/2019-12-31T23:59:59+00:00",
-#                 "limit": 1,
-#                 "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
-#             },
-#             "tiling:1": {"tile_width": 768, "tile_height": 768},
-#         },
-#         {
-#             "esa-s2-l2a-gtiff-visual:1": {
-#                 "time": "2020-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
-#                 "limit": 1,
-#                 "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
-#             },
-#             "tiling:1": {"tile_width": 768, "tile_height": 768},
-#         },
-#     ]
-
-#     jb = workflow_live.test_jobs_parallel(input_parameters_list=input_parameters_list)
-#     assert isinstance(jb, JobCollection)
-
-#     input_parameters_list = copy.deepcopy(input_parameters_list)
-#     for input_parameters in input_parameters_list:
-#         input_parameters.update({"config": {"mode": "DRY_RUN"}})
-#     for index, job in enumerate(jb.jobs):
-#         assert job.status == "SUCCEEDED"
-#         assert job._info["inputs"] == input_parameters_list[index]
-#         assert job._info["mode"] == "DRY_RUN"
-
-
-# # NOTE: This workflow could not be found
-# @pytest.mark.live
-# def test_run_jobs_parallel_live(workflow_live):
-#     input_parameters_list = [
-#         {
-#             "esa-s2-l2a-gtiff-visual:1": {
-#                 "time": "2019-01-01T00:00:00+00:00/2019-12-31T23:59:59+00:00",
-#                 "limit": 1,
-#                 "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
-#             },
-#             "tiling:1": {"tile_width": 768, "tile_height": 768},
-#         },
-#         {
-#             "esa-s2-l2a-gtiff-visual:1": {
-#                 "time": "2020-01-01T00:00:00+00:00/2020-12-31T23:59:59+00:00",
-#                 "limit": 1,
-#                 "bbox": [13.375966, 52.515068, 13.378314, 52.516639],
-#             },
-#             "tiling:1": {"tile_width": 768, "tile_height": 768},
-#         },
-#     ]
-
-#     jb = workflow_live.run_jobs_parallel(input_parameters_list=input_parameters_list)
-#     assert isinstance(jb, JobCollection)
-#     for index, job in enumerate(jb.jobs):
-#         assert job.status == "SUCCEEDED"
-#         assert job._info["inputs"] == input_parameters_list[index]
-#         assert job._info["mode"] == "DEFAULT"
-
-
-# # NOTE: This workflow could not be found
-# @pytest.mark.live
-# def test_test_job_live(workflow_live):
-#     input_parameters_json = (
-#         Path(__file__).resolve().parent / "mock_data/input_params_simple.json"
-#     )
-#     jb = workflow_live.test_job(
-#         input_parameters=input_parameters_json, track_status=True
-#     )
-#     assert isinstance(jb, Job)
-#     with open(input_parameters_json) as src:
-#         job_info_params = json.load(src)
-#         job_info_params.update({"config": {"mode": "DRY_RUN"}})
-#         assert jb._info["inputs"] == job_info_params
-#         assert jb._info["mode"] == "DRY_RUN"
-#     assert jb.status == "SUCCEEDED"
-
-
-# # NOTE: This workflow could not be found
-# @pytest.mark.live
-# def test_run_job_live(workflow_live):
-#     input_parameters_json = (
-#         Path(__file__).resolve().parent / "mock_data/input_params_simple.json"
-#     )
-#     jb = workflow_live.run_job(input_parameters_json, track_status=True, name=JOB_NAME)
-#     assert isinstance(jb, Job)
-#     with open(input_parameters_json) as src:
-#         assert jb._info["inputs"] == json.load(src)
-#         assert jb._info["mode"] == "DEFAULT"
-#     assert jb.status == "SUCCEEDED"
-#     assert jb._info["name"] == JOB_NAME + "_py"
 
 
 def test_get_jobs(workflow_mock, requests_mock):


### PR DESCRIPTION
Jira Ticket [here](https://up42.atlassian.net/browse/AT-2836).

Scope: Now that we are moving the scope of live tests to e2e tests, it doesn't make sense to fix the failing live tests here.
@janchrizz please refer to this PR to see which tests are being removed.

Following tests deleted since given test asset doesn’t exist anymore:
 - test_asset_info_live(asset_live)
 - test_asset_stac_info_live(asset_live)
 - test_asset_get_download_url_live(asset_live)
 - test_asset_download_live(asset_live)
 - test_asset_download_live_2(asset_live)
 
Following tests deleted since given job doesn’t exist anymore:
 - test_job_download_result_live(job_live)
 - test_job_get_credits_live(job_live)

Following tests deleted since given job collection doesn’t exist anymore:
 - test_jobcollection_download_results_live(jobcollection_live)

Following tests deleted since given job task doesn’t exist anymore:
 - test_get_result_json_live(jobtask_live)
 - test_jobtask_download_result_live(jobtask_live)
 - test_download_quicklook_live(jobtask_live)

Following tests deleted since given Order id doesn’t exist anymore:
 - test_order_info_live(order_live)
 - test_order_parameters_live(order_live)

Following tests deleted since given Workflow doesn’t exist anymore:
 - test_get_workflow_tasks_basic_live(workflow_live)
 - test_get_compatible_blocks_live(workflow_live)
 - test_add_workflow_tasks_simple_not_existing_block_id_raises_live(workflow_live)
 - test_get_parameter_info_live(workflow_live)
 - test_estimate_jobs_live(workflow_live)
 - test_test_jobs_parallel_live(workflow_live)
 - test_run_jobs_parallel_live(workflow_live)
 - test_test_job_live(workflow_live)
 - test_run_job_live(workflow_live)