### PR TITLE
DOC-732: Convert an SDK reference page to markdown: up42

### DIFF
--- a/docs/reference/asset-reference.md
+++ b/docs/reference/asset-reference.md
@@ -37,29 +37,25 @@ The `update_metadata()` function allows you to change the title and tags of an U
 ```python
 update_metadata(
     title,
-    tags
+    tags,
 )
 ```
 
+The returned format is `dict`.
+
 <h5> Arguments </h5>
 
-| Name    | Type        | Description                                       |
-| ------- | ----------- | ------------------------------------------------- |
-| `title` | `str`       | An editable asset title.                          |
-| `tags`  | `List[str]` | An editable list of tags to categorize the asset. |
-
-<h5> Returns </h5>
-
-| Type   | Description     |
-| ------ | --------------- |
-| `dict` | Asset metadata. |
+| Argument | Overview                                                            |
+| -------- | ------------------------------------------------------------------- |
+| `title`  | **str**<br/>An editable asset title.                                |
+| `tags`   | **List[str]**<br/>An editable list of tags to categorize the asset. |
 
 <h5> Example </h5>
 
 ```python
 asset.update_metadata(
     title="Sentinel-2 over Western Europe",
-    tags=["optical", "WEU"]
+    tags=["optical", "WEU"],
 )
 ```
 
@@ -70,28 +66,25 @@ The `download()` function allows you to download UP42 assets from storage.
 ```python
 download(
     output_directory,
-    unpacking
+    unpacking,
 )
 ```
+
+The returned format is `List[str]`.
+
 <h5> Arguments </h5>
 
-| Name               | Type                     | Description                         |
-| ------------------ | ------------------------ | ----------------------------------- |
-| `output_directory` | `Union[str, Path, None]` | The file output directory.          |
-| `unpacking`        | `bool`                   | Whether to unpack the archive file. |
-
-<h5> Returns </h5>
-
-| Type        | Description                                       |
-| ----------- | ------------------------------------------------- |
-| `List[str]` | A list of paths where the files were uploaded to. |
+| Argument           | Overview                                                                                                                                                                                       |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `output_directory` | **Union[str, Path, None]**<br/>The file output directory. The default value is the current directory.                                                                                          |
+| `unpacking`        | **bool / required**<br/>Determines how to download the asset:<br/><ul><li>`True`: download and unpack the file.</li><li>`False`: just download the file.</li></ul>The default value is `True`. |
 
 <h5> Example </h5>
 
 ```python
 asset.download(
     output_directory="/Users/max.mustermann/Desktop/",
-    unpacking=True
+    unpacking=False,
 )
 ```
 
@@ -124,27 +117,24 @@ The `download_stac_asset()` function allows you to download STAC assets from sto
 ```python
 download_stac_asset(
     stac_asset,
-    unpacking
+    output_directory,
 )
 ```
+
+The returned format is `Path`.
+
 <h5> Arguments </h5>
 
-| Name               | Type                     | Description                |
-| ------------------ | ------------------------ | -------------------------- |
-| `stac_asset`       | `pystac.Asset`           | The STAC asset name.       |
-| `output_directory` | `Union[str, Path, None]` | The file output directory. |
-
-<h5> Returns </h5>
-
-| Type   | Description                               |
-| ------ | ----------------------------------------- |
-| `Path` | The path where the file were uploaded to. |
+| Argument           | Description                                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| `stac_asset`       | **pystac.Asset / required**<br/>The STAC asset name.                                                  |
+| `output_directory` | **Union[str, Path, None]**<br/>The file output directory. The default value is the current directory. |
 
 <h5> Example </h5>
 
 ```python
 asset.download_stac_asset(
     stac_asset="b12.tiff",
-    output_directory="/Users/max.mustermann/Desktop/"
+    output_directory="/Users/max.mustermann/Desktop/",
 )
 ```

--- a/docs/reference/asset-reference.md
+++ b/docs/reference/asset-reference.md
@@ -61,7 +61,7 @@ asset.update_metadata(
 
 ### download()
 
-The `download()` function allows you to download UP42 assets from storage.
+The `download()` function allows you to download UP42 assets from storage and returns a list of download paths.
 
 ```python
 download(
@@ -74,10 +74,10 @@ The returned format is `List[str]`.
 
 <h5> Arguments </h5>
 
-| Argument           | Overview                                                                                                                                                                                       |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `output_directory` | **Union[str, Path, None]**<br/>The file output directory. The default value is the current directory.                                                                                          |
-| `unpacking`        | **bool / required**<br/>Determines how to download the asset:<br/><ul><li>`True`: download and unpack the file.</li><li>`False`: just download the file.</li></ul>The default value is `True`. |
+| Argument           | Overview                                                                                                                                                                                             |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `output_directory` | **Union[str, Path, None]**<br/>The file output directory. The default value is the current directory.                                                                                                |
+| `unpacking`        | **bool / required**<br/>Determines how to download the asset:<br/><ul><li>`True`: download and unpack the file.</li><li>`False`: download the compressed file.</li></ul>The default value is `True`. |
 
 <h5> Example </h5>
 
@@ -112,7 +112,7 @@ asset.stac_items
 
 ### download_stac_asset()
 
-The `download_stac_asset()` function allows you to download STAC assets from storage.
+The `download_stac_asset()` function allows you to download a STAC asset from storage and returns the path to the downloaded file.
 
 ```python
 download_stac_asset(
@@ -121,7 +121,7 @@ download_stac_asset(
 )
 ```
 
-The returned format is `Path`.
+The returned format is `pathlib.Path`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/asset-reference.md
+++ b/docs/reference/asset-reference.md
@@ -112,7 +112,7 @@ asset.stac_items
 
 ### download_stac_asset()
 
-The `download_stac_asset()` function allows you to download a STAC asset from storage and returns the path to the downloaded file.
+The `download_stac_asset()` function allows you to download a STAC asset from storage and returns the path to the downloaded file. A new directory for the file will be created.
 
 ```python
 download_stac_asset(

--- a/docs/reference/catalogbase-reference.md
+++ b/docs/reference/catalogbase-reference.md
@@ -46,9 +46,9 @@ get_data_products(basic=True)
 
 <h5> Arguments </h5>
 
-| Name    | Type   | Description                                                                                                                                                                                                                                |
-| ------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `basic` | `bool` | Determines how to return a list of data products:<ul><li>`True`: returns only collection titles, collection names, host names, product configuration titles, and data product IDs.</li><li>`False`: returns the full response.</li></ul> |
+| Name    | Type   | Description                                                                                                                                                                                                                            |
+| ------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `basic` | `bool` | Determines how to return a list of data products:<ul><li>`True`: return only collection titles, collection names, host names, product configuration titles, and data product IDs.</li><li>`False`: return the full response.</li></ul> |
 
 <h5> Returns </h5>
 
@@ -108,9 +108,9 @@ place_order(
 
 <h5> Arguments </h5>
 
-| Name               | Type                | Description                                                                                                                                                                                |
-| ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `order_parameters` | `Union[dict, None]` | Parameters with which to place an order.                                                                                                                                                   |
+| Name               | Type                | Description                                                                                                                                                                                     |
+| ------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `order_parameters` | `Union[dict, None]` | Parameters with which to place an order.                                                                                                                                                        |
 | `track_status`     | `bool`              | Determines when to return order data:<ul><li>`True`: return order data only when the order status changes to `FULFILLED` or `FAILED`.</li><li>`False`: return order data immediately.</li></ul> |
 | `report_time`      | `int`               | Use if `track_status=True`.<br/><br/>The time interval for querying whether the order status has changed to `FULFILLED` or `FAILED`, in seconds.                                                |
 

--- a/docs/reference/catalogbase-reference.md
+++ b/docs/reference/catalogbase-reference.md
@@ -41,9 +41,7 @@ catalog.get_collections()
 The `get_data_products()` function returns a list of data products.
 
 ```python
-get_data_products(
-    basic=True
-)
+get_data_products(basic=True)
 ```
 
 <h5> Arguments </h5>
@@ -61,13 +59,9 @@ get_data_products(
 <h5> Example </h5>
 
 ```python
-tasking.get_data_products(
-    basic=False
-)
+tasking.get_data_products(basic=False)
 
-catalog.get_data_products(
-    basic=False
-)
+catalog.get_data_products(basic=False)
 ```
 
 ### get_data_product_schema()
@@ -75,9 +69,7 @@ catalog.get_data_products(
 The `get_data_product_schema()` function returns the parameters needed to place an order for a specific data product.
 
 ```python
-get_data_product_schema(
-    data_product_id
-)
+get_data_product_schema(data_product_id=None)
 ```
 
 <h5> Arguments </h5>
@@ -95,13 +87,9 @@ get_data_product_schema(
 <h5> Example </h5>
 
 ```python
-tasking.get_data_product_schema(
-    data_product_id="123eabab-0511-4f36-883a-80928716c3db"
-)
+tasking.get_data_product_schema(data_product_id="123eabab-0511-4f36-883a-80928716c3db")
 
-catalog.get_data_product_schema(
-    data_product_id="647780db-5a06-4b61-b525-577a8b68bb54"
-)
+catalog.get_data_product_schema(data_product_id="647780db-5a06-4b61-b525-577a8b68bb54")
 ```
 
 ## Orders
@@ -112,7 +100,7 @@ The `place_order()` function allows you to place a catalog or tasking order.
 
 ```python
 place_order(
-    order_parameters,
+    order_parameters=None,
     track_status=False,
     report_time=120,
 )

--- a/docs/reference/catalogbase-reference.md
+++ b/docs/reference/catalogbase-reference.md
@@ -20,11 +20,7 @@ The `get_collections()` function returns a list of geospatial collections.
 get_collections()
 ```
 
-<h5> Returns </h5>
-
-| Type                | Description                       |
-| ------------------- | --------------------------------- |
-| `Union[Dict, List]` | A list of geospatial collections. |
+The returned format is `Union[Dict, List]`.
 
 <h5> Example </h5>
 
@@ -41,20 +37,16 @@ catalog.get_collections()
 The `get_data_products()` function returns a list of data products.
 
 ```python
-get_data_products(basic=True)
+get_data_products(basic)
 ```
+
+The returned format is `Union[dict, List[dict]]`.
 
 <h5> Arguments </h5>
 
-| Name    | Type   | Description                                                                                                                                                                                                                            |
-| ------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `basic` | `bool` | Determines how to return a list of data products:<ul><li>`True`: return only collection titles, collection names, host names, product configuration titles, and data product IDs.</li><li>`False`: return the full response.</li></ul> |
-
-<h5> Returns </h5>
-
-| Type                      | Description              |
-| ------------------------- | ------------------------ |
-| `Union[dict, List[dict]]` | A list of data products. |
+| Argument | Overview                                                                                                                                                                                                                                                                              |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `basic`  | **bool**<br/>Determines how to return a list of data products:</br/><ul><li>`True`: return only collection titles, collection names, host names, product configuration titles, and data product IDs.</li><li>`False`: return the full response.</li></ul>The default value is `True`. |
 
 <h5> Example </h5>
 
@@ -69,20 +61,16 @@ catalog.get_data_products(basic=False)
 The `get_data_product_schema()` function returns the parameters needed to place an order for a specific data product.
 
 ```python
-get_data_product_schema(data_product_id=None)
+get_data_product_schema(data_product_id)
 ```
+
+The returned format is `dict`.
 
 <h5> Arguments </h5>
 
-| Name              | Type  | Description          |
-| ----------------- | ----- | -------------------- |
-| `data_product_id` | `str` | The data product ID. |
-
-<h5> Returns </h5>
-
-| Type   | Description              |
-| ------ | ------------------------ |
-| `dict` | Data product parameters. |
+| Argument          | Overview                                    |
+| ----------------- | ------------------------------------------- |
+| `data_product_id` | **str / required**<br/>The data product ID. |
 
 <h5> Example </h5>
 
@@ -100,25 +88,21 @@ The `place_order()` function allows you to place a catalog or tasking order.
 
 ```python
 place_order(
-    order_parameters=None,
-    track_status=False,
-    report_time=120,
+    order_parameters,
+    track_status,
+    report_time,
 )
 ```
 
+The returned format is `Order`.
+
 <h5> Arguments </h5>
 
-| Name               | Type                | Description                                                                                                                                                                                     |
-| ------------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `order_parameters` | `Union[dict, None]` | Parameters with which to place an order.                                                                                                                                                        |
-| `track_status`     | `bool`              | Determines when to return order data:<ul><li>`True`: return order data only when the order status changes to `FULFILLED` or `FAILED`.</li><li>`False`: return order data immediately.</li></ul> |
-| `report_time`      | `int`               | Use if `track_status=True`.<br/><br/>The time interval for querying whether the order status has changed to `FULFILLED` or `FAILED`, in seconds.                                                |
-
-<h5> Returns </h5>
-
-| Type    | Description |
-| ------- | ----------- |
-| `Order` | Order data. |
+| Argument           | Overview                                                                                                                                                                                                                                      |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `order_parameters` | **Union[dict, None]**<br/>Parameters with which to place an order.                                                                                                                                                                            |
+| `track_status`     | **bool**<br/>Determines when to return order data:</p><ul><li>`True`: return order data only when the order status changes to `FULFILLED` or `FAILED`.</li><li>`False`: return order data immediately.</li></ul>The default value is `False`. |
+| `report_time`      | **int**<br/>Use if `track_status=True`.<br/><br/>The time interval for querying whether the order status has changed to `FULFILLED` or `FAILED`, in seconds. The default value is `120`.                                                      |
 
 <h5> Example </h5>
 

--- a/docs/reference/tasking-reference.md
+++ b/docs/reference/tasking-reference.md
@@ -16,12 +16,12 @@ The `construct_order_parameters()` function allows you to fill out an order form
 
 ```python
 construct_order_parameters(
-    data_product_id,
-    name,
-    acquisition_start,
-    acquisition_end,
-    geometry,
-    tags
+    data_product_id=None,
+    name=None,
+    acquisition_start=None,
+    acquisition_end=None,
+    geometry=None,
+    tags=None,
 )
 ```
 
@@ -105,12 +105,10 @@ get_feasibility(
 
 ```python
 tasking.get_feasibility(
-    feasibility_id=None,
     workspace_id="68567134-27ad-7bd7-4b65-d61adb11fc78",
-    order_id=None,
     decision="NOT_DECIDED",
-    sortby="createdAt",
-    descending=False
+    sortby="updatedAt",
+    descending=False,
 )
 ```
 
@@ -122,8 +120,8 @@ You can only perform actions with feasibility studies with the `NOT_DECIDED` sta
 
 ```python
 choose_feasibility(
-    feasibility_id,
-    accepted_option_id
+    feasibility_id=None,
+    accepted_option_id=None,
 )
 ```
 
@@ -187,11 +185,9 @@ get_quotations(
 
 ```python
 tasking.get_quotations(
-    quotation_id=None,
     workspace_id="68567134-27ad-7bd7-4b65-d61adb11fc78",
-    order_id=None,
     decision="NOT_DECIDED",
-    sortby="createdAt",
+    sortby="updatedAt",
     descending=False
 )
 ```
@@ -204,8 +200,8 @@ You can only perform actions with feasibility studies with the `NOT_DECIDED` sta
 
 ```python
 decide_quotation(
-    quotation_id,
-    decision
+    quotation_id=None,
+    decision=None,
 )
 ```
 
@@ -227,6 +223,6 @@ decide_quotation(
 ```python
 tasking.decide_quotation(
     quotation_id="68567134-27ad-7bd7-4b65-d61adb11fc78",
-    decision="ACCEPTED"
+    decision="ACCEPTED",
 )
 ```

--- a/docs/reference/tasking-reference.md
+++ b/docs/reference/tasking-reference.md
@@ -16,31 +16,27 @@ The `construct_order_parameters()` function allows you to fill out an order form
 
 ```python
 construct_order_parameters(
-    data_product_id=None,
-    name=None,
-    acquisition_start=None,
-    acquisition_end=None,
-    geometry=None,
-    tags=None,
+    data_product_id,
+    name,
+    acquisition_start,
+    acquisition_end,
+    geometry,
+    tags,
 )
 ```
 
+The returned format is `dict`.
+
 <h5> Arguments </h5>
 
-| Name                | Type                                                                          | Description                                                                                                                                   |
-| ------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data_product_id`   | `str`                                                                         | The data product ID.                                                                                                                          |
-| `name`              | `str`                                                                         | The tasking order name.                                                                                                                       |
-| `acquisition_start` | `Union[str, datetime]`                                                        | The start date of the acquisition period in the `YYYY-MM-DD` format.                                                                          |
-| `acquisition_end`   | `Union[str, datetime]`                                                        | The end date of the acquisition period in the `YYYY-MM-DD` format.                                                                            |
-| `geometry`          | `Union[FeatureCollection, Feature, dict, list, GeoDataFrame, Polygon, Point]` | Geometry of the area to be captured. It can be a POI or an AOI depending on the [collection](https://docs.up42.com/data/tasking/limitations). |
-| `tags`              | `Optional[List[str]]`                                                         | A list of tags that categorize the order.                                                                                                     |
-
-<h5> Returns </h5>
-
-| Type   | Description       |
-| ------ | ----------------- |
-| `dict` | Order parameters. |
+| Argument            | Overview                                                                                                                                                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `data_product_id`   | **str / required**<br/>The data product ID.                                                                                                                                                                                                      |
+| `name`              | **str / required**<br/>The tasking order name.                                                                                                                                                                                                   |
+| `acquisition_start` | **Union[str, datetime] / required**<br/>The start date of the acquisition period in the `YYYY-MM-DD` format.                                                                                                                                     |
+| `acquisition_end`   | **Union[str, datetime] / required**<br/>The end date of the acquisition period in the `YYYY-MM-DD` format.                                                                                                                                       |
+| `geometry`          | **Union[FeatureCollection, Feature, dict, list, GeoDataFrame, Polygon, Point] / required**<br/>The geometry of the area to be captured. It can be a POI or an AOI depending on the [collection](https://docs.up42.com/data/tasking/limitations). |
+| `tags`              | **List[str]**<br/>A list of tags that categorize the order.                                                                                                                                                                                      |
 
 <h5> Example </h5>
 
@@ -62,7 +58,7 @@ tasking.construct_order_parameters(
             ),
         ),
     },
-    tags=["project-7", "optical"]
+    tags=["project-7", "optical"],
 )
 ```
 
@@ -74,32 +70,27 @@ The `get_feasibility()` function returns a list of feasibility studies for taski
 
 ```python
 get_feasibility(
-    feasibility_id=None,
-    workspace_id=None,
-    order_id=None,
-    decision=None,
-    sortby="createdAt",
-    descending=True
+    feasibility_id,
+    workspace_id,
+    order_id,
+    decision,
+    sortby,
+    descending,
 )
 ```
 
+The returned format is `list`.
+
 <h5> Arguments </h5>
 
-| Name             | Type                  | Description                                                                                                                           |
-| ---------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `feasibility_id` | `Optional[str]`       | The feasibility study ID.                                                                                                             |
-| `workspace_id`   | `Optional[str]`       | The workspace ID.<br/><br/>Use to get objects from a specific workspace. Otherwise, objects from the entire account will be returned. |
-| `order_id`       | `Optional[str]`       | The order ID.                                                                                                                         |
-| `decision`       | `Optional[list[str]]` | The status of feasibility studies. The allowed values:<ul><li>`NOT_DECIDED`</li><li>`ACCEPTED`</li></ul>                              |
-| `sortby`         | `str`                 | Arrange elements in the order specified in `descending` based on a chosen field.                                                      |
-| `descending`     | `bool`                | Whether to arrange elements in ascending or descending order based on the field specified in `sortby`.                                |
-
-
-<h5> Returns </h5>
-
-| Type   | Description                    |
-| ------ | ------------------------------ |
-| `list` | A list of feasibility studies. |
+| Argument         | Overview                                                                                                                                                                                                                                                                                     |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `feasibility_id` | **str**<br/>The feasibility study ID.                                                                                                                                                                                                                                                        |
+| `workspace_id`   | **str**<br/>The workspace ID. Use to get objects from a specific workspace. Otherwise, objects from the entire account will be returned.                                                                                                                                                     |
+| `order_id`       | **str**<br/>The order ID.                                                                                                                                                                                                                                                                    |
+| `decision`       | **List[str]**<br/>The status of feasibility studies. The allowed values:<br/><ul><li>`NOT_DECIDED`</li><li>`ACCEPTED`</li></ul>                                                                                                                                                              |
+| `sortby`         | **str**<br/>Arrange elements in the order specified in `descending` based on a chosen field. The default value is `createdAt`.                                                                                                                                                               |
+| `descending`     | **bool**<br/>Determines the arrangement of elements:<br/><ul><li>`True`: arrange elements in descending order based on the field specified in `sortby`.</li><li>`False`: arrange elements in ascending order based on the field specified in `sortby`.</li></ul>The default value is `True`. |
 
 <h5> Example </h5>
 
@@ -120,30 +111,26 @@ You can only perform actions with feasibility studies with the `NOT_DECIDED` sta
 
 ```python
 choose_feasibility(
-    feasibility_id=None,
-    accepted_option_id=None,
+    feasibility_id,
+    accepted_option_id,
 )
 ```
 
+The returned format is `dict`.
+
 <h5> Arguments </h5>
 
-| Name                 | Type  | Description                                 |
-| -------------------- | ----- | ------------------------------------------- |
-| `feasibility_id`     | `str` | The feasibility study ID.                   |
-| `accepted_option_id` | `str` | The ID of the feasibility option to accept. |
-
-<h5> Returns </h5>
-
-| Type   | Description                                   |
-| ------ | --------------------------------------------- |
-| `dict` | Feasibility option confirmation and metadata. |
+| Argument             | Overview                                                           |
+| -------------------- | ------------------------------------------------------------------ |
+| `feasibility_id`     | **str / required**<br/>The feasibility study ID.                   |
+| `accepted_option_id` | **str / required**<br/>The ID of the feasibility option to accept. |
 
 <h5> Example </h5>
 
 ```python
 tasking.choose_feasibility(
     feasibility_id="68567134-27ad-7bd7-4b65-d61adb11fc78",
-    accepted_option_id="a0d443a2-41e8-4995-8b54-a5cc4c448227"
+    accepted_option_id="a0d443a2-41e8-4995-8b54-a5cc4c448227",
 )
 ```
 
@@ -155,31 +142,27 @@ The `get_quotations()` function returns a list of all quotations for tasking ord
 
 ```python
 get_quotations(
-    quotation_id=None,
-    workspace_id=None,
-    order_id=None,
-    decision=None,
-    sortby="createdAt",
-    descending=True
+    quotation_id,
+    workspace_id,
+    order_id,
+    decision,
+    sortby,
+    descending,
 )
 ```
 
+The returned format is `list`.
+
 <h5> Arguments </h5>
 
-| Name           | Type                  | Description                                                                                                                           |
-| -------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `quotation_id` | `Optional[str]`       | The quotation ID.                                                                                                                     |
-| `workspace_id` | `Optional[str]`       | The workspace ID.<br/><br/>Use to get objects from a specific workspace. Otherwise, objects from the entire account will be returned. |
-| `order_id`     | `Optional[str]`       | The order ID.                                                                                                                         |
-| `decision`     | `Optional[list[str]]` | The status of quotations. The allowed values:<ul><li>`NOT_DECIDED`</li><li>`ACCEPTED`</li><li>`REJECTED`</li></ul>                    |
-| `sortby`       | `str`                 | Arrange elements in the order specified in `descending` based on a chosen field.                                                      |
-| `descending`   | `bool`                | Whether to arrange elements in ascending or descending order based on the field specified in `sortby`.                                |
-
-<h5> Returns </h5>
-
-| Type   | Description           |
-| ------ | --------------------- |
-| `list` | A list of quotations. |
+| Argument       | Overview                                                                                                                                                                                                                                                                                     |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `quotation_id` | **str**<br/>The quotation ID.                                                                                                                                                                                                                                                                |
+| `workspace_id` | **str**<br/>The workspace ID. Use to get objects from a specific workspace. Otherwise, objects from the entire account will be returned.                                                                                                                                                     |
+| `order_id`     | **str**<br/>The order ID.                                                                                                                                                                                                                                                                    |
+| `decision`     | **List[str]**<br/>The status of quotations. The allowed values:<br/><ul><li>`NOT_DECIDED`</li><li>`ACCEPTED`</li><li>`REJECTED`</li></ul>                                                                                                                                                    |
+| `sortby`       | **str**<br/>Arrange elements in the order specified in `descending` based on a chosen field. The default value is `createdAt`.                                                                                                                                                               |
+| `descending`   | **bool**<br/>Determines the arrangement of elements:<br/><ul><li>`True`: arrange elements in descending order based on the field specified in `sortby`.</li><li>`False`: arrange elements in ascending order based on the field specified in `sortby`.</li></ul>The default value is `True`. |
 
 <h5> Example </h5>
 
@@ -188,7 +171,7 @@ tasking.get_quotations(
     workspace_id="68567134-27ad-7bd7-4b65-d61adb11fc78",
     decision="NOT_DECIDED",
     sortby="updatedAt",
-    descending=False
+    descending=False,
 )
 ```
 
@@ -200,23 +183,19 @@ You can only perform actions with feasibility studies with the `NOT_DECIDED` sta
 
 ```python
 decide_quotation(
-    quotation_id=None,
-    decision=None,
+    quotation_id,
+    decision,
 )
 ```
 
+The returned format is `dict`.
+
 <h5> Arguments </h5>
 
-| Name           | Type  | Description                                                                                              |
-| -------------- | ----- | -------------------------------------------------------------------------------------------------------- |
-| `quotation_id` | `str` | The quotation ID.                                                                                        |
-| `decision`     | `str` | The decision made for this quotation. The allowed values:<ul><li>`ACCEPTED`</li><li>`REJECTED`</li></ul> |
-
-<h5> Returns </h5>
-
-| Type   | Description                                   |
-| ------ | --------------------------------------------- |
-| `dict` | Quotation decision confirmation and metadata. |
+| Argument       | Description                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `quotation_id` | **str / required**<br/>The quotation ID.                                                                                        |
+| `decision`     | **str / required**<br/>The decision made for this quotation. The allowed values:<ul><li>`ACCEPTED`</li><li>`REJECTED`</li></ul> |
 
 <h5> Example </h5>
 

--- a/docs/reference/up42-reference.md
+++ b/docs/reference/up42-reference.md
@@ -1,35 +1,69 @@
 # up42
 
-::: up42.main
-    selection:
-        members:
-            - "authenticate"
-    rendering:
-       group_by_category: False
+## Authentication
 
+### authenticate()
 
-::: up42.tools
-    rendering:
-        group_by_category: False
+### settings()
 
+## Geometries
+### draw_aoi()
+### get_example_aoi()
+### read_vector_file()
 
-::: up42.viztools
-    selection:
-        members:
-            - "draw_aoi"
-    rendering:
-        group_by_category: False
+## Credits
 
+### get_credits_balance()
 
-::: up42.main
-    selection:
-        filters:
-            - "!authenticate"
-            - "!^_"
-    rendering:
-        group_by_category: False
+## Blocks
 
+### get_block_coverage()
+### get_block_details()
+### get_blocks()
+### validate_manifest()
 
-::: up42.initialization
-    rendering:
-        group_by_category: False
+## Initialization
+
+### initialize_tasking()
+
+The `initialize_tasking()` function allows you to access the [Tasking class](tasking-reference.md).
+
+### initialize_catalog()
+
+The `initialize_catalog()` function allows you to access the [Catalog class](catalog-reference.md).
+
+### initialize_order()
+
+The `initialize_order()` function allows you to access the [Order class](order-reference.md).
+
+### initialize_storage()
+
+The `initialize_storage()` function allows you to access the [Storage class](storage-reference.md).
+
+### initialize_asset()
+
+The `initialize_asset()` function allows you to access the [Asset class](asset-reference.md).
+
+### initialize_project()
+
+The `initialize_project()` function allows you to access the [Project class](project-reference.md).
+
+### initialize_workflow()
+
+The `initialize_workflow()` function allows you to access the [Workflow class](workflow-reference.md).
+
+### initialize_job()
+
+The `initialize_job()` function allows you to access the [Job class](job-reference.md).
+
+### initialize_jobcollection()
+
+The `initialize_jobcollection()` function allows you to access the [JobCollection class](jobcollection-reference.md).
+
+### initialize_jobtask()
+
+The `initialize_jobtask()` function allows you to access the [JobTask class](jobtask-reference.md).
+
+### initialize_webhook()
+
+The `initialize_webhook()` function allows you to access the [Webhooks class](webhooks-reference.md).

--- a/docs/reference/up42-reference.md
+++ b/docs/reference/up42-reference.md
@@ -59,11 +59,156 @@ tools.settings(log=True)
 up42.tools.settings(log=True)
 ```
 
+## Credits
+
+### get_credits_balance()
+
+The `get_credits_balance()` function returns your account balance.
+
+```python
+get_credits_balance()
+```
+
+<h5> Returns </h5>
+˝
+| Type   | Description                       |
+| ------ | --------------------------------- |
+| `dict` | Your account balance, in credits. |
+
+<h5> Example </h5>
+
+```python
+up42.get_credits_balance()
+```
+
+## Blocks
+
+### get_block_coverage()
+
+The `get_block_coverage()` function returns the spatial coverage of the block.
+
+```python
+get_block_coverage(block_id=None)
+```
+
+<h5> Arguments </h5>
+
+| Name       | Type  | Description   |
+| ---------- | ----- | ------------- |
+| `block_id` | `str` | The block ID. |
+
+<h5> Returns </h5>
+
+| Type   | Description       |
+| ------ | ----------------- |
+| `dict` | Spatial coverage. |
+
+<h5> Example </h5>
+
+```python
+up42.get_block_coverage(block_id="045019bb-06fc-4fa1-b703-318725b4d8af")
+```
+
+### get_block_details()
+
+The `get_block_details()` function returns information about a specific block.
+
+```python
+get_block_details(
+    block_id=None,
+    as_dataframe=False,
+)
+```
+
+<h5> Arguments </h5>
+
+| Name           | Type   | Description                                                                                                        |
+| -------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
+| `block_id`     | `str`  | The block ID.                                                                                                      |
+| `as_dataframe` | `bool` | Determines how to return the information:<ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul> |
+
+<h5> Returns </h5>
+
+| Type   | Description     |
+| ------ | --------------- |
+| `dict` | Block metadata. |
+
+<h5> Example </h5>
+
+```python
+up42.get_block_details(
+    block_id="045019bb-06fc-4fa1-b703-318725b4d8af",
+    as_dataframe=True,
+)
+```
+
+### get_blocks()
+
+The `get_blocks()` function returns a list of all blocks on the marketplace.
+
+```python
+get_blocks(
+    block_type=None,
+    basic=True,
+    as_dataframe=False,
+)
+```
+
+<h5> Arguments </h5>
+
+| Name           | Type            | Description                                                                                                                                           |
+| -------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `block_type`   | `Optional[str]` | Filters blocks:<ul><li>`data`: return data blocks.</li><li>`processing`: return processing blocks.</li></ul>                                          |
+| `basic`        | `bool`          | Determines how to return a list of blocks:<ul><li>`True`: return only block names and block IDs.</li><li>`False`: return the full response.</li></ul> |
+| `as_dataframe` | `bool`          | Determines how to return the information:<ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul>                                    |
+
+<h5> Returns </h5>
+
+| Type                      | Description     |
+| ------------------------- | --------------- |
+| `Union[List[Dict], dict]` | Block metadata. |
+
+<h5> Example </h5>
+
+```python
+up42.get_blocks(
+    block_type="data",
+    basic=True,
+    as_dataframe=True,
+)
+```
+
+### validate_manifest()
+
+The `validate_manifest()` function allows you to validate the [manifest of your custom block](https://docs.up42.com/processing-platform/custom-blocks/manifest).
+
+```python
+validate_manifest(path_or_json=None)
+```
+
+<h5> Arguments </h5>
+
+| Name           | Type                     | Description                                    |
+| -------------- | ------------------------ | ---------------------------------------------- |
+| `path_or_json` | `Union[str, Path, dict]` | The file path to the manifest to be validated. |
+
+<h5> Returns </h5>
+
+| Type   | Description         |
+| ------ | ------------------- |
+| `dict` | Validation results. |
+
+<h5> Example </h5>
+
+```python
+validate_manifest(path_or_json="/Users/max.mustermann/Desktop/UP42Manifest.json")
+```
+
 ## Geometries
 
 ### get_example_aoi()
 
-The `get_example_aoi()` function allows you to… / returns.
+The `get_example_aoi()` function returns an example AOI.
 
 ```python
 get_example_aoi(
@@ -74,16 +219,16 @@ get_example_aoi(
 
 <h5> Arguments </h5>
 
-| Name           | Type   | Description                                                                                                                               |
-| -------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `location`     | `str`  | A defined location. The allowed values:<ul><li>`Berlin`</li><li>`Washington`</li></ul>                                                    |
-| `as_dataframe` | `bool` | Determines how to return the geometry:<ul><li>`True`: return a GeoDataFrame.</li><li>`False`: return a FeatureCollection object.</li></ul> |
+| Name           | Type   | Description                                                                                                        |
+| -------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
+| `location`     | `str`  | A defined location. The allowed values:<ul><li>`Berlin`</li><li>`Washington`</li></ul>                             |
+| `as_dataframe` | `bool` | Determines how to return the information:<ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul> |
 
 <h5> Returns </h5>
 
-| Type                        | Description                |
-| --------------------------- | -------------------------- |
-| `Union[dict, GeoDataFrame]` | A FeatureCollection object. |
+| Type                        | Description     |
+| --------------------------- | --------------- |
+| `Union[dict, GeoDataFrame]` | The chosen AOI. |
 
 <h5> Example </h5>
 
@@ -107,16 +252,16 @@ read_vector_file(
 
 <h5> Arguments </h5>
 
-| Name           | Type   | Description                                                                                                                               |
-| -------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `filename`     | `str`  | The file path to the vector file containing the geometry.                                                                                 |
-| `as_dataframe` | `bool` | Determines how to return the geometry:<ul><li>`True`: return a GeoDataFrame.</li><li>`False`: return a FeatureCollection object.</li></ul> |
+| Name           | Type   | Description                                                                                                        |
+| -------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
+| `filename`     | `str`  | The file path to the vector file containing the geometry.                                                          |
+| `as_dataframe` | `bool` | Determines how to return the information:<ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul> |
 
 <h5> Returns </h5>
 
-| Type                        | Description                |
-| --------------------------- | -------------------------- |
-| `Union[dict, GeoDataFrame]` | A FeatureCollection object. |
+| Type                        | Description            |
+| --------------------------- | ---------------------- |
+| `Union[dict, GeoDataFrame]` | The uploaded geometry. |
 
 <h5> Example </h5>
 
@@ -129,55 +274,64 @@ up42.read_vector_file(
 
 ### draw_aoi()
 
-The `draw_aoi()` function allows you to… / returns.
+The `draw_aoi()` function allows you to draw an AOI on an interactive map. To be able to use the function, [install plotting functionalities](installation.md) first.
 
 ```python
+draw_aoi()
 ```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
 
 <h5> Example </h5>
 
 ```python
+up42.draw_aoi()
 ```
 
-### folium_base_map()
+## Visualization
 
-The `folium_base_map()` function allows you to… / returns.
+### viztools.folium_base_map()
+
+The `viztools.folium_base_map()` function returns a Folium map with the UP42 logo. Use it to [visualize your assets](visualizations.md).
 
 ```python
+viztools.folium_base_map(
+    lat=52.49190032214706,
+    lon=13.39117252959244,
+    zoom_start=14,
+    width_percent="95%",
+    layer_control=False,
+)
 ```
 
 <h5> Arguments </h5>
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
+| Name            | Type    | Description                                                                                                                                   |
+| --------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lat`           | `float` | The latitude.                                                                                                                                 |
+| `lon`           | `float` | The longitude.                                                                                                                                |
+| `zoom_start`    | `int`   | The value of initial zooming in on the coordinates.                                                                                           |
+| `width_percent` | `str`   | The map width in percentage.                                                                                                                  |
+| `layer_control` | `bool`  | Determines how to return the map:<ul><li>`True`: return a basic map.</li><li>`False`: return a map with visualized geospatial data.</li></ul> |
+
 
 <h5> Returns </h5>
 
-| Type | Description |
-| ---- | ----------- |
-|      |             |
+| Type         | Description |
+| ------------ | ----------- |
+| `folium.Map` | A map.      |
 
 <h5> Example </h5>
 
 ```python
+up42.viztools.folium_base_map(
+    lat=48.8584,
+    lon=2.2945,
+    zoom_start=40,
+    width_percent="100%",
+    layer_control=False,
+)
 ```
 
-## Credits
-
-### get_credits_balance()
+### map_quicklooks()
 
 The `` function allows you to… / returns.
 
@@ -201,9 +355,7 @@ The `` function allows you to… / returns.
 ```python
 ```
 
-## Blocks
-
-### get_block_coverage()
+### map_results()
 
 The `` function allows you to… / returns.
 
@@ -227,7 +379,7 @@ The `` function allows you to… / returns.
 ```python
 ```
 
-### get_block_details()
+### plot_coverage()
 
 The `` function allows you to… / returns.
 
@@ -251,7 +403,7 @@ The `` function allows you to… / returns.
 ```python
 ```
 
-### get_blocks()
+### plot_quicklooks()
 
 The `` function allows you to… / returns.
 
@@ -275,7 +427,7 @@ The `` function allows you to… / returns.
 ```python
 ```
 
-### validate_manifest()
+### plot_results()
 
 The `` function allows you to… / returns.
 

--- a/docs/reference/up42-reference.md
+++ b/docs/reference/up42-reference.md
@@ -4,23 +4,300 @@
 
 ### authenticate()
 
-### settings()
+The `authenticate()` function allows you to access UP42 SDK requests. For more information, see [Authentication](authentication.md).
+
+```python
+authenticate(
+    cfg_file=None,
+    project_id=None,
+    project_api_key=None,
+)
+```
+
+<h5> Arguments </h5>
+
+| Name              | Type               | Description                                                               |
+| ----------------- | ------------------ | ------------------------------------------------------------------------- |
+| `cfg_file`        | `Union[str, Path]` | The file path to the JSON file containing the project ID and the API key. |
+| `project_id`      | `Optional[str]`    | The project ID.                                                           |
+| `project_api_key` | `Optional[str]`    | The project API key.                                                      |
+
+<h5> Example </h5>
+
+```python
+# Authenticate directly in code
+
+up42.authenticate(
+    project_id="your-project-ID",
+    project_api_key="your-project-API-key",
+)
+
+# Authenticate in a configuration file
+
+up42.authenticate(cfg_file="config.json")
+```
+
+## Logging
+
+### tools.settings()
+
+The `tools.settings()` function allows you to enable logging.
+
+```python
+tools.settings(log=True)
+```
+
+<h5> Arguments </h5>
+
+| Name  | Type   | Description                |
+| ----- | ------ | -------------------------- |
+| `log` | `bool` | Whether to enable logging. |
+
+<h5> Example </h5>
+
+```python
+up42.tools.settings(log=True)
+```
 
 ## Geometries
-### draw_aoi()
+
 ### get_example_aoi()
+
+The `get_example_aoi()` function allows you to… / returns.
+
+```python
+get_example_aoi(
+    location="Berlin",
+    as_dataframe=False,
+)
+```
+
+<h5> Arguments </h5>
+
+| Name           | Type   | Description                                                                                                                               |
+| -------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `location`     | `str`  | A defined location. The allowed values:<ul><li>`Berlin`</li><li>`Washington`</li></ul>                                                    |
+| `as_dataframe` | `bool` | Determines how to return the geometry:<ul><li>`True`: return a GeoDataFrame.</li><li>`False`: return a FeatureCollection object.</li></ul> |
+
+<h5> Returns </h5>
+
+| Type                        | Description                |
+| --------------------------- | -------------------------- |
+| `Union[dict, GeoDataFrame]` | A FeatureCollection object. |
+
+<h5> Example </h5>
+
+```python
+up42.get_example_aoi(
+    location="Washington",
+    as_dataframe=True,
+)
+```
+
 ### read_vector_file()
+
+The `read_vector_file()` function allows you to upload your geometry from a vector file.
+
+```python
+read_vector_file(
+    filename="aoi.geojson",
+    as_dataframe=False,
+)
+```
+
+<h5> Arguments </h5>
+
+| Name           | Type   | Description                                                                                                                               |
+| -------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `filename`     | `str`  | The file path to the vector file containing the geometry.                                                                                 |
+| `as_dataframe` | `bool` | Determines how to return the geometry:<ul><li>`True`: return a GeoDataFrame.</li><li>`False`: return a FeatureCollection object.</li></ul> |
+
+<h5> Returns </h5>
+
+| Type                        | Description                |
+| --------------------------- | -------------------------- |
+| `Union[dict, GeoDataFrame]` | A FeatureCollection object. |
+
+<h5> Example </h5>
+
+```python
+up42.read_vector_file(
+    filename="/Users/max.mustermann/Desktop/aoi.geojson",
+    as_dataframe=True,
+)
+```
+
+### draw_aoi()
+
+The `draw_aoi()` function allows you to… / returns.
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
+
+### folium_base_map()
+
+The `folium_base_map()` function allows you to… / returns.
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
 
 ## Credits
 
 ### get_credits_balance()
 
+The `` function allows you to… / returns.
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
+
 ## Blocks
 
 ### get_block_coverage()
+
+The `` function allows you to… / returns.
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
+
 ### get_block_details()
+
+The `` function allows you to… / returns.
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
+
 ### get_blocks()
+
+The `` function allows you to… / returns.
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
+
 ### validate_manifest()
+
+The `` function allows you to… / returns.
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
 
 ## Initialization
 
@@ -28,42 +305,262 @@
 
 The `initialize_tasking()` function allows you to access the [Tasking class](tasking-reference.md).
 
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
+
 ### initialize_catalog()
 
 The `initialize_catalog()` function allows you to access the [Catalog class](catalog-reference.md).
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
 
 ### initialize_order()
 
 The `initialize_order()` function allows you to access the [Order class](order-reference.md).
 
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
+
 ### initialize_storage()
 
 The `initialize_storage()` function allows you to access the [Storage class](storage-reference.md).
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
 
 ### initialize_asset()
 
 The `initialize_asset()` function allows you to access the [Asset class](asset-reference.md).
 
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
+
 ### initialize_project()
 
 The `initialize_project()` function allows you to access the [Project class](project-reference.md).
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
 
 ### initialize_workflow()
 
 The `initialize_workflow()` function allows you to access the [Workflow class](workflow-reference.md).
 
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
+
 ### initialize_job()
 
 The `initialize_job()` function allows you to access the [Job class](job-reference.md).
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
 
 ### initialize_jobcollection()
 
 The `initialize_jobcollection()` function allows you to access the [JobCollection class](jobcollection-reference.md).
 
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
+
 ### initialize_jobtask()
 
 The `initialize_jobtask()` function allows you to access the [JobTask class](jobtask-reference.md).
 
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```
+
 ### initialize_webhook()
 
 The `initialize_webhook()` function allows you to access the [Webhooks class](webhooks-reference.md).
+
+```python
+```
+
+<h5> Arguments </h5>
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+|      |      |             |
+
+<h5> Returns </h5>
+
+| Type | Description |
+| ---- | ----------- |
+|      |             |
+
+<h5> Example </h5>
+
+```python
+```

--- a/docs/reference/up42-reference.md
+++ b/docs/reference/up42-reference.md
@@ -8,19 +8,19 @@ The `authenticate()` function allows you to access UP42 SDK requests. For more i
 
 ```python
 authenticate(
-    cfg_file=None,
-    project_id=None,
-    project_api_key=None,
+    cfg_file,
+    project_id,
+    project_api_key,
 )
 ```
 
 <h5> Arguments </h5>
 
-| Name              | Type               | Description                                                               |
-| ----------------- | ------------------ | ------------------------------------------------------------------------- |
-| `cfg_file`        | `Union[str, Path]` | The file path to the JSON file containing the project ID and the API key. |
-| `project_id`      | `Optional[str]`    | The project ID.                                                           |
-| `project_api_key` | `Optional[str]`    | The project API key.                                                      |
+| Argument          | Overview                                                                                           |
+| ----------------- | -------------------------------------------------------------------------------------------------- |
+| `cfg_file`        | **Union[str, Path]**<br/>The file path to the JSON file containing the project ID and the API key. |
+| `project_id`      | **str**<br/>The project ID.                                                                        |
+| `project_api_key` | **str**<br/>The project API key.                                                                   |
 
 <h5> Example </h5>
 
@@ -44,14 +44,14 @@ up42.authenticate(cfg_file="config.json")
 The `tools.settings()` function allows you to enable logging.
 
 ```python
-tools.settings(log=True)
+tools.settings(log)
 ```
 
 <h5> Arguments </h5>
 
-| Name  | Type   | Description                |
-| ----- | ------ | -------------------------- |
-| `log` | `bool` | Whether to enable logging. |
+| Argument | Overview                                                                                                                                              |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log`    | **bool**<br/>Determines logging enabling:<br/><ul><li>`True`: enable logging.</li><li>`False`: disable logging.</li></ul>The default value is `True`. |
 
 <h5> Example </h5>
 
@@ -63,17 +63,13 @@ up42.tools.settings(log=True)
 
 ### get_credits_balance()
 
-The `get_credits_balance()` function returns your account balance.
+The `get_credits_balance()` function returns your account balance, in credits.
 
 ```python
 get_credits_balance()
 ```
 
-<h5> Returns </h5>
-˝
-| Type   | Description                       |
-| ------ | --------------------------------- |
-| `dict` | Your account balance, in credits. |
+The returned format is `dict`.
 
 <h5> Example </h5>
 
@@ -88,25 +84,21 @@ up42.get_credits_balance()
 The `get_block_coverage()` function returns the spatial coverage of the block.
 
 ```python
-get_block_coverage(block_id=None)
+get_block_coverage(block_id)
 ```
+
+The returned format is `dict`.
 
 <h5> Arguments </h5>
 
-| Name       | Type  | Description   |
-| ---------- | ----- | ------------- |
-| `block_id` | `str` | The block ID. |
-
-<h5> Returns </h5>
-
-| Type   | Description       |
-| ------ | ----------------- |
-| `dict` | Spatial coverage. |
+| Argument   | Overview                             |
+| ---------- | ------------------------------------ |
+| `block_id` | **str / required**<br/>The block ID. |
 
 <h5> Example </h5>
 
 ```python
-up42.get_block_coverage(block_id="045019bb-06fc-4fa1-b703-318725b4d8af")
+up42.get_block_coverage(block_id="f73c60f6-3f3c-4120-96cf-62b8d3019346")
 ```
 
 ### get_block_details()
@@ -115,23 +107,19 @@ The `get_block_details()` function returns information about a specific block.
 
 ```python
 get_block_details(
-    block_id=None,
-    as_dataframe=False,
+    block_id,
+    as_dataframe,
 )
 ```
 
+The returned format is `dict`.
+
 <h5> Arguments </h5>
 
-| Name           | Type   | Description                                                                                                        |
-| -------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
-| `block_id`     | `str`  | The block ID.                                                                                                      |
-| `as_dataframe` | `bool` | Determines how to return the information:<ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul> |
-
-<h5> Returns </h5>
-
-| Type   | Description     |
-| ------ | --------------- |
-| `dict` | Block metadata. |
+| Argument       | Overview                                                                                                                                                          |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `block_id`     | **str / required**<br/>The block ID.                                                                                                                              |
+| `as_dataframe` | **bool**<br/>Determines how to return the information:<br/><ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul>The default value is `False`. |
 
 <h5> Example </h5>
 
@@ -148,25 +136,21 @@ The `get_blocks()` function returns a list of all blocks on the marketplace.
 
 ```python
 get_blocks(
-    block_type=None,
-    basic=True,
-    as_dataframe=False,
+    block_type,
+    basic,
+    as_dataframe,
 )
 ```
 
+The returned format is `Union[List[Dict], dict]`.
+
 <h5> Arguments </h5>
 
-| Name           | Type            | Description                                                                                                                                           |
-| -------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `block_type`   | `Optional[str]` | Filters blocks:<ul><li>`data`: return data blocks.</li><li>`processing`: return processing blocks.</li></ul>                                          |
-| `basic`        | `bool`          | Determines how to return a list of blocks:<ul><li>`True`: return only block names and block IDs.</li><li>`False`: return the full response.</li></ul> |
-| `as_dataframe` | `bool`          | Determines how to return the information:<ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul>                                    |
-
-<h5> Returns </h5>
-
-| Type                      | Description     |
-| ------------------------- | --------------- |
-| `Union[List[Dict], dict]` | Block metadata. |
+| Argument       | Overview                                                                                                                                                                                            |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `block_type`   | **str**<br/>Filters blocks:<br/><ul><li>`data`: return data blocks.</li><li>`processing`: return processing blocks.</li></ul>                                                                       |
+| `basic`        | **bool**<br/>Determines how to return a list of blocks:<br/><ul><li>`True`: return only block names and block IDs.</li><li>`False`: return the full response.</li></ul>The default value is `True`. |
+| `as_dataframe` | **bool**<br/>Determines how to return the information:<br/><ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul>The default value is `False`.                                   |
 
 <h5> Example </h5>
 
@@ -183,20 +167,16 @@ up42.get_blocks(
 The `validate_manifest()` function allows you to validate the [manifest of your custom block](https://docs.up42.com/processing-platform/custom-blocks/manifest).
 
 ```python
-validate_manifest(path_or_json=None)
+validate_manifest(path_or_json)
 ```
+
+The returned format is `dict`.
 
 <h5> Arguments </h5>
 
-| Name           | Type                     | Description                                    |
-| -------------- | ------------------------ | ---------------------------------------------- |
-| `path_or_json` | `Union[str, Path, dict]` | The file path to the manifest to be validated. |
-
-<h5> Returns </h5>
-
-| Type   | Description         |
-| ------ | ------------------- |
-| `dict` | Validation results. |
+| Argument       | Overview                                                                                 |
+| -------------- | ---------------------------------------------------------------------------------------- |
+| `path_or_json` | **Union[str, Path, dict] / required**<br/>The file path to the manifest to be validated. |
 
 <h5> Example </h5>
 
@@ -212,23 +192,19 @@ The `get_example_aoi()` function returns an example AOI.
 
 ```python
 get_example_aoi(
-    location="Berlin",
-    as_dataframe=False,
+    location,
+    as_dataframe,
 )
 ```
 
+The returned format is `Union[dict, GeoDataFrame]`.
+
 <h5> Arguments </h5>
 
-| Name           | Type   | Description                                                                                                        |
-| -------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
-| `location`     | `str`  | A defined location. The allowed values:<ul><li>`Berlin`</li><li>`Washington`</li></ul>                             |
-| `as_dataframe` | `bool` | Determines how to return the information:<ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul> |
-
-<h5> Returns </h5>
-
-| Type                        | Description     |
-| --------------------------- | --------------- |
-| `Union[dict, GeoDataFrame]` | The chosen AOI. |
+| Argument       | Overview                                                                                                                                                          |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `location`     | **str**<br/>A defined location. The allowed values:<br/><ul><li>`Berlin`</li><li>`Washington`</li></ul>The default value is `Berlin`.                             |
+| `as_dataframe` | **bool**<br/>Determines how to return the information:<br/><ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul>The default value is `False`. |
 
 <h5> Example </h5>
 
@@ -245,23 +221,19 @@ The `read_vector_file()` function allows you to upload your geometry from a vect
 
 ```python
 read_vector_file(
-    filename="aoi.geojson",
-    as_dataframe=False,
+    filename,
+    as_dataframe,
 )
 ```
 
+The returned format is `Union[dict, GeoDataFrame]`.
+
 <h5> Arguments </h5>
 
-| Name           | Type   | Description                                                                                                        |
-| -------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
-| `filename`     | `str`  | The file path to the vector file containing the geometry.                                                          |
-| `as_dataframe` | `bool` | Determines how to return the information:<ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul> |
-
-<h5> Returns </h5>
-
-| Type                        | Description            |
-| --------------------------- | ---------------------- |
-| `Union[dict, GeoDataFrame]` | The uploaded geometry. |
+| Argument       | Overview                                                                                                                                                          |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `filename`     | **str**<br/>The file path to the vector file containing the geometry. The default value is `aoi.geojson`.                                                         |
+| `as_dataframe` | **bool**<br/>Determines how to return the information:<br/><ul><li>`True`: return DataFrame.</li><li>`False`: return JSON.</li></ul>The default value is `False`. |
 
 <h5> Example </h5>
 
@@ -280,6 +252,8 @@ The `draw_aoi()` function allows you to draw an AOI on an interactive map. To be
 draw_aoi()
 ```
 
+The returned format is `folium.Map`.
+
 <h5> Example </h5>
 
 ```python
@@ -294,30 +268,25 @@ The `viztools.folium_base_map()` function returns a Folium map with the UP42 log
 
 ```python
 viztools.folium_base_map(
-    lat=52.49190032214706,
-    lon=13.39117252959244,
-    zoom_start=14,
-    width_percent="95%",
-    layer_control=False,
+    lat,
+    lon,
+    zoom_start,
+    width_percent,
+    layer_control,
 )
 ```
 
+The returned format is `folium.Map`.
+
 <h5> Arguments </h5>
 
-| Name            | Type    | Description                                                                                                                                   |
-| --------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `lat`           | `float` | The latitude.                                                                                                                                 |
-| `lon`           | `float` | The longitude.                                                                                                                                |
-| `zoom_start`    | `int`   | The value of initial zooming in on the coordinates.                                                                                           |
-| `width_percent` | `str`   | The map width in percentage.                                                                                                                  |
-| `layer_control` | `bool`  | Determines how to return the map:<ul><li>`True`: return a basic map.</li><li>`False`: return a map with visualized geospatial data.</li></ul> |
-
-
-<h5> Returns </h5>
-
-| Type         | Description |
-| ------------ | ----------- |
-| `folium.Map` | A map.      |
+| Argument        | Overview                                                                                                                                                                                     |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lat`           | **float**<br/>The latitude. The default value is `52.49190032214706`.                                                                                                                        |
+| `lon`           | **float**<br/>The longitude. The default value is `13.39117252959244`.                                                                                                                       |
+| `zoom_start`    | **int**<br/>The value of initial zooming in on the coordinates. The default value is `14`.                                                                                                   |
+| `width_percent` | **str**<br/>The map width in percentage. The default value is `95%`.                                                                                                                         |
+| `layer_control` | **bool**<br/>Determines how to return the map:<br/><ul><li>`True`: return a basic map.</li><li>`False`: return a map with visualized geospatial data.</li></ul>The default value is `False`. |
 
 <h5> Example </h5>
 
@@ -329,390 +298,4 @@ up42.viztools.folium_base_map(
     width_percent="100%",
     layer_control=False,
 )
-```
-
-### map_quicklooks()
-
-The `` function allows you to… / returns.
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### map_results()
-
-The `` function allows you to… / returns.
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### plot_coverage()
-
-The `` function allows you to… / returns.
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### plot_quicklooks()
-
-The `` function allows you to… / returns.
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### plot_results()
-
-The `` function allows you to… / returns.
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-## Initialization
-
-### initialize_tasking()
-
-The `initialize_tasking()` function allows you to access the [Tasking class](tasking-reference.md).
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### initialize_catalog()
-
-The `initialize_catalog()` function allows you to access the [Catalog class](catalog-reference.md).
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### initialize_order()
-
-The `initialize_order()` function allows you to access the [Order class](order-reference.md).
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### initialize_storage()
-
-The `initialize_storage()` function allows you to access the [Storage class](storage-reference.md).
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### initialize_asset()
-
-The `initialize_asset()` function allows you to access the [Asset class](asset-reference.md).
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### initialize_project()
-
-The `initialize_project()` function allows you to access the [Project class](project-reference.md).
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### initialize_workflow()
-
-The `initialize_workflow()` function allows you to access the [Workflow class](workflow-reference.md).
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### initialize_job()
-
-The `initialize_job()` function allows you to access the [Job class](job-reference.md).
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### initialize_jobcollection()
-
-The `initialize_jobcollection()` function allows you to access the [JobCollection class](jobcollection-reference.md).
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### initialize_jobtask()
-
-The `initialize_jobtask()` function allows you to access the [JobTask class](jobtask-reference.md).
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
-```
-
-### initialize_webhook()
-
-The `initialize_webhook()` function allows you to access the [Webhooks class](webhooks-reference.md).
-
-```python
-```
-
-<h5> Arguments </h5>
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-|      |      |             |
-
-<h5> Returns </h5>
-
-| Type | Description |
-| ---- | ----------- |
-|      |             |
-
-<h5> Example </h5>
-
-```python
 ```

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -24,21 +24,21 @@
         Available functions, see also [**up42 reference**](up42-reference.md):
         {{ format_funcs(funcs_up42) }}
 
-    === "Catalog"
-
-        {{ docstring_catalog }}
-        <br>
-        Available functions, see also [**Catalog reference**](catalog-reference.md):
-        {{ format_funcs(funcs_catalog) }}
-        <br>
-        This class also inherits functions from the [CatalogBase](catalogbase-reference.md) class.
-
     === "Tasking"
 
         {{ docstring_tasking }}
         <br>
         Available functions, see also [**Tasking reference**](tasking-reference.md):
         {{ format_funcs(funcs_tasking) }}
+        <br>
+        This class also inherits functions from the [CatalogBase](catalogbase-reference.md) class.
+
+    === "Catalog"
+
+        {{ docstring_catalog }}
+        <br>
+        Available functions, see also [**Catalog reference**](catalog-reference.md):
+        {{ format_funcs(funcs_catalog) }}
         <br>
         This class also inherits functions from the [CatalogBase](catalogbase-reference.md) class.
 
@@ -54,25 +54,26 @@
             <li>`.place_order()`</li>
         </ul>
 
-    === "Storage"
-
-        {{ docstring_storage }}
-        <br>
-        Available functions, see also [**Storage reference**](storage-reference.md):
-        {{ format_funcs(funcs_storage) }}
-    
     === "Order"
 
         {{ docstring_order }}
         <br>
         Available functions, see also [**Order reference**](order-reference.md):
         {{ format_funcs(funcs_order) }}
-    
+
+
+    === "Storage"
+
+        {{ docstring_storage }}
+        <br>
+        Available functions, see also [**Storage reference**](storage-reference.md):
+        {{ format_funcs(funcs_storage) }}
+
     === "Asset"
 
         {{ docstring_asset }}
         <br>
-        Available functions, see also [**Asset reference**](asset-reference.md): 
+        Available functions, see also [**Asset reference**](asset-reference.md):
         {{ format_funcs(funcs_asset) }}
 
     === "Project"
@@ -81,28 +82,28 @@
         <br>
         Available functions, see also [**Project reference**](project-reference.md):
         {{ format_funcs(funcs_project) }}
-    
+
     === "Workflow"
 
         {{ docstring_workflow }}
         <br>
         Available functions, see also [**Workflow reference**](workflow-reference.md):
         {{ format_funcs(funcs_workflow) }}
-        
+
     === "Job"
 
         {{ docstring_job }}
         <br>
         Available functions, see also [**Job reference**](job-reference.md):
         {{ format_funcs(funcs_job) }}
-        
+
     === "JobTask"
 
         {{ docstring_jobtask }}
         <br>
         Available functions, see also [**JobTask reference**](jobtask-reference.md):
         {{ format_funcs(funcs_jobtask) }}
-        
+
     === "JobCollection"
 
         {{ docstring_jobcollection }}
@@ -114,5 +115,5 @@
 
         {{ docstring_webhooks }}
         <br>
-        Available functions, see also [**Webhooks reference**](webhooks-reference.md): 
+        Available functions, see also [**Webhooks reference**](webhooks-reference.md):
         {{ format_funcs(funcs_webhook) }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,11 +48,11 @@ nav:
     - Code reference:
         - structure.md
         - up42: reference/up42-reference.md
-        - Catalog: reference/catalog-reference.md
         - Tasking: reference/tasking-reference.md
+        - Catalog: reference/catalog-reference.md
         - CatalogBase: reference/catalogbase-reference.md
-        - Storage: reference/storage-reference.md
         - Order: reference/order-reference.md
+        - Storage: reference/storage-reference.md
         - Asset: reference/asset-reference.md
         - Project: reference/project-reference.md
         - Workflow: reference/workflow-reference.md


### PR DESCRIPTION
Update the docs:
* Convert `up42-reference.md` to Markdown and review the functions.
  Additional notes:
  * `map_quicklooks`, `plot_quicklooks`, `plot_coverage`, `map_results`, and `plot_results` were removed from the page, they will be added in [this task](https://up42.atlassian.net/browse/DOC-731) and [this task](https://up42.atlassian.net/browse/DOC-726).
  * `create_webhook was`, `get_webhook_events`, and `get_webhooks` were removed from the page, they are already added on [Webhooks](https://sdk.up42.com/reference/webhooks-reference/).
  * Initialization functions were removed because they are already mentioned on their respective reference pages.
  * The functionality overview table wasn't updated, it will be restructured in [this task](https://up42.atlassian.net/browse/DOC-722). 
* Updated the layout:
  * `asset-reference.md`
  * `catalogbase-reference.md`
  * `tasking-reference.md`
* Changed the order of Tasking and Catalog pages:
  * `structure.md`
  * `mkdocs.yml`



