### PR TITLE
DOC-831 + DOC-812: Update reference articles

### DIFF
--- a/docs/reference/asset-reference.md
+++ b/docs/reference/asset-reference.md
@@ -24,7 +24,7 @@ Types of assets:
 
 The `info` attribute returns metadata of a specific UP42 asset.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 
@@ -36,7 +36,7 @@ asset.info
 
 The `update_metadata()` function allows you to change the title and tags of an UP42 asset.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Arguments </h5>
 
@@ -58,7 +58,7 @@ asset.update_metadata(
 
 The `download()` function allows you to download UP42 assets from storage and returns a list of download paths.
 
-The returned format is `list[str]`.
+The returned data type is `list[str]`.
 
 <h5> Arguments </h5>
 
@@ -82,7 +82,7 @@ asset.download(
 
 The `stac_info` attribute returns the STAC collection associated with a specific UP42 asset.
 
-The returned format is `pystac.Collection`.
+The returned data type is `pystac.Collection`.
 
 <h5> Example </h5>
 
@@ -94,7 +94,7 @@ asset.stac_info
 
 The `stac_items` attribute returns STAC items from a specific UP42 asset.
 
-The returned format is `pystac.ItemCollection`.
+The returned data type is `pystac.ItemCollection`.
 
 <h5> Example </h5>
 
@@ -106,7 +106,7 @@ asset.stac_items
 
 The `download_stac_asset()` function allows you to download a STAC asset from storage and returns the path to the downloaded file. A new directory for the file will be created.
 
-The returned format is `pathlib.Path`.
+The returned data type is `pathlib.Path`.
 
 <h5> Arguments </h5>
 
@@ -129,7 +129,7 @@ asset.download_stac_asset(
 The `get_stac_asset_url()` function returns a signed download URL for a STAC asset.
 The generated URL can be used for up to 5 minutes to download the asset without authentication.
 
-The returned format is `str`.
+The returned data type is `str`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/asset-reference.md
+++ b/docs/reference/asset-reference.md
@@ -36,13 +36,6 @@ asset.info
 
 The `update_metadata()` function allows you to change the title and tags of an UP42 asset.
 
-```python
-update_metadata(
-    title,
-    tags,
-)
-```
-
 The returned format is `dict`.
 
 <h5> Arguments </h5>
@@ -64,13 +57,6 @@ asset.update_metadata(
 ### download()
 
 The `download()` function allows you to download UP42 assets from storage and returns a list of download paths.
-
-```python
-download(
-    output_directory,
-    unpacking,
-)
-```
 
 The returned format is `list[str]`.
 
@@ -120,13 +106,6 @@ asset.stac_items
 
 The `download_stac_asset()` function allows you to download a STAC asset from storage and returns the path to the downloaded file. A new directory for the file will be created.
 
-```python
-download_stac_asset(
-    stac_asset,
-    output_directory,
-)
-```
-
 The returned format is `pathlib.Path`.
 
 <h5> Arguments </h5>
@@ -149,10 +128,6 @@ asset.download_stac_asset(
 
 The `get_stac_asset_url()` function returns a signed download URL for a STAC asset.
 The generated URL can be used for up to 5 minutes to download the asset without authentication.
-
-```python
-get_stac_asset_url(stac_asset)
-```
 
 The returned format is `str`.
 

--- a/docs/reference/catalog-reference.md
+++ b/docs/reference/catalog-reference.md
@@ -14,7 +14,7 @@ This class also inherits functions from the [CatalogBase](catalogbase-reference.
 
 The `construct_search_parameters()` function allows you to fill out search parameters when searching for catalog imagery.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Arguments </h5>
 
@@ -44,7 +44,7 @@ catalog.construct_search_parameters(
 
 The `search()` function returns the scenes matching the search parameters.
 
-The returned format is `Union[GeoDataFrame, dict]`.
+The returned data type is `Union[GeoDataFrame, dict]`.
 
 <h5> Arguments </h5>
 
@@ -74,7 +74,7 @@ catalog.search(
 The `download_quicklooks()` function allows you to download low-resolution previews of scenes returned in search results.
 Visualize quicklooks with [`map_quicklooks()`](#map_quicklooks) or [`plot_quicklooks()`](#plot_quicklooks).
 
-The returned format is `list[str]`.
+The returned data type is `list[str]`.
 
 <h5> Arguments </h5>
 
@@ -100,7 +100,7 @@ catalog.download_quicklooks(
 
 The `construct_order_parameters()` function allows you to fill out an order form for a new catalog order.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Arguments </h5>
 
@@ -126,7 +126,7 @@ catalog.construct_order_parameters(
 
 The `estimate_order()` function returns the cost estimate for a catalog order.
 
-The returned format is `int`.
+The returned data type is `int`.
 
 <h5> Arguments </h5>
 
@@ -193,7 +193,7 @@ catalog.plot_coverage(
 The `map_quicklooks()` function allows you to visualize downloaded quicklooks on a Folium map.
 Use together with [`search()`](#search) and [`download_quicklooks()`](#download_quicklooks).
 
-The returned format is `folium.Map`.
+The returned data type is `folium.Map`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/catalog-reference.md
+++ b/docs/reference/catalog-reference.md
@@ -14,18 +14,6 @@ This class also inherits functions from the [CatalogBase](catalogbase-reference.
 
 The `construct_search_parameters()` function allows you to fill out search parameters when searching for catalog imagery.
 
-```python
-construct_search_parameters(
-    geometry,
-    collections,
-    start_date,
-    end_date,
-    usage_type,
-    limit,
-    max_cloud_cover,
-)
-```
-
 The returned format is `dict`.
 
 <h5> Arguments </h5>
@@ -55,13 +43,6 @@ catalog.construct_search_parameters(
 ### search()
 
 The `search()` function returns the scenes matching the search parameters.
-
-```python
-search(
-    search_parameters,
-    as_dataframe,
-)
-```
 
 The returned format is `Union[GeoDataFrame, dict]`.
 
@@ -93,14 +74,6 @@ catalog.search(
 The `download_quicklooks()` function allows you to download low-resolution previews of scenes returned in search results.
 Visualize quicklooks with [`map_quicklooks()`](#map_quicklooks) or [`plot_quicklooks()`](#plot_quicklooks).
 
-```python
-download_quicklooks(
-    image_ids,
-    collection,
-    output_directory,
-)
-```
-
 The returned format is `list[str]`.
 
 <h5> Arguments </h5>
@@ -127,15 +100,6 @@ catalog.download_quicklooks(
 
 The `construct_order_parameters()` function allows you to fill out an order form for a new catalog order.
 
-```python
-construct_order_parameters(
-    data_product_id,
-    image_id,
-    aoi,
-    tags,
-)
-```
-
 The returned format is `dict`.
 
 <h5> Arguments </h5>
@@ -161,10 +125,6 @@ catalog.construct_order_parameters(
 ### estimate_order()
 
 The `estimate_order()` function returns the cost estimate for a catalog order.
-
-```python
-estimate_order(order_parameters)
-```
 
 The returned format is `int`.
 
@@ -194,15 +154,6 @@ To use the visualization functionalities, [install](../../installation/) the adv
 
 The `plot_coverage()` function allows you to visualize the coverage of scenes matching the search parameters.
 Use together with [`search()`](#search).
-
-```python
-plot_coverage(
-    scenes,
-    aoi,
-    legend_column,
-    figsize,
-)
-```
 
 <h5> Arguments </h5>
 
@@ -241,18 +192,6 @@ catalog.plot_coverage(
 
 The `map_quicklooks()` function allows you to visualize downloaded quicklooks on a Folium map.
 Use together with [`search()`](#search) and [`download_quicklooks()`](#download_quicklooks).
-
-```python
-map_quicklooks(
-    scenes,
-    aoi,
-    show_images,
-    show_features,
-    filepaths,
-    name_column,
-    save_html,
-)
-```
 
 The returned format is `folium.Map`.
 
@@ -309,14 +248,6 @@ catalog.map_quicklooks(
 
 The `plot_quicklooks()` function allows you to visualize downloaded quicklooks.
 Use together with [`search()`](#search) and [`download_quicklooks()`](#download_quicklooks).
-
-```python
-plot_quicklooks(
-    figsize,
-    filepaths,
-    titles
-)
-```
 
 <h5> Arguments </h5>
 

--- a/docs/reference/catalogbase-reference.md
+++ b/docs/reference/catalogbase-reference.md
@@ -16,10 +16,6 @@ catalog = up42.initialize_catalog()
 
 The `get_collections()` function returns a list of geospatial collections.
 
-```python
-get_collections()
-```
-
 The returned format is `Union[Dict, List]`.
 
 <h5> Example </h5>
@@ -35,10 +31,6 @@ catalog.get_collections()
 ### get_data_products()
 
 The `get_data_products()` function returns a list of data products.
-
-```python
-get_data_products(basic)
-```
 
 The returned format is `Union[dict, List[dict]]`.
 
@@ -59,10 +51,6 @@ catalog.get_data_products(basic=False)
 ### get_data_product_schema()
 
 The `get_data_product_schema()` function returns the parameters needed to place an order for a specific data product.
-
-```python
-get_data_product_schema(data_product_id)
-```
 
 The returned format is `dict`.
 
@@ -85,14 +73,6 @@ catalog.get_data_product_schema(data_product_id="647780db-5a06-4b61-b525-577a8b6
 ### place_order()
 
 The `place_order()` function allows you to place a catalog or tasking order.
-
-```python
-place_order(
-    order_parameters,
-    track_status,
-    report_time,
-)
-```
 
 The returned format is `Order`.
 

--- a/docs/reference/catalogbase-reference.md
+++ b/docs/reference/catalogbase-reference.md
@@ -16,7 +16,7 @@ catalog = up42.initialize_catalog()
 
 The `get_collections()` function returns a list of geospatial collections.
 
-The returned format is `Union[Dict, List]`.
+The returned data type is `Union[Dict, List]`.
 
 <h5> Example </h5>
 
@@ -32,7 +32,7 @@ catalog.get_collections()
 
 The `get_data_products()` function returns a list of data products.
 
-The returned format is `Union[dict, List[dict]]`.
+The returned data type is `Union[dict, List[dict]]`.
 
 <h5> Arguments </h5>
 
@@ -52,7 +52,7 @@ catalog.get_data_products(basic=False)
 
 The `get_data_product_schema()` function returns the parameters needed to place an order for a specific data product.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Arguments </h5>
 
@@ -74,7 +74,7 @@ catalog.get_data_product_schema(data_product_id="647780db-5a06-4b61-b525-577a8b6
 
 The `place_order()` function allows you to place a catalog or tasking order.
 
-The returned format is `Order`.
+The returned data type is `Order`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/job-reference.md
+++ b/docs/reference/job-reference.md
@@ -19,7 +19,7 @@ job = up42.initialize_job(
 
 The `info` attribute returns metadata of a specific job.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 
@@ -40,7 +40,7 @@ The `status` attribute returns the job status. It can be one of the following:
 - `FAILED`
 - `ERROR`
 
-The returned format is `str`.
+The returned data type is `str`.
 
 <h5> Example </h5>
 
@@ -55,7 +55,7 @@ The `is_succeeded` attribute returns the following:
 - `True`, if the job has the `SUCCEEDED` status.
 - `False`, if the job has any other status.
 
-The returned format is `bool`.
+The returned data type is `bool`.
 
 <h5> Example </h5>
 
@@ -67,7 +67,7 @@ job.is_succeeded
 
 The `get_credits()` function returns the number of credits spent on the job.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 
@@ -79,7 +79,7 @@ job.get_credits()
 
 The `download_quicklooks()` function allows you to download low-resolution previews of available images.
 
-The returned format is `list[str]`.
+The returned data type is `list[str]`.
 
 <h5> Arguments </h5>
 
@@ -97,7 +97,7 @@ job.download_quicklooks(output_directory="/Users/max.mustermann/Desktop/")
 
 The `get_results_json()` function returns job results.
 
-The returned format is `Union[dict, GeoDataFrame]`.
+The returned data type is `Union[dict, GeoDataFrame]`.
 
 <h5> Arguments </h5>
 
@@ -115,7 +115,7 @@ job.get_results_json(as_dataframe=True)
 
 The `download_results()` function allows you to download job results and returns a list of download paths.
 
-The returned format is `list[str]`.
+The returned data type is `list[str]`.
 
 <h5> Arguments </h5>
 
@@ -167,7 +167,7 @@ Job tasks are unique configurations of workflow tasks in a job. You can access a
 
 The `get_jobtasks()` function returns a list of job tasks.
 
-The returned format is `Union[list[JobTask], list[dict]]`.
+The returned data type is `Union[list[JobTask], list[dict]]`.
 
 <h5> Arguments </h5>
 
@@ -185,7 +185,7 @@ job.get_jobtasks(return_json=True)
 
 The `get_logs()` function returns the logs of job tasks.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Arguments </h5>
 
@@ -207,7 +207,7 @@ job.get_logs(
 
 The `get_jobtasks_results_json()` function returns job tasks results.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 
@@ -223,7 +223,7 @@ To use the visualization functionalities, [install](../../installation/) the adv
 
 The `map_results()` function allows you to visualize job results on a Folium map. Use together with [`download_results()`](#download_results).
 
-The returned format is `folium.Map`.
+The returned data type is `folium.Map`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/job-reference.md
+++ b/docs/reference/job-reference.md
@@ -67,10 +67,6 @@ job.is_succeeded
 
 The `get_credits()` function returns the number of credits spent on the job.
 
-```python
-get_credits()
-```
-
 The returned format is `dict`.
 
 <h5> Example </h5>
@@ -82,10 +78,6 @@ job.get_credits()
 ### download_quicklooks()
 
 The `download_quicklooks()` function allows you to download low-resolution previews of available images.
-
-```python
-download_quicklooks(output_directory)
-```
 
 The returned format is `list[str]`.
 
@@ -105,10 +97,6 @@ job.download_quicklooks(output_directory="/Users/max.mustermann/Desktop/")
 
 The `get_results_json()` function returns job results.
 
-```python
-get_results_json(as_dataframe)
-```
-
 The returned format is `Union[dict, GeoDataFrame]`.
 
 <h5> Arguments </h5>
@@ -126,13 +114,6 @@ job.get_results_json(as_dataframe=True)
 ### download_results()
 
 The `download_results()` function allows you to download job results and returns a list of download paths.
-
-```python
-download_results(
-    output_directory,
-    unpacking,
-)
-```
 
 The returned format is `list[str]`.
 
@@ -155,16 +136,6 @@ job.download_results(
 ### upload_results_to_bucket()
 
 The `upload_results_to_bucket()` function allows you to upload the job results to a custom Google Cloud Storage bucket.
-
-```python
-upload_results_to_bucket(
-    gs_client,
-    bucket,
-    folder,
-    extension,
-    version,
-)
-```
 
 <h5> Arguments </h5>
 
@@ -196,10 +167,6 @@ Job tasks are unique configurations of workflow tasks in a job. You can access a
 
 The `get_jobtasks()` function returns a list of job tasks.
 
-```python
-get_jobtasks(return_json)
-```
-
 The returned format is `Union[list[JobTask], list[dict]]`.
 
 <h5> Arguments </h5>
@@ -217,13 +184,6 @@ job.get_jobtasks(return_json=True)
 ### get_logs()
 
 The `get_logs()` function returns the logs of job tasks.
-
-```python
-get_logs(
-    as_print,
-    as_return,
-)
-```
 
 The returned format is `dict`.
 
@@ -247,10 +207,6 @@ job.get_logs(
 
 The `get_jobtasks_results_json()` function returns job tasks results.
 
-```python
-get_jobtasks_results_json()
-```
-
 The returned format is `dict`.
 
 <h5> Example </h5>
@@ -266,17 +222,6 @@ To use the visualization functionalities, [install](../../installation/) the adv
 ### map_results()
 
 The `map_results()` function allows you to visualize job results on a Folium map. Use together with [`download_results()`](#download_results).
-
-```python
-map_results(
-    bands,
-    aoi,
-    show_images,
-    show_features,
-    name_column,
-    save_html,
-)
-```
 
 The returned format is `folium.Map`.
 
@@ -307,17 +252,6 @@ job.map_results(
 ### plot_results()
 
 The `plot_results()` function allows you to visualize job results. Use together with [`download_results()`](#download_results).
-
-```python
-plot_results(
-    figsize,
-    bands,
-    titles,
-    filepaths,
-    plot_file_format,
-    **kwargs,
-)
-```
 
 <h5> Arguments </h5>
 

--- a/docs/reference/jobcollection-reference.md
+++ b/docs/reference/jobcollection-reference.md
@@ -22,7 +22,7 @@ jobcollection = up42.initialize_jobcollection(
 
 The `info` attribute returns metadata of jobs in a job collection.
 
-The returned format is `dict[str, dict]`.
+The returned data type is `dict[str, dict]`.
 
 <h5> Example </h5>
 
@@ -34,7 +34,7 @@ jobcollection.info
 
 The `status` attribute returns the [status](../../reference/job-reference/#status) of jobs in a job collection.
 
-The returned format is `dict[str, dict]`.
+The returned data type is `dict[str, dict]`.
 
 <h5> Example </h5>
 
@@ -46,7 +46,7 @@ jobcollection.status
 
 The `apply()` function allows you to apply `worker` on jobs in a job collection.
 
-The returned format is `dict[str, any]`.
+The returned data type is `dict[str, any]`.
 
 <h5> Arguments </h5>
 
@@ -71,7 +71,7 @@ jobcollection.apply(
 
 The `download_results()` function allows you to download job collection results and returns a dictionary with a list of download paths.
 
-The returned format is `dict[str, list[str]]`.
+The returned data type is `dict[str, list[str]]`.
 
 <h5> Arguments </h5>
 
@@ -99,7 +99,7 @@ To use the visualization functions, [install](installation.md) the SDK's advance
 
 The `map_results()` function allows you to visualize downloaded job collection results on a Folium map. Use together with [`download_results()`](#download_results).
 
-The returned format is `folium.Map`.
+The returned data type is `folium.Map`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/jobcollection-reference.md
+++ b/docs/reference/jobcollection-reference.md
@@ -46,14 +46,6 @@ jobcollection.status
 
 The `apply()` function allows you to apply `worker` on jobs in a job collection.
 
-```python
-apply(
-    worker,
-    only_succeeded,
-    **kwargs,
-)
-```
-
 The returned format is `dict[str, any]`.
 
 <h5> Arguments </h5>
@@ -78,14 +70,6 @@ jobcollection.apply(
 ### download_results()
 
 The `download_results()` function allows you to download job collection results and returns a dictionary with a list of download paths.
-
-```python
-download_results(
-    output_directory,
-    merge,
-    unpacking,
-)
-```
 
 The returned format is `dict[str, list[str]]`.
 
@@ -114,17 +98,6 @@ To use the visualization functions, [install](installation.md) the SDK's advance
 ### map_results()
 
 The `map_results()` function allows you to visualize downloaded job collection results on a Folium map. Use together with [`download_results()`](#download_results).
-
-```python
-map_results(
-    bands,
-    aoi,
-    show_images,
-    show_features,
-    name_column,
-    save_html,
-)
-```
 
 The returned format is `folium.Map`.
 
@@ -155,17 +128,6 @@ jobcollection.map_results(
 ### plot_results()
 
 The `plot_results()` function allows you to visualize downloaded job collection results. Use together with [`download_results()`](#download_results).
-
-```python
-plot_results(
-    figsize,
-    bands,
-    titles,
-    filepaths,
-    plot_file_format,
-    **kwargs,
-)
-```
 
 <h5> Arguments </h5>
 

--- a/docs/reference/jobtask-reference.md
+++ b/docs/reference/jobtask-reference.md
@@ -20,7 +20,7 @@ jobtask = up42.initialize_jobtask(
 
 The `info` attribute returns metadata of a specific job task.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 
@@ -32,7 +32,7 @@ jobtask.info
 
 The `download_quicklooks()` function allows you to download low-resolution preview images. Not all job tasks have quicklooks.
 
-The returned format is `list[str]`. If an empty list `[]` is returned, no quicklooks are available.
+The returned data type is `list[str]`. If an empty list `[]` is returned, no quicklooks are available.
 
 <h5> Arguments </h5>
 
@@ -50,7 +50,7 @@ jobtask.download_quicklooks(output_directory="/Users/max.mustermann/Desktop/")
 
 The `get_results_json()` function allows you to get the `data.json` from a specific job task.
 
-The returned format is `Union[dict, GeoDataFrame]`.
+The returned data type is `Union[dict, GeoDataFrame]`.
 
 <h5> Arguments </h5>
 
@@ -68,7 +68,7 @@ jobtask.get_results_json(as_dataframe=True)
 
 The `download_results()` function allows you to download a specific job task's results and returns a list of download paths.
 
-The returned format is `list[str]`.
+The returned data type is `list[str]`.
 
 <h5> Arguments </h5>
 
@@ -90,7 +90,7 @@ To use the visualization functions, [install](installation.md) the SDK's advance
 
 The `map_results()` function allows you to visualize a specific job task's results on a Folium map. Use together with [`download_results()`](#download_results).
 
-The returned format is `folium.Map`.
+The returned data type is `folium.Map`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/jobtask-reference.md
+++ b/docs/reference/jobtask-reference.md
@@ -32,10 +32,6 @@ jobtask.info
 
 The `download_quicklooks()` function allows you to download low-resolution preview images. Not all job tasks have quicklooks.
 
-```python
-download_quicklooks(output_directory)
-```
-
 The returned format is `list[str]`. If an empty list `[]` is returned, no quicklooks are available.
 
 <h5> Arguments </h5>
@@ -54,10 +50,6 @@ jobtask.download_quicklooks(output_directory="/Users/max.mustermann/Desktop/")
 
 The `get_results_json()` function allows you to get the `data.json` from a specific job task.
 
-```python
-get_results_json(as_dataframe)
-```
-
 The returned format is `Union[dict, GeoDataFrame]`.
 
 <h5> Arguments </h5>
@@ -75,10 +67,6 @@ jobtask.get_results_json(as_dataframe=True)
 ### download_results()
 
 The `download_results()` function allows you to download a specific job task's results and returns a list of download paths.
-
-```python
-download_results(output_directory)
-```
 
 The returned format is `list[str]`.
 
@@ -101,17 +89,6 @@ To use the visualization functions, [install](installation.md) the SDK's advance
 ### map_results()
 
 The `map_results()` function allows you to visualize a specific job task's results on a Folium map. Use together with [`download_results()`](#download_results).
-
-```python
-map_results(
-    bands,
-    aoi,
-    show_images,
-    show_features,
-    name_column,
-    save_html,
-)
-```
 
 The returned format is `folium.Map`.
 
@@ -143,17 +120,6 @@ jobtask.map_results(
 
 The `plot_results()` function allows you to visualize downloaded job task's results. Use together with [`download_results()`](#download_results).
 
-```python
-plot_results(
-    figsize,
-    bands,
-    titles,
-    filepaths,
-    plot_file_format,
-    **kwargs,
-)
-```
-
 <h5> Arguments </h5>
 
 | Argument           | Overview                                                                                                                                               |
@@ -180,14 +146,6 @@ jobtask.plot_results(
 ### plot_quicklooks()
 
 The `plot_quicklooks()` function allows you to visualize downloaded quicklooks. Use together with [`download_quicklooks()`](#download_quicklooks).
-
-```python
-plot_quicklooks(
-    figsize,
-    filepaths,
-    titles
-)
-```
 
 <h5> Arguments </h5>
 

--- a/docs/reference/order-reference.md
+++ b/docs/reference/order-reference.md
@@ -12,7 +12,7 @@ order = up42.initialize_order(order_id="ea36dee9-fed6-457e-8400-2c20ebd30f44")
 
 The `info` attribute returns metadata of a specific order.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 
@@ -24,7 +24,7 @@ order.info
 
 The `order_details` attribute returns details of a specific tasking order. It doesn't work with catalog orders.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 
@@ -36,7 +36,7 @@ order.order_details
 
 The `status` attribute returns the [order status](https://docs.up42.com/developers/api-tasking/tasking-monitor#order-statuses).
 
-The returned format is `str`.
+The returned data type is `str`.
 
 <h5> Example </h5>
 
@@ -51,7 +51,7 @@ The `is_fulfilled` attribute returns the following:
 - `True`, if the order has the `FULFILLED` status.
 - `False`, if the job has any other status.
 
-The returned format is `bool`.
+The returned data type is `bool`.
 
 <h5> Example </h5>
 
@@ -63,7 +63,7 @@ order.is_fulfilled
 
 The `track_status()` function allows you to track the order status until the order is fulfilled or failed.
 
-The returned format is `str`.
+The returned data type is `str`.
 
 <h5> Arguments </h5>
 
@@ -83,7 +83,7 @@ order.track_status(report_time=150)
 
 The `get_assets()` function returns a list of order assets.
 
-The returned format is `list[Asset]`.
+The returned data type is `list[Asset]`.
 
 <h5> Example </h5>
 

--- a/docs/reference/order-reference.md
+++ b/docs/reference/order-reference.md
@@ -63,10 +63,6 @@ order.is_fulfilled
 
 The `track_status()` function allows you to track the order status until the order is fulfilled or failed.
 
-```python
-track_status(report_time)
-```
-
 The returned format is `str`.
 
 <h5> Arguments </h5>
@@ -86,10 +82,6 @@ order.track_status(report_time=150)
 ### get_assets()
 
 The `get_assets()` function returns a list of order assets.
-
-```python
-get_assets()
-```
 
 The returned format is `list[Asset]`.
 

--- a/docs/reference/project-reference.md
+++ b/docs/reference/project-reference.md
@@ -28,10 +28,6 @@ project.info
 
 The `get_project_settings()` function returns threshold limits applied to the project.
 
-```python
-get_project_settings()
-```
-
 The returned format is `list[dict[str, str]]`.
 
 <h5> Example </h5>
@@ -45,10 +41,6 @@ project.get_project_settings()
 ### get_workflows()
 
 The `get_workflows()` function returns a list of workflows.
-
-```python
-get_workflows(return_json)
-```
 
 The returned format is `Union[list[Workflow], list[dict]]`.
 
@@ -69,17 +61,6 @@ project.get_workflows(return_json=True)
 ### get_jobs()
 
 The `get_jobs()` function returns a list of jobs.
-
-```python
-get_jobs(
-    return_json,
-    test_jobs,
-    real_jobs,
-    limit,
-    sortby,
-    descending,
-)
-```
 
 The returned format is `Union[JobCollection, list[dict]]`.
 

--- a/docs/reference/project-reference.md
+++ b/docs/reference/project-reference.md
@@ -16,7 +16,7 @@ project = up42.initialize_project(project_id="68567134-27ad-7bd7-4b65-d61adb11fc
 
 The `info` attribute returns metadata of a specific UP42 project.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 
@@ -28,7 +28,7 @@ project.info
 
 The `get_project_settings()` function returns threshold limits applied to the project.
 
-The returned format is `list[dict[str, str]]`.
+The returned data type is `list[dict[str, str]]`.
 
 <h5> Example </h5>
 
@@ -42,7 +42,7 @@ project.get_project_settings()
 
 The `get_workflows()` function returns a list of workflows.
 
-The returned format is `Union[list[Workflow], list[dict]]`.
+The returned data type is `Union[list[Workflow], list[dict]]`.
 
 <h5> Arguments </h5>
 
@@ -62,7 +62,7 @@ project.get_workflows(return_json=True)
 
 The `get_jobs()` function returns a list of jobs.
 
-The returned format is `Union[JobCollection, list[dict]]`.
+The returned data type is `Union[JobCollection, list[dict]]`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/storage-reference.md
+++ b/docs/reference/storage-reference.md
@@ -12,23 +12,6 @@ storage = up42.initialize_storage()
 
 The `get_assets()` function allows you to search for assets in storage.
 
-```python
-get_assets(
-    created_after,
-    created_before,
-    workspace_id,
-    collection_names,
-    producer_names,
-    tags,
-    sources,
-    search,
-    limit,
-    sortby,
-    descending,
-    return_json,
-)
-```
-
 The returned format is `Union[list[Asset], dict]`.
 
 <h5> Arguments </h5>
@@ -72,20 +55,6 @@ storage.get_assets(
 ### get_orders()
 
 The `get_orders()` function allows you to search for tasking and catalog orders.
-
-```python
-get_orders(
-    workspace_orders,
-    return_json,
-    limit,
-    sortby,
-    descending,
-    order_type,
-    statuses,
-    name,
-    tags,
-)
-```
 
 The returned format is `Union[list[Order], dict]`.
 

--- a/docs/reference/storage-reference.md
+++ b/docs/reference/storage-reference.md
@@ -12,7 +12,7 @@ storage = up42.initialize_storage()
 
 The `get_assets()` function allows you to search for assets in storage.
 
-The returned format is `Union[list[Asset], dict]`.
+The returned data type is `Union[list[Asset], dict]`.
 
 <h5> Arguments </h5>
 
@@ -56,7 +56,7 @@ storage.get_assets(
 
 The `get_orders()` function allows you to search for tasking and catalog orders.
 
-The returned format is `Union[list[Order], dict]`.
+The returned data type is `Union[list[Order], dict]`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/tasking-reference.md
+++ b/docs/reference/tasking-reference.md
@@ -14,17 +14,6 @@ This class also inherits functions from the [CatalogBase](catalogbase-reference.
 
 The `construct_order_parameters()` function allows you to fill out an order form for a new tasking order.
 
-```python
-construct_order_parameters(
-    data_product_id,
-    name,
-    acquisition_start,
-    acquisition_end,
-    geometry,
-    tags,
-)
-```
-
 The returned format is `dict`.
 
 <h5> Arguments </h5>
@@ -68,17 +57,6 @@ tasking.construct_order_parameters(
 
 The `get_feasibility()` function returns a list of feasibility studies for tasking orders.
 
-```python
-get_feasibility(
-    feasibility_id,
-    workspace_id,
-    order_id,
-    decision,
-    sortby,
-    descending,
-)
-```
-
 The returned format is `list`.
 
 <h5> Arguments </h5>
@@ -109,13 +87,6 @@ The `choose_feasibility()` function allows you to accept one of the proposed fea
 
 You can only perform actions with feasibility studies with the `NOT_DECIDED` status.
 
-```python
-choose_feasibility(
-    feasibility_id,
-    accepted_option_id,
-)
-```
-
 The returned format is `dict`.
 
 <h5> Arguments </h5>
@@ -139,17 +110,6 @@ tasking.choose_feasibility(
 ### get_quotations()
 
 The `get_quotations()` function returns a list of all quotations for tasking orders.
-
-```python
-get_quotations(
-    quotation_id,
-    workspace_id,
-    order_id,
-    decision,
-    sortby,
-    descending,
-)
-```
 
 The returned format is `list`.
 
@@ -180,13 +140,6 @@ tasking.get_quotations(
 The `decide_quotation()` function allows you to accept or reject a quotation for a tasking order.
 
 You can only perform actions with feasibility studies with the `NOT_DECIDED` status.
-
-```python
-decide_quotation(
-    quotation_id,
-    decision,
-)
-```
 
 The returned format is `dict`.
 

--- a/docs/reference/tasking-reference.md
+++ b/docs/reference/tasking-reference.md
@@ -14,7 +14,7 @@ This class also inherits functions from the [CatalogBase](catalogbase-reference.
 
 The `construct_order_parameters()` function allows you to fill out an order form for a new tasking order.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Arguments </h5>
 
@@ -57,7 +57,7 @@ tasking.construct_order_parameters(
 
 The `get_feasibility()` function returns a list of feasibility studies for tasking orders.
 
-The returned format is `list`.
+The returned data type is `list`.
 
 <h5> Arguments </h5>
 
@@ -87,7 +87,7 @@ The `choose_feasibility()` function allows you to accept one of the proposed fea
 
 You can only perform actions with feasibility studies with the `NOT_DECIDED` status.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Arguments </h5>
 
@@ -111,7 +111,7 @@ tasking.choose_feasibility(
 
 The `get_quotations()` function returns a list of all quotations for tasking orders.
 
-The returned format is `list`.
+The returned data type is `list`.
 
 <h5> Arguments </h5>
 
@@ -141,7 +141,7 @@ The `decide_quotation()` function allows you to accept or reject a quotation for
 
 You can only perform actions with feasibility studies with the `NOT_DECIDED` status.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/up42-reference.md
+++ b/docs/reference/up42-reference.md
@@ -55,7 +55,7 @@ up42.tools.settings(log=True)
 
 The `get_credits_balance()` function returns your account balance, in credits.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 
@@ -69,7 +69,7 @@ up42.get_credits_balance()
 
 The `get_block_coverage()` function returns the spatial coverage of the block.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Arguments </h5>
 
@@ -87,7 +87,7 @@ up42.get_block_coverage(block_id="f73c60f6-3f3c-4120-96cf-62b8d3019346")
 
 The `get_block_details()` function returns information about a specific block.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Arguments </h5>
 
@@ -109,7 +109,7 @@ up42.get_block_details(
 
 The `get_blocks()` function returns a list of all blocks on the marketplace.
 
-The returned format is `Union[List[Dict], dict]`.
+The returned data type is `Union[List[Dict], dict]`.
 
 <h5> Arguments </h5>
 
@@ -135,7 +135,7 @@ up42.get_blocks(
 
 The `get_example_aoi()` function returns an example AOI.
 
-The returned format is `Union[dict, GeoDataFrame]`.
+The returned data type is `Union[dict, GeoDataFrame]`.
 
 <h5> Arguments </h5>
 
@@ -157,7 +157,7 @@ up42.get_example_aoi(
 
 The `read_vector_file()` function allows you to upload your geometry from a vector file.
 
-The returned format is `Union[dict, GeoDataFrame]`.
+The returned data type is `Union[dict, GeoDataFrame]`.
 
 <h5> Arguments </h5>
 
@@ -179,7 +179,7 @@ up42.read_vector_file(
 
 The `draw_aoi()` function allows you to draw an AOI on an interactive map. To be able to use the function, [install plotting functionalities](installation.md) first.
 
-The returned format is `folium.Map`.
+The returned data type is `folium.Map`.
 
 <h5> Example </h5>
 
@@ -193,7 +193,7 @@ up42.draw_aoi()
 
 The `viztools.folium_base_map()` function returns a Folium map with the UP42 logo. Use it to [visualize your assets](visualizations.md).
 
-The returned format is `folium.Map`.
+The returned data type is `folium.Map`.
 
 <h5> Arguments </h5>
 
@@ -222,7 +222,7 @@ up42.viztools.folium_base_map(
 
 The `get_webhook_events()` function returns all available webhook events. For more information, see [Webhooks](webhooks.md).
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 
@@ -234,7 +234,7 @@ up42.get_webhook_events()
 
 The `create_webhook()` function allows you to register a new webhook in the system.
 
-The returned format is `Webhook`.
+The returned data type is `Webhook`.
 
 <h5> Arguments </h5>
 
@@ -262,7 +262,7 @@ up42.create_webhook(
 
 The `get_webhooks()` function returns all registered webhooks for this workspace.
 
-The returned format is `list[Webhook]`.
+The returned data type is `list[Webhook]`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/up42-reference.md
+++ b/docs/reference/up42-reference.md
@@ -8,14 +8,6 @@ The up42 class is the base library module imported to Python. It provides the el
 
 The `authenticate()` function allows you to access UP42 SDK requests. For more information, see [Authentication](authentication.md).
 
-```python
-authenticate(
-    cfg_file,
-    username,
-    password,
-)
-```
-
 <h5> Arguments </h5>
 
 | Argument   | Overview                                                                                      |
@@ -45,10 +37,6 @@ up42.authenticate(cfg_file="config.json")
 
 The `tools.settings()` function allows you to enable logging.
 
-```python
-tools.settings(log)
-```
-
 <h5> Arguments </h5>
 
 | Argument | Overview                                                                                                                                              |
@@ -67,10 +55,6 @@ up42.tools.settings(log=True)
 
 The `get_credits_balance()` function returns your account balance, in credits.
 
-```python
-get_credits_balance()
-```
-
 The returned format is `dict`.
 
 <h5> Example </h5>
@@ -84,10 +68,6 @@ up42.get_credits_balance()
 ### get_block_coverage()
 
 The `get_block_coverage()` function returns the spatial coverage of the block.
-
-```python
-get_block_coverage(block_id)
-```
 
 The returned format is `dict`.
 
@@ -106,13 +86,6 @@ up42.get_block_coverage(block_id="f73c60f6-3f3c-4120-96cf-62b8d3019346")
 ### get_block_details()
 
 The `get_block_details()` function returns information about a specific block.
-
-```python
-get_block_details(
-    block_id,
-    as_dataframe,
-)
-```
 
 The returned format is `dict`.
 
@@ -135,14 +108,6 @@ up42.get_block_details(
 ### get_blocks()
 
 The `get_blocks()` function returns a list of all blocks on the marketplace.
-
-```python
-get_blocks(
-    block_type,
-    basic,
-    as_dataframe,
-)
-```
 
 The returned format is `Union[List[Dict], dict]`.
 
@@ -170,13 +135,6 @@ up42.get_blocks(
 
 The `get_example_aoi()` function returns an example AOI.
 
-```python
-get_example_aoi(
-    location,
-    as_dataframe,
-)
-```
-
 The returned format is `Union[dict, GeoDataFrame]`.
 
 <h5> Arguments </h5>
@@ -198,13 +156,6 @@ up42.get_example_aoi(
 ### read_vector_file()
 
 The `read_vector_file()` function allows you to upload your geometry from a vector file.
-
-```python
-read_vector_file(
-    filename,
-    as_dataframe,
-)
-```
 
 The returned format is `Union[dict, GeoDataFrame]`.
 
@@ -228,10 +179,6 @@ up42.read_vector_file(
 
 The `draw_aoi()` function allows you to draw an AOI on an interactive map. To be able to use the function, [install plotting functionalities](installation.md) first.
 
-```python
-draw_aoi()
-```
-
 The returned format is `folium.Map`.
 
 <h5> Example </h5>
@@ -245,16 +192,6 @@ up42.draw_aoi()
 ### viztools.folium_base_map()
 
 The `viztools.folium_base_map()` function returns a Folium map with the UP42 logo. Use it to [visualize your assets](visualizations.md).
-
-```python
-viztools.folium_base_map(
-    lat,
-    lon,
-    zoom_start,
-    width_percent,
-    layer_control,
-)
-```
 
 The returned format is `folium.Map`.
 
@@ -285,10 +222,6 @@ up42.viztools.folium_base_map(
 
 The `get_webhook_events()` function returns all available webhook events. For more information, see [Webhooks](webhooks.md).
 
-```python
-get_webhook_events()
-```
-
 The returned format is `dict`.
 
 <h5> Example </h5>
@@ -300,16 +233,6 @@ up42.get_webhook_events()
 ### create_webhook()
 
 The `create_webhook()` function allows you to register a new webhook in the system.
-
-```python
-create_webhook(
-    name,
-    url,
-    events,
-    active,
-    secret,
-)
-```
 
 The returned format is `Webhook`.
 
@@ -338,10 +261,6 @@ up42.create_webhook(
 ### get_webhooks()
 
 The `get_webhooks()` function returns all registered webhooks for this workspace.
-
-```python
-get_webhooks(return_json)
-```
 
 The returned format is `list[Webhook]`.
 

--- a/docs/reference/webhook-reference.md
+++ b/docs/reference/webhook-reference.md
@@ -25,16 +25,6 @@ webhook.info
 
 The `update()` function allows you to modify a specific webhook.
 
-```python
-update(
-    name,
-    url,
-    events,
-    active,
-    secret,
-)
-```
-
 The returned format is `dict`.
 
 <h5> Arguments </h5>
@@ -63,10 +53,6 @@ webhook.update(
 
 The `delete()` function allows you to delete a registered webhook.
 
-```python
-delete()
-```
-
 <h5> Example </h5>
 
 ```python
@@ -78,10 +64,6 @@ webhook.delete()
 ### trigger_test_events()
 
 The `trigger_test_events()` allows you to trigger a webhook test event to test your receiving side. The UP42 server will send test messages for each subscribed event to the specified webhook URL.
-
-```python
-trigger_test_events()
-```
 
 The returned format is `dict`.
 

--- a/docs/reference/webhook-reference.md
+++ b/docs/reference/webhook-reference.md
@@ -13,7 +13,7 @@ To learn how to create a webhook, see the [up42 class](up42-reference.md).
 
 The `info` attribute returns metadata of a specific webhook.
 
-The returned format is `dict`
+The returned data type is `dict`
 
 <h5> Example </h5>
 
@@ -25,7 +25,7 @@ webhook.info
 
 The `update()` function allows you to modify a specific webhook.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Arguments </h5>
 
@@ -65,7 +65,7 @@ webhook.delete()
 
 The `trigger_test_events()` allows you to trigger a webhook test event to test your receiving side. The UP42 server will send test messages for each subscribed event to the specified webhook URL.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 

--- a/docs/reference/workflow-reference.md
+++ b/docs/reference/workflow-reference.md
@@ -19,7 +19,7 @@ workflow = up42.initialize_workflow(
 
 The `info` attribute returns metadata of a specific workflow.
 
-The returned format is `dict`.
+The returned data type is `dict`.
 
 <h5> Example </h5>
 
@@ -45,7 +45,7 @@ Workflow tasks are blocks that are added to a workflow. A workflow task uses a s
 
 The `workflow_tasks` attribute returns a list of workflow tasks in a workflow.
 
-The returned format is `dict[str, str]`.
+The returned data type is `dict[str, str]`.
 
 <h5> Example </h5>
 
@@ -57,7 +57,7 @@ workflow.workflow_tasks
 
 The `get_workflow_tasks` function returns a list of workflow tasks in a workflow.
 
-The returned format is `Union[list, dict]`.
+The returned data type is `Union[list, dict]`.
 
 <h5> Arguments </h5>
 
@@ -77,7 +77,7 @@ workflow.get_workflow_tasks(basic=True)
 
 The `get_jobs()` function returns all jobs associated with a workflow.
 
-The returned format is `Union[JobCollection, list[dict]]`.
+The returned data type is `Union[JobCollection, list[dict]]`.
 
 <h5> Arguments </h5>
 

--- a/docs/reference/workflow-reference.md
+++ b/docs/reference/workflow-reference.md
@@ -31,10 +31,6 @@ workflow.info
 
 The `delete()` function allows you to delete a workflow.
 
-```python
-delete()
-```
-
 <h5> Example </h5>
 
 ```python
@@ -61,10 +57,6 @@ workflow.workflow_tasks
 
 The `get_workflow_tasks` function returns a list of workflow tasks in a workflow.
 
-```python
-get_workflow_tasks(basic)
-```
-
 The returned format is `Union[list, dict]`.
 
 <h5> Arguments </h5>
@@ -84,14 +76,6 @@ workflow.get_workflow_tasks(basic=True)
 ### get_jobs()
 
 The `get_jobs()` function returns all jobs associated with a workflow.
-
-```python
-get_jobs(
-    return_json,
-    test_jobs,
-    real_jobs,
-)
-```
 
 The returned format is `Union[JobCollection, list[dict]]`.
 


### PR DESCRIPTION
Corresponds to Documentation Jira tasks:
- [DOC-831](https://up42.atlassian.net/browse/DOC-831)
- [DOC-812](https://up42.atlassian.net/browse/DOC-812)

### Removed

- Removed initialization code blocks on reference pages

### Changed

- Changed “The returned format is `this`.” → “The returned data type is `this.`” on all reference pages

[DOC-831]: https://up42.atlassian.net/browse/DOC-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-812]: https://up42.atlassian.net/browse/DOC-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ