### PR TITLE
DOC-783: Add get_stac_asset_url to asset reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ You can check your current version with the following command:
 
 For more information, see [UP42 Python package description](https://pypi.org/project/up42-py/).
 
+## 0.33.0
+
+**October 16, 2023**
+
+A new function added to the [Asset class](https://sdk.up42.com/reference/asset-reference):
+
+- `get_stac_asset_url` generates a pre-signed URL to allow you to download STAC assets from storage without authentication.
+
 ## 0.32.0
 
 **September 7, 2023**

--- a/docs/reference/asset-reference.md
+++ b/docs/reference/asset-reference.md
@@ -10,7 +10,7 @@ Types of assets:
 
 - **UP42 assets**
 
-    The original delivery you received in storage as a result of a completed tasking or catalog order.
+  The original delivery you received in storage as a result of a completed tasking or catalog order.
 
 - **STAC assets**
 
@@ -143,4 +143,27 @@ asset.download_stac_asset(
     stac_asset=asset.stac_items.items[0].assets.get("b01.tiff"),
     output_directory="/Users/max.mustermann/Desktop/",
 )
+```
+
+### get_stac_asset_url()
+
+The `get_stac_asset_url()` function returns a pre-signed download URL for a STAC asset.
+The generated URL can be used for up to 30 seconds to download an asset without authentication.
+
+```python
+get_stac_asset_url(stac_asset)
+```
+
+The returned format is `str`.
+
+<h5> Arguments </h5>
+
+| Argument     | Description                                                      |
+| ------------ | ---------------------------------------------------------------- |
+| `stac_asset` | **pystac.Asset / required**<br/>The STAC asset to be downloaded. |
+
+<h5> Example </h5>
+
+```python
+get_stac_asset_url(stac_asset=asset.stac_items.items[0].assets.get("b01.tiff"),)
 ```

--- a/docs/theme_override_home/main.html
+++ b/docs/theme_override_home/main.html
@@ -20,7 +20,7 @@ if (typeof window !== 'undefined' && window.location.href.includes('127.0.0.1'))
 <!-- Announcement bar -->
 {% block announce %}
   <style>.md-announce a,.md-announce a:focus,.md-announce a:hover{color:currentColor}.md-announce strong{white-space:nowrap}.md-announce .twitter{margin-left:.2em;color:#00acee}</style>
-    <strong><a href="https://sdk.up42.com/CHANGELOG/">New in 0.32.0: STAC assets downloading is supported</a></strong>
+    <strong><a href="https://sdk.up42.com/CHANGELOG/">New in 0.33.0: Generating pre-signed download URLs for STAC assets is supported</a></strong>
 {% endblock %}
 
 <!-- More minimal footer -->

--- a/examples/asset/asset-example.ipynb
+++ b/examples/asset/asset-example.ipynb
@@ -3139,6 +3139,30 @@
     "    output_directory=\"/Users/max.mustermann/Desktop/\",\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6. Get STAC asset download URL"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get a pre-signed download URL to download the STAC asset.\n",
+    "The generated URL can be used for up to 30 seconds to download an asset without authentication."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "asset.download_stac_asset(stac_asset=stac_assets.get(\"b01.tiff\"))"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Corresponds to JIRA task [DOC-783](https://up42.atlassian.net/browse/DOC-783).

Changes made:

- Added `get_stac_asset_url()` to asset-reference.md 
- Updated asset-example.ipynb to include new function
- The banner is updated
- The changelog is updated

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [x ] Updated [documentation](sdk.up42.com)

For release:
* [ x] Bumped version
* [ x] Added changelog
* [ x] Updated announcement banner
