### PR TITLE
AT-3182 Migrating to v2 order endpoints

### DIFF
--- a/tests/fixtures/fixtures_storage.py
+++ b/tests/fixtures/fixtures_storage.py
@@ -1,18 +1,15 @@
 import pytest
 
+from ..context import Storage
 from .fixtures_globals import (
-    JSON_ASSETS,
-    JSON_ASSET,
-    JSON_STORAGE_STAC,
     ASSET_ID,
-    JSON_ORDERS,
+    JSON_ASSET,
+    JSON_ASSETS,
     JSON_ORDER,
+    JSON_ORDERS,
+    JSON_STORAGE_STAC,
     ORDER_ID,
     PYSTAC_MOCK_CLIENT,
-)
-
-from ..context import (
-    Storage,
 )
 
 
@@ -36,7 +33,8 @@ def storage_mock(auth_mock, requests_mock):
 
     # orders
     url_storage_assets = (
-        f"{auth_mock._endpoint()}/workspaces/{auth_mock.workspace_id}/orders"
+        f"{auth_mock._endpoint()}/v2/orders?sort=createdAt,desc&workspaceId={auth_mock.workspace_id}"
+        "&type=ARCHIVE&tags=project-7&tags=optical&size=50"
     )
     requests_mock.get(url=url_storage_assets, json=JSON_ORDERS)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -380,8 +380,8 @@ def test_get_orders_pagination(auth_mock, requests_mock):
 
     # assets pages
     url_storage_orders_paginated = (
-        f"{auth_mock._endpoint()}/workspaces/{auth_mock.workspace_id}/"
-        f"orders?format=paginated&sort=createdAt,asc&size=50"
+        f"{auth_mock._endpoint()}/v2/"
+        f"orders?sort=createdAt,asc&workspaceId={auth_mock.workspace_id}&size=50"
     )
     requests_mock.get(url=url_storage_orders_paginated, json=json_orders_paginated)
 


### PR DESCRIPTION
Order endpoints will deprecate soon, we need to migrate the endpoints that utilize these endpoint to the new version. 

https://up42.atlassian.net/browse/AT-3182?atlOrigin=eyJpIjoiNzZlYzRjMjRlMTBhNDkzOWFhMWM5ODM0ZGViZGMzNjIiLCJwIjoiaiJ9

Public endpoints:
Update code to use GET /v2/orders in place of GET /workspaces/{workspace_id}/orders
Update code to use GET /v2/orders/{order_id} in place of GET /workspaces/{workspace_id}/orders


Items:
* [X] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
