### PR TITLE
DOC-925: Update auth in notebooks

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -20,7 +20,7 @@
         "password": "<your-password>"
       }
       ```
-    3. Authenticate from the created `config.json` file.
+    3. Authenticate from the created `credentials.json` file.
       ```python
       import up42
       up42.authenticate(cfg_file="credentials.json")

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -12,7 +12,7 @@
 
 === "In a configuration file"
 
-    1. Create a `config.json` file.
+    1. Create a `credentials.json` file.
     2. Paste the following code:
       ```json
       {
@@ -23,7 +23,7 @@
     3. Authenticate from the created `config.json` file.
       ```python
       import up42
-      up42.authenticate(cfg_file="config.json")
+      up42.authenticate(cfg_file="credentials.json")
       ```
 
 Retrieve the [email address and password](https://docs.up42.com/getting-started/account/management) used for logging into the [console](https://console.up42.com/?utm_source=documentation). Use them as values in the following arguments:

--- a/docs/notebooks/catalog-example.ipynb
+++ b/docs/notebooks/catalog-example.ipynb
@@ -51,7 +51,7 @@
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "up42.authenticate(cfg_file=\"config.json\")"
+        "up42.authenticate(cfg_file=\"credentials.json\")"
       ]
     },
     {

--- a/docs/notebooks/catalog-example.ipynb
+++ b/docs/notebooks/catalog-example.ipynb
@@ -51,7 +51,7 @@
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "up42.authenticate(cfg_file=\"credentials.json\")"
+        "up42.authenticate(cfg_file=\"config.json\")"
       ]
     },
     {

--- a/docs/notebooks/catalog-example.ipynb
+++ b/docs/notebooks/catalog-example.ipynb
@@ -45,19 +45,13 @@
         }
       ],
       "source": [
-        "up42.authenticate(\n",
-        "    username=\"<your-email-address>\",\n",
-        "    password=\"<your-password>\",\n",
-        ")\n",
-        "\n",
-        "# Alternatively, you can create a config.json file and use the following code for it:\n",
+        "# Create a configuration file and use the following code for it:\n",
         "# {\n",
         "#   \"username\": \"<your-email-address>\",\n",
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "# If you use a configuration file, uncomment this line:\n",
-        "# up42.authenticate(cfg_file=\"credentials.json\")"
+        "up42.authenticate(cfg_file=\"credentials.json\")"
       ]
     },
     {

--- a/docs/notebooks/order-assets-example.ipynb
+++ b/docs/notebooks/order-assets-example.ipynb
@@ -51,7 +51,7 @@
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "up42.authenticate(cfg_file=\"config.json\")"
+        "up42.authenticate(cfg_file=\"credentials.json\")"
       ]
     },
     {

--- a/docs/notebooks/order-assets-example.ipynb
+++ b/docs/notebooks/order-assets-example.ipynb
@@ -51,7 +51,7 @@
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "up42.authenticate(cfg_file=\"credentials.json\")"
+        "up42.authenticate(cfg_file=\"config.json\")"
       ]
     },
     {

--- a/docs/notebooks/order-assets-example.ipynb
+++ b/docs/notebooks/order-assets-example.ipynb
@@ -45,19 +45,13 @@
         }
       ],
       "source": [
-        "up42.authenticate(\n",
-        "    username=\"<your-email-address>\",\n",
-        "    password=\"<your-password>\",\n",
-        ")\n",
-        "\n",
-        "# Alternatively, you can create a config.json file and use the following code for it:\n",
+        "# Create a configuration file and use the following code for it:\n",
         "# {\n",
         "#   \"username\": \"<your-email-address>\",\n",
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "# If you use a configuration file, uncomment this line:\n",
-        "# up42.authenticate(cfg_file=\"credentials.json\")"
+        "up42.authenticate(cfg_file=\"credentials.json\")"
       ]
     },
     {

--- a/docs/notebooks/stac-example.ipynb
+++ b/docs/notebooks/stac-example.ipynb
@@ -65,7 +65,7 @@
     "#   \"password\": \"<your-password>\"\n",
     "# }\n",
     "\n",
-    "up42.authenticate(cfg_file=\"credentials.json\")"
+    "up42.authenticate(cfg_file=\"config.json\")"
    ]
   },
   {

--- a/docs/notebooks/stac-example.ipynb
+++ b/docs/notebooks/stac-example.ipynb
@@ -65,7 +65,7 @@
     "#   \"password\": \"<your-password>\"\n",
     "# }\n",
     "\n",
-    "up42.authenticate(cfg_file=\"config.json\")"
+    "up42.authenticate(cfg_file=\"credentials.json\")"
    ]
   },
   {

--- a/docs/notebooks/stac-example.ipynb
+++ b/docs/notebooks/stac-example.ipynb
@@ -59,18 +59,13 @@
     }
    ],
    "source": [
-    "up42.authenticate(\n",
-    "    username=\"<your-email-address>\",\n",
-    "    password=\"<your-password>\",\n",
-    ")\n",
-    "# Alternatively, you can create a config.json file and use the following code for it:\n",
+    "# Create a configuration file and use the following code for it:\n",
     "# {\n",
     "#   \"username\": \"<your-email-address>\",\n",
     "#   \"password\": \"<your-password>\"\n",
     "# }\n",
     "\n",
-    "# If you use a configuration file, uncomment the following line:\n",
-    "# up42.authenticate(cfg_file=\"credentials.json\")"
+    "up42.authenticate(cfg_file=\"credentials.json\")"
    ]
   },
   {

--- a/docs/notebooks/storage-assets-example.ipynb
+++ b/docs/notebooks/storage-assets-example.ipynb
@@ -51,7 +51,7 @@
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "up42.authenticate(cfg_file=\"config.json\")"
+        "up42.authenticate(cfg_file=\"credentials.json\")"
       ]
     },
     {

--- a/docs/notebooks/storage-assets-example.ipynb
+++ b/docs/notebooks/storage-assets-example.ipynb
@@ -51,7 +51,7 @@
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "up42.authenticate(cfg_file=\"credentials.json\")"
+        "up42.authenticate(cfg_file=\"config.json\")"
       ]
     },
     {

--- a/docs/notebooks/storage-assets-example.ipynb
+++ b/docs/notebooks/storage-assets-example.ipynb
@@ -45,19 +45,13 @@
         }
       ],
       "source": [
-        "up42.authenticate(\n",
-        "    username=\"<your-email-address>\",\n",
-        "    password=\"<your-password>\",\n",
-        ")\n",
-        "\n",
-        "# Alternatively, you can create a config.json file and use the following code for it:\n",
+        "# Create a configuration file and use the following code for it:\n",
         "# {\n",
         "#   \"username\": \"<your-email-address>\",\n",
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "# If you use a configuration file, uncomment this line:\n",
-        "# up42.authenticate(cfg_file=\"credentials.json\")"
+        "up42.authenticate(cfg_file=\"credentials.json\")"
       ]
     },
     {

--- a/docs/notebooks/tasking-example.ipynb
+++ b/docs/notebooks/tasking-example.ipynb
@@ -42,7 +42,7 @@
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "up42.authenticate(cfg_file=\"config.json\")"
+        "up42.authenticate(cfg_file=\"credentials.json\")"
       ]
     },
     {

--- a/docs/notebooks/tasking-example.ipynb
+++ b/docs/notebooks/tasking-example.ipynb
@@ -42,7 +42,7 @@
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "up42.authenticate(cfg_file=\"credentials.json\")"
+        "up42.authenticate(cfg_file=\"config.json\")"
       ]
     },
     {

--- a/docs/notebooks/tasking-example.ipynb
+++ b/docs/notebooks/tasking-example.ipynb
@@ -36,19 +36,13 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "up42.authenticate(\n",
-        "    username=\"<your-email-address>\",\n",
-        "    password=\"<your-password>\",\n",
-        ")\n",
-        "\n",
-        "# Alternatively, you can create a config.json file and use the following code for it:\n",
+        "# Create a configuration file and use the following code for it:\n",
         "# {\n",
         "#   \"username\": \"<your-email-address>\",\n",
         "#   \"password\": \"<your-password>\"\n",
         "# }\n",
         "\n",
-        "# If you use a configuration file, uncomment this line:\n",
-        "# up42.authenticate(cfg_file=\"credentials.json\")"
+        "up42.authenticate(cfg_file=\"credentials.json\")"
       ]
     },
     {


### PR DESCRIPTION
## Updated

[DOC-925](https://up42.atlassian.net/browse/DOC-925?atlOrigin=eyJpIjoiYTE5MWRlMGE2NjdjNGM5MDkwYzMyZDBhNDM5NTNmMDgiLCJwIjoiaiJ9): Update the auth cell in Notebooks
- `/notebooks`
      - Remove the example in 5 notebooks to provide credentials directly in code
      - Provide only the example with a file
- `authentication.md`
      - Changed name of file from `config.json` -> `credentials.json` to match other notebooks.



[DOC-925]: https://up42.atlassian.net/browse/DOC-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ