### PR TITLE
AT-4219 Fixing tasking order translate bug

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ from .fixtures.fixtures_order import (
     catalog_order_parameters,
     order_live,
     order_mock,
-    order_parameters_tasking_catalog,
+    order_parameters,
     tasking_order_parameters,
 )
 from .fixtures.fixtures_project import project_live, project_mock, project_mock_max_concurrent_jobs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,11 +26,11 @@ from .fixtures.fixtures_jobcollection import (
 )
 from .fixtures.fixtures_jobtask import jobtask_live, jobtask_mock
 from .fixtures.fixtures_order import (
+    catalog_order_parameters,
     order_live,
     order_mock,
-    order_parameter_by_type,
-    order_parameters,
-    order_parameters_tasking,
+    order_parameters_tasking_catalog,
+    tasking_order_parameters,
 )
 from .fixtures.fixtures_project import project_live, project_mock, project_mock_max_concurrent_jobs
 from .fixtures.fixtures_storage import storage_live, storage_mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,13 @@ from .fixtures.fixtures_jobcollection import (
     jobcollection_single_mock,
 )
 from .fixtures.fixtures_jobtask import jobtask_live, jobtask_mock
-from .fixtures.fixtures_order import order_live, order_mock, order_parameters
+from .fixtures.fixtures_order import (
+    order_live,
+    order_mock,
+    order_parameter_by_type,
+    order_parameters,
+    order_parameters_tasking,
+)
 from .fixtures.fixtures_project import project_live, project_mock, project_mock_max_concurrent_jobs
 from .fixtures.fixtures_storage import storage_live, storage_mock
 from .fixtures.fixtures_tasking import (

--- a/tests/fixtures/fixtures_order.py
+++ b/tests/fixtures/fixtures_order.py
@@ -71,7 +71,7 @@ def order_live(auth_live):
 
 
 @pytest.fixture
-def order_parameters():
+def catalog_order_parameters():
     return {
         "dataProduct": "4f1b2f62-98df-4c74-81f4-5dce45deee99",
         "params": {
@@ -96,7 +96,7 @@ def order_parameters():
 
 
 @pytest.fixture
-def order_parameters_tasking():
+def tasking_order_parameters():
     return {
         "dataProduct": "47dadb27-9532-4552-93a5-48f70a83eaef",
         "params": {
@@ -128,6 +128,6 @@ def order_parameters_tasking():
 
 
 @pytest.fixture(params=["catalog", "tasking"])
-def order_parameter_by_type(request, order_parameters, order_parameters_tasking):
-    mocks = {"catalog": order_parameters, "tasking": order_parameters_tasking}
+def order_parameters_tasking_catalog(request, catalog_order_parameters, tasking_order_parameters):
+    mocks = {"catalog": catalog_order_parameters, "tasking": tasking_order_parameters}
     return mocks[request.param]

--- a/tests/fixtures/fixtures_order.py
+++ b/tests/fixtures/fixtures_order.py
@@ -93,3 +93,41 @@ def order_parameters():
         },
         "tags": ["Test", "SDK"],
     }
+
+
+@pytest.fixture
+def order_parameters_tasking():
+    return {
+        "dataProduct": "47dadb27-9532-4552-93a5-48f70a83eaef",
+        "params": {
+            "displayName": "my_tasking_order",
+            "acquisitionStart": "2022-11-01T00:00:00Z",
+            "acquisitionEnd": "2022-11-10T23:59:59Z",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": (
+                    (
+                        (13.152222, 52.638054),
+                        (13.152222, 52.387978),
+                        (13.588728, 52.387978),
+                        (13.588728, 52.638054),
+                        (13.152222, 52.638054),
+                    ),
+                ),
+            },
+            "acquisitionMode": None,
+            "cloudCoverage": None,
+            "incidenceAngle": None,
+            "geometricProcessing": None,
+            "spectralProcessing": None,
+            "pixelCoding": None,
+            "radiometricProcessing": None,
+            "deliveredAs": None,
+        },
+    }
+
+
+@pytest.fixture(params=["catalog", "tasking"])
+def order_parameter_by_type(request, order_parameters, order_parameters_tasking):
+    mocks = {"catalog": order_parameters, "tasking": order_parameters_tasking}
+    return mocks[request.param]

--- a/tests/fixtures/fixtures_order.py
+++ b/tests/fixtures/fixtures_order.py
@@ -128,6 +128,6 @@ def tasking_order_parameters():
 
 
 @pytest.fixture(params=["catalog", "tasking"])
-def order_parameters_tasking_catalog(request, catalog_order_parameters, tasking_order_parameters):
+def order_parameters(request, catalog_order_parameters, tasking_order_parameters):
     mocks = {"catalog": catalog_order_parameters, "tasking": tasking_order_parameters}
     return mocks[request.param]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -463,9 +463,7 @@ def test_estimate_order_from_catalog(catalog_order_parameters, requests_mock, au
 
 
 def test_order_from_catalog(
-    catalog_order_parameters,
-    tasking_order_parameters,
-    order_parameters_tasking_catalog,
+    order_parameters,
     order_mock,
     catalog_mock,
     requests_mock,
@@ -477,7 +475,7 @@ def test_order_from_catalog(
             "errors": [],
         },
     )
-    order = catalog_mock.place_order(order_parameters=order_parameters_tasking_catalog)
+    order = catalog_mock.place_order(order_parameters=order_parameters)
     assert isinstance(order, Order)
     assert order.order_id == ORDER_ID
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -448,7 +448,7 @@ def test_construct_order_parameters_live(catalog_live, product_id):
 
 
 # pylint: disable=unused-argument
-def test_estimate_order_from_catalog(order_parameters, requests_mock, auth_mock):
+def test_estimate_order_from_catalog(catalog_order_parameters, requests_mock, auth_mock):
     catalog_instance = Catalog(auth=auth_mock)
     expected_payload = {
         "summary": {"totalCredits": 100, "totalSize": 0.1, "unit": "SQ_KM"},
@@ -457,12 +457,19 @@ def test_estimate_order_from_catalog(order_parameters, requests_mock, auth_mock)
     }
     url_order_estimation = f"{API_HOST}/v2/orders/estimate"
     requests_mock.post(url=url_order_estimation, json=expected_payload)
-    estimation = catalog_instance.estimate_order(order_parameters)
+    estimation = catalog_instance.estimate_order(catalog_order_parameters)
     assert isinstance(estimation, int)
     assert estimation == 100
 
 
-def test_order_from_catalog(order_parameters, order_mock, catalog_mock, requests_mock):
+def test_order_from_catalog(
+    catalog_order_parameters,
+    tasking_order_parameters,
+    order_parameters_tasking_catalog,
+    order_mock,
+    catalog_mock,
+    requests_mock,
+):
     requests_mock.post(
         url=f"{API_HOST}/v2/orders?workspaceId={WORKSPACE_ID}",
         json={
@@ -470,12 +477,12 @@ def test_order_from_catalog(order_parameters, order_mock, catalog_mock, requests
             "errors": [],
         },
     )
-    order = catalog_mock.place_order(order_parameters=order_parameters)
+    order = catalog_mock.place_order(order_parameters=order_parameters_tasking_catalog)
     assert isinstance(order, Order)
     assert order.order_id == ORDER_ID
 
 
-def test_order_from_catalog_track_status(order_parameters, order_mock, catalog_mock, requests_mock):
+def test_order_from_catalog_track_status(catalog_order_parameters, order_mock, catalog_mock, requests_mock):
     requests_mock.post(
         url=f"{API_HOST}/v2/orders?workspaceId={WORKSPACE_ID}",
         json={
@@ -493,7 +500,7 @@ def test_order_from_catalog_track_status(order_parameters, order_mock, catalog_m
         ],
     )
     order = catalog_mock.place_order(
-        order_parameters=order_parameters,
+        order_parameters=catalog_order_parameters,
         track_status=True,
         report_time=0.1,
     )
@@ -502,15 +509,15 @@ def test_order_from_catalog_track_status(order_parameters, order_mock, catalog_m
 
 
 @pytest.mark.live
-def test_estimate_order_from_catalog_live(order_parameters, catalog_live):
-    estimation = catalog_live.estimate_order(order_parameters)
+def test_estimate_order_from_catalog_live(catalog_order_parameters, catalog_live):
+    estimation = catalog_live.estimate_order(catalog_order_parameters)
     assert isinstance(estimation, int)
     assert estimation == 100
 
 
 @pytest.mark.skip(reason="Placing orders costs credits.")
 @pytest.mark.live
-def test_order_from_catalog_live(order_parameters, catalog_live):
-    order = catalog_live.place_order(order_parameters)
+def test_order_from_catalog_live(catalog_order_parameters, catalog_live):
+    order = catalog_live.place_order(catalog_order_parameters)
     assert isinstance(order, Order)
     assert order.order_id

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from up42.asset import Asset
-from up42.order import Order
+from up42.order import Order, _translate_construct_parameters
 
 from .fixtures.fixtures_globals import API_HOST, ASSET_ORDER_ID, ORDER_ID, WORKSPACE_ID
 from .fixtures.fixtures_order import JSON_GET_ASSETS_RESPONSE
@@ -235,3 +235,8 @@ def test_estimate_order_live(order_parameters, auth_live):
     estimation = Order.estimate(auth_live, order_parameters=order_parameters)
     assert isinstance(estimation, int)
     assert estimation == 100
+
+
+def test_order_translate_parameter(order_parameter_by_type):
+    new_parameters = _translate_construct_parameters(order_parameter_by_type)
+    assert new_parameters["featureCollection"]["features"][0]["geometry"] is not None

--- a/up42/order.py
+++ b/up42/order.py
@@ -19,7 +19,7 @@ def _translate_construct_parameters(order_parameters):
     params = order_parameters_v2["params"]
     data_product_id = order_parameters_v2["dataProduct"]
     order_parameters_v2["displayName"] = f"{data_product_id} order"
-    aoi = params.pop("aoi", None)
+    aoi = params.pop("aoi", None) or params.pop("geometry", None)
     feature_collection = {
         "type": "FeatureCollection",
         "features": [


### PR DESCRIPTION
Fixing the OrderV2 migration to allow tasking orders.

Items:
* [ ] Ran test & live-tests
* [ ] Implemented (new) unit tests
* [ ] Removed credentials
* [ ] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
