### PR TITLE
DOC-797: Fix download_stac_asset code snippet example

### DIFF
--- a/docs/reference/asset-reference.md
+++ b/docs/reference/asset-reference.md
@@ -76,9 +76,9 @@ The returned format is `list[str]`.
 
 <h5> Arguments </h5>
 
-| Argument           | Overview                                                                                                                                                                                             |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `output_directory` | **Union[str, Path, none]**<br/>The file output directory. The default value is the current directory.                                                                                                |
+| Argument           | Overview                                                                                                                                                                                  |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `output_directory` | **Union[str, Path, none]**<br/>The file output directory. The default value is the current directory.                                                                                     |
 | `unpacking`        | **bool**<br/>Determines how to download the asset:<br/><ul><li>`True`: download and unpack the file.</li><li>`False`: download the compressed file.</li></ul>The default value is `True`. |
 
 <h5> Example </h5>
@@ -133,14 +133,14 @@ The returned format is `pathlib.Path`.
 
 | Argument           | Description                                                                                           |
 | ------------------ | ----------------------------------------------------------------------------------------------------- |
-| `stac_asset`       | **pystac.Asset / required**<br/>The STAC asset name.                                                  |
+| `stac_asset`       | **pystac.Asset / required**<br/>The STAC asset to be downloaded.                                      |
 | `output_directory` | **Union[str, Path, none]**<br/>The file output directory. The default value is the current directory. |
 
 <h5> Example </h5>
 
 ```python
 asset.download_stac_asset(
-    stac_asset="b12.tiff",
+    stac_asset=asset.stac_items.items[0].assets.get("b01.tiff"),
     output_directory="/Users/max.mustermann/Desktop/",
 )
 ```

--- a/examples/asset/asset-example.ipynb
+++ b/examples/asset/asset-example.ipynb
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -1711,7 +1711,7 @@
        "<CollectionClient id=2ef4a8a3-c6a7-43a6-96ce-2d881a124341>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1731,7 +1731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -3077,7 +3077,7 @@
        "<pystac.item_collection.ItemCollection at 0x175e83110>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3097,7 +3097,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -3130,15 +3130,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "asset.download_stac_asset(\n",
-    "    stac_assets.get(\n",
-    "        \"b01.tiff\",\n",
-    "        \"/Users/max.mustermann/Desktop/\"\n",
-    "    )\n",
+    "    stac_asset=stac_assets.get(\"b01.tiff\"),\n",
+    "    output_directory=\"/Users/max.mustermann/Desktop/\",\n",
     ")"
    ]
   }


### PR DESCRIPTION
- In `asset-reference.md`, fix example and description.
- In `asset-example.ipynb`, fix cell counts and example.
