### PR TITLE
Enable linting for webhooks

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -15,7 +15,7 @@ ignore=
 
 # Files or directories matching the regex patterns are skipped. The regex
 # matches against base names, not paths.
-ignore-patterns=.*init.*,.*asset.*.py,.*initialization.py,.*job.*.py,.*estimation.py,.*http_adapter.py,.*main.py,macros.py,.*order.py,.*project.py,.*stac_client.py,.*utils.py,.*vis.*.py,.*viz.*.py,.*webhook.*.py,.*workflow.py,.*e2e.*.py
+ignore-patterns=.*init.*,.*asset.*.py,.*initialization.py,.*job.*.py,.*estimation.py,.*http_adapter.py,.*main.py,macros.py,.*order.py,.*project.py,.*stac_client.py,.*utils.py,.*vis.*.py,.*viz.*.py,.*workflow.py,.*e2e.*.py
 
 
 # Pickle collected data for later comparisons.

--- a/tests/fixtures/fixtures_webhook.py
+++ b/tests/fixtures/fixtures_webhook.py
@@ -1,20 +1,18 @@
-import os
-
 import pytest
 
-from up42.webhooks import Webhook, Webhooks
+from up42 import webhooks
 
-from .fixtures_globals import API_HOST, JSON_WEBHOOK, WEBHOOK_ID
+from . import fixtures_globals as constants
 
 
-@pytest.fixture()
+@pytest.fixture
 def webhook_mock(auth_mock, requests_mock):
     # webhook info
-    url_webhook_info = f"{API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks/{WEBHOOK_ID}"
-    requests_mock.get(url=url_webhook_info, json=JSON_WEBHOOK)
+    url_webhook_info = f"{constants.API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks/{constants.WEBHOOK_ID}"
+    requests_mock.get(url=url_webhook_info, json=constants.JSON_WEBHOOK)
 
     # test event
-    url_test_event = f"{API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks/{WEBHOOK_ID}/tests"
+    url_test_event = f"{constants.API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks/{constants.WEBHOOK_ID}/tests"
     json_test_event = {
         "data": {
             "startedAt": "2022-06-20T04:33:48.770826Z",
@@ -25,30 +23,25 @@ def webhook_mock(auth_mock, requests_mock):
     requests_mock.post(url=url_test_event, json=json_test_event)
 
     # update
-    url_update = f"{API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks/{WEBHOOK_ID}"
-    requests_mock.put(url=url_update, json=JSON_WEBHOOK)
+    url_update = f"{constants.API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks/{constants.WEBHOOK_ID}"
+    requests_mock.put(url=url_update, json=constants.JSON_WEBHOOK)
 
     # delete
-    url_delete = f"{API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks/{WEBHOOK_ID}"
+    url_delete = f"{constants.API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks/{constants.WEBHOOK_ID}"
     requests_mock.delete(url=url_delete)
 
-    return Webhook(auth=auth_mock, webhook_id=WEBHOOK_ID)
+    return webhooks.Webhook(auth=auth_mock, webhook_id=constants.WEBHOOK_ID)
 
 
-@pytest.fixture()
-def webhook_live(auth_live):
-    return Webhook(auth=auth_live, webhook_id=os.environ["TEST_UP42_WEBHOOK_ID"])
-
-
-@pytest.fixture()
+@pytest.fixture
 def webhooks_mock(auth_mock, requests_mock):
     # events
-    url_events = f"{API_HOST}/webhooks/events"
+    url_events = f"{constants.API_HOST}/webhooks/events"
     events_json = {"data": [{"name": "job.status"}], "error": None}
     requests_mock.get(url=url_events, json=events_json)
 
     # get webhooks
-    url_webhooks = f"{API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks"
+    url_webhooks = f"{constants.API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks"
     webhooks_json = {
         "data": [
             {
@@ -77,12 +70,7 @@ def webhooks_mock(auth_mock, requests_mock):
     requests_mock.get(url=url_webhooks, json=webhooks_json)
 
     # create webhook
-    url_create_webhook = f"{API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks"
-    requests_mock.post(url=url_create_webhook, json=JSON_WEBHOOK)
+    url_create_webhook = f"{constants.API_HOST}/workspaces/{auth_mock.workspace_id}/webhooks"
+    requests_mock.post(url=url_create_webhook, json=constants.JSON_WEBHOOK)
 
-    return Webhooks(auth=auth_mock)
-
-
-@pytest.fixture()
-def webhooks_live(auth_live):
-    return Webhooks(auth=auth_live)
+    return webhooks.Webhooks(auth=auth_mock)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,19 +1,19 @@
 import pytest
 
-from up42.webhooks import Webhook
+from up42 import webhooks
 
-from .fixtures.fixtures_globals import WEBHOOK_ID, WORKSPACE_ID
+from .fixtures import fixtures_globals as constants
 
 
 def test_webhook_initiate(webhook_mock):
-    assert isinstance(webhook_mock, Webhook)
-    assert webhook_mock.webhook_id == WEBHOOK_ID
-    assert webhook_mock.workspace_id == WORKSPACE_ID
+    assert isinstance(webhook_mock, webhooks.Webhook)
+    assert webhook_mock.webhook_id == constants.WEBHOOK_ID
+    assert webhook_mock.workspace_id == constants.WORKSPACE_ID
 
 
 def test_webhook_info(webhook_mock):
-    assert webhook_mock.info
-    assert webhook_mock._info["id"] == WEBHOOK_ID
+    info = webhook_mock.info
+    assert info and info["id"] == constants.WEBHOOK_ID
 
 
 def test_webhook_trigger_test_event(webhook_mock):
@@ -24,7 +24,7 @@ def test_webhook_trigger_test_event(webhook_mock):
 
 def test_webhook_update(webhook_mock):
     updated_webhook = webhook_mock.update(name="test_info_webhook")
-    assert isinstance(updated_webhook, Webhook)
+    assert isinstance(updated_webhook, webhooks.Webhook)
     assert updated_webhook._info["name"] == "test_info_webhook"
 
 
@@ -46,23 +46,15 @@ def test_get_webhook_events_live(webhooks_live):
 
 
 def test_get_webhooks(webhooks_mock):
-    webhooks = webhooks_mock.get_webhooks()
-    assert isinstance(webhooks, list)
-    assert isinstance(webhooks[0], Webhook)
+    hooks = webhooks_mock.get_webhooks()
+    assert isinstance(hooks, list)
+    assert isinstance(hooks[0], webhooks.Webhook)
 
 
 def test_get_webhooks_return_json(webhooks_mock):
-    webhooks = webhooks_mock.get_webhooks(return_json=True)
-    assert isinstance(webhooks, list)
-    assert isinstance(webhooks[0], dict)
-
-
-@pytest.mark.live
-def test_get_webhooks_live(webhooks_live):
-    webhooks = webhooks_live.get_webhooks()
-    assert isinstance(webhooks, list)
-    assert len(webhooks) == 3  # TEST_UP42_WEBHOOK_ID env variable needs to be updated
-    # assert isinstance(webhooks[0], Webhook)
+    hooks = webhooks_mock.get_webhooks(return_json=True)
+    assert isinstance(hooks, list)
+    assert isinstance(hooks[0], dict)
 
 
 def test_create_webhook(webhooks_mock):
@@ -72,14 +64,3 @@ def test_create_webhook(webhooks_mock):
         events=["job.status"],
     )
     assert new_webhook._info["name"] == "test_info_webhook"
-
-
-@pytest.mark.live
-def test_create_webhook_live(webhooks_live):
-    new_webhook = webhooks_live.create_webhook(
-        name="test_webhook_creation",
-        url="https://test-webhook-creation.com",
-        events=["job.status"],
-    )
-    assert new_webhook._info["name"] == "test_webhook_creation"
-    new_webhook.delete()

--- a/up42/webhooks.py
+++ b/up42/webhooks.py
@@ -1,10 +1,9 @@
 from typing import List, Optional
 
+from up42 import host, utils
 from up42.auth import Auth
-from up42.host import endpoint
-from up42.utils import get_logger
 
-logger = get_logger(__name__)
+logger = utils.get_logger(__name__)
 
 
 class Webhook:
@@ -35,7 +34,7 @@ class Webhook:
         """
         Gets and updates the webhook metadata information.
         """
-        url = endpoint(f"/workspaces/{self.workspace_id}/webhooks/{self.webhook_id}")
+        url = host.endpoint(f"/workspaces/{self.workspace_id}/webhooks/{self.webhook_id}")
         response_json = self.auth.request(request_type="GET", url=url)
         self._info = response_json["data"]
         return self._info
@@ -48,7 +47,7 @@ class Webhook:
         Returns:
             A dict with information about the test events.
         """
-        url = endpoint(f"/workspaces/{self.workspace_id}/webhooks/{self.webhook_id}/tests")
+        url = host.endpoint(f"/workspaces/{self.workspace_id}/webhooks/{self.webhook_id}/tests")
         response_json = self.auth.request(
             request_type="POST",
             url=url,
@@ -84,19 +83,19 @@ class Webhook:
             "secret": secret if secret is not None else self._info["secret"],
             "active": active if active is not None else self._info["active"],
         }
-        url_put = endpoint(f"/workspaces/{self.workspace_id}/webhooks/{self.webhook_id}")
+        url_put = host.endpoint(f"/workspaces/{self.workspace_id}/webhooks/{self.webhook_id}")
         response_json = self.auth.request(request_type="PUT", url=url_put, data=input_parameters)
         self._info = response_json["data"]
-        logger.info(f"Updated webhook {self}")
+        logger.info("Updated webhook %s", self)
         return self
 
     def delete(self) -> None:
         """
         Deletes a registered webhook.
         """
-        url = endpoint(f"/workspaces/{self.workspace_id}/webhooks/{self.webhook_id}")
+        url = host.endpoint(f"/workspaces/{self.workspace_id}/webhooks/{self.webhook_id}")
         self.auth.request(request_type="DELETE", url=url)
-        logger.info(f"Successfully deleted Webhook: {self.webhook_id}")
+        logger.info("Successfully deleted Webhook: %s", self.webhook_id)
 
 
 class Webhooks:
@@ -131,7 +130,7 @@ class Webhooks:
         Returns:
             A dict of the available webhook events.
         """
-        url = endpoint("/webhooks/events")
+        url = host.endpoint("/webhooks/events")
         response_json = self.auth.request(request_type="GET", url=url)
         return response_json["data"]
 
@@ -145,9 +144,9 @@ class Webhooks:
         Returns:
             A list of the registered webhooks for this workspace.
         """
-        url = endpoint(f"/workspaces/{self.workspace_id}/webhooks")
+        url = host.endpoint(f"/workspaces/{self.workspace_id}/webhooks")
         response_json = self.auth.request(request_type="GET", url=url)
-        logger.info(f"Queried {len(response_json['data'])} webhooks.")
+        logger.info("Queried %s webhooks.", len(response_json["data"]))
 
         if return_json:
             return response_json["data"]
@@ -189,12 +188,12 @@ class Webhooks:
             "secret": secret,
             "active": active,
         }
-        url_post = endpoint(f"/workspaces/{self.workspace_id}/webhooks")
+        url_post = host.endpoint(f"/workspaces/{self.workspace_id}/webhooks")
         response_json = self.auth.request(request_type="POST", url=url_post, data=input_parameters)
         webhook = Webhook(
             auth=self.auth,
             webhook_id=response_json["data"]["id"],
             webhook_info=response_json["data"],
         )
-        logger.info(f"Created webhook {webhook}")
+        logger.info("Created webhook %s", webhook)
         return webhook


### PR DESCRIPTION
Enabling linting for webhooks + tests + fixtures

Items:
* [x] Ran test & live-tests
* [x] Implemented (new) unit tests
* [x] Removed credentials
* [x] Removed argument pointing to staging
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
* [ ] Updated announcement banner
