### PR TITLE
update docker image for publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           command: poetry run pytest --runlive --durations=5
   deploy:
     docker:
-      - image: circleci/python:3.11
+      - image: cimg/python:3.11
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Scope: Use cimg/python3.11 as base docker image for publishing to pypi.

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
