### PR TITLE
Update Sonarcloud Orb Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ venv-cache: &venv-cache venv-{{ checksum "poetry.lock" }}
 pre-commit-cache: &pre-commit-cache pre-commit-{{ checksum ".pre-commit-config.yaml" }}
 
 orbs:
-  sonarcloud: sonarsource/sonarcloud@1.0.3
+  sonarcloud: sonarsource/sonarcloud@2.0.0
 
 # variables
 workspace: &workspace-dir /tmp/workspace


### PR DESCRIPTION
Updates Sonarcloud version as the old orb won't be supported from 15th of November. 

See https://up-42.slack.com/archives/C04FLMD3YK0/p1699376601021069

(insert scope and description here)

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
