### PR TITLE
Simplify project authentication

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -30,8 +30,8 @@ files = [
 lazy-object-proxy = ">=1.4.0"
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 wrapt = [
-    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
 ]
 
 [[package]]
@@ -1947,22 +1947,6 @@ files = [
 ]
 
 [[package]]
-name = "oauthlib"
-version = "3.2.2"
-description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
-    {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
-]
-
-[package.extras]
-rsa = ["cryptography (>=3.0.0)"]
-signals = ["blinker (>=1.4.0)"]
-signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
-
-[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -2009,9 +1993,9 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
+    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -2229,8 +2213,8 @@ files = [
 astroid = ">=2.15.8,<=2.17.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
     {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
+    {version = ">=0.2", markers = "python_version < \"3.11\""},
 ]
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.8"
@@ -2422,13 +2406,13 @@ files = [
 attrs = ">=19.0"
 filelock = ">=3.0"
 mypy = [
-    {version = ">=0.700", markers = "python_version >= \"3.8\" and python_version < \"3.9\""},
-    {version = ">=0.780", markers = "python_version >= \"3.9\" and python_version < \"3.11\""},
     {version = ">=0.900", markers = "python_version >= \"3.11\""},
+    {version = ">=0.780", markers = "python_version >= \"3.9\" and python_version < \"3.11\""},
+    {version = ">=0.700", markers = "python_version >= \"3.8\" and python_version < \"3.9\""},
 ]
 pytest = [
-    {version = ">=4.6", markers = "python_version >= \"3.6\" and python_version < \"3.10\""},
     {version = ">=6.2", markers = "python_version >= \"3.10\""},
+    {version = ">=4.6", markers = "python_version >= \"3.6\" and python_version < \"3.10\""},
 ]
 
 [[package]]
@@ -2795,24 +2779,6 @@ six = "*"
 [package.extras]
 fixture = ["fixtures"]
 test = ["fixtures", "mock", "purl", "pytest", "requests-futures", "sphinx", "testtools"]
-
-[[package]]
-name = "requests-oauthlib"
-version = "1.3.1"
-description = "OAuthlib authentication support for Requests."
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "requests-oauthlib-1.3.1.tar.gz", hash = "sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a"},
-    {file = "requests_oauthlib-1.3.1-py2.py3-none-any.whl", hash = "sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5"},
-]
-
-[package.dependencies]
-oauthlib = ">=3.0.0"
-requests = ">=2.0.0"
-
-[package.extras]
-rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "rpds-py"
@@ -3421,4 +3387,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "6bbd5c2811d0ff5d7ec122f79ca20c810137b10e85e81823bc4990c1738bb578"
+content-hash = "99ba62b44e0267c8b665a0bdce00b55ce635ab343f515720a7d0ccf7fde45469"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers=[
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 requests =  "^2.31.0"
-requests-oauthlib = "^1.3.1"
 tenacity = "^8.2.2"
 tqdm = "^4.66.0"
 geojson = "^3.0.1"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -73,7 +73,7 @@ def test_get_token_raises_wrong_credentials_live(auth_live):
     auth_live._credentials_id = "123"
     with pytest.raises(ValueError) as e:
         auth_live._get_token()
-    assert "Authentication" in str(e.value)
+    assert "authentication" in str(e.value)
 
 
 @pytest.mark.live

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -38,15 +38,15 @@ class retry_if_401_invalid_token(retry_if_exception):
     def __init__(self):
         def is_http_401_error(exception):
             return (
-                    isinstance(
-                        exception,
-                        (
-                            requests.exceptions.HTTPError,
-                            requests.exceptions.RequestException,
-                        ),
-                    )
-                    and hasattr(exception.response, "status_code")  # check if response has status_code
-                    and exception.response.status_code == 401
+                isinstance(
+                    exception,
+                    (
+                        requests.exceptions.HTTPError,
+                        requests.exceptions.RequestException,
+                    ),
+                )
+                and hasattr(exception.response, "status_code")  # check if response has status_code
+                and exception.response.status_code == 401
             )
 
         super().__init__(predicate=is_http_401_error)
@@ -69,13 +69,13 @@ class retry_if_429_rate_limit(retry_if_exception):
 
 class Auth:
     def __init__(
-            self,
-            cfg_file: Union[str, Path, None] = None,
-            project_id: Optional[str] = None,
-            project_api_key: Optional[str] = None,
-            username: Optional[str] = None,
-            password: Optional[str] = None,
-            **kwargs,
+        self,
+        cfg_file: Union[str, Path, None] = None,
+        project_id: Optional[str] = None,
+        project_api_key: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        **kwargs,
     ):
         """
         The Auth class handles the authentication with UP42.
@@ -220,11 +220,11 @@ class Auth:
         reraise=True,
     )
     def _request_helper(
-            self,
-            request_type: str,
-            url: str,
-            data: dict = {},
-            querystring: dict = {},
+        self,
+        request_type: str,
+        url: str,
+        data: dict = {},
+        querystring: dict = {},
     ) -> requests.Response:
         """
         Helper function for the request, running the actual request with the correct headers.
@@ -262,12 +262,12 @@ class Auth:
         return response
 
     def _request(
-            self,
-            request_type: str,
-            url: str,
-            data: Union[dict, list] = {},
-            querystring: dict = {},
-            return_text: bool = True,
+        self,
+        request_type: str,
+        url: str,
+        data: Union[dict, list] = {},
+        querystring: dict = {},
+        return_text: bool = True,
     ):  # Union[str, dict, requests.Response]:
         """
         Handles retrying the request and automatically retries and gets a new token if
@@ -329,8 +329,8 @@ class Auth:
                     raise ValueError(response_text["error"])
                 return response_text
             except (
-                    KeyError,
-                    TypeError,
+                KeyError,
+                TypeError,
             ):  # Catalog search, JobTask logs etc. does not have the usual {"data":"",
                 # "error":""} format.
                 return response_text

--- a/up42/auth.py
+++ b/up42/auth.py
@@ -24,7 +24,7 @@ from up42.utils import get_logger, get_up42_py_version, read_json
 
 logger = get_logger(__name__)
 
-AUTHENTICATION_TIMEOUT = 120
+HTTP_TIMEOUT = 120
 
 
 class retry_if_401_invalid_token(retry_if_exception):
@@ -166,7 +166,7 @@ class Auth:
                 url=host.endpoint("/oauth/token"),
                 data=req_body,
                 headers=req_headers,
-                timeout=AUTHENTICATION_TIMEOUT,
+                timeout=HTTP_TIMEOUT,
             )
             token_response.raise_for_status()
             self.token = token_response.json()["access_token"]
@@ -181,7 +181,7 @@ class Auth:
                 url=host.endpoint("/oauth/token"),
                 auth=basic_auth,
                 data={"grant_type": "client_credentials"},
-                timeout=AUTHENTICATION_TIMEOUT,
+                timeout=HTTP_TIMEOUT,
             )
             token_response.raise_for_status()
             self.token = token_response.json()["access_token"]
@@ -245,7 +245,7 @@ class Auth:
                 url=url,
                 data=json.dumps(data),
                 headers=headers,
-                timeout=AUTHENTICATION_TIMEOUT,
+                timeout=HTTP_TIMEOUT,
             )
         else:
             response = requests.request(
@@ -254,7 +254,7 @@ class Auth:
                 data=json.dumps(data),
                 headers=headers,
                 params=querystring,
-                timeout=AUTHENTICATION_TIMEOUT,
+                timeout=HTTP_TIMEOUT,
             )
         logger.debug(response)
         logger.debug(data)


### PR DESCRIPTION
This PR simplifies project authentication and drops unneeded oauthlib dependency, since we don't use it's token refresh functionality

Items:
* [x] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner