### PR TITLE
Release version 0.37.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ You can check your current version with the following command:
     ```
 
 For more information, see [UP42 Python package description](https://pypi.org/project/up42-py/).
+## 0.37.1
+
+**Apr 5, 2024**
+
+- Removed upper bound for Python 3.12.
+- Dropped support for Python 3.8.
+- New authentication token are retrieved upon expiration instead of every request.
+- Dropped tenacity, requests-oauthlib and types-oauthlib as dependencies.
+- Updated the deprecation date for `Jobs`, `Workflow`, and `Projects` related features.
+- Multiple refactoring improvements.
+
 ## 0.37.1a11
 
 **Apr 4, 2024**

--- a/docs/theme_override_home/main.html
+++ b/docs/theme_override_home/main.html
@@ -20,7 +20,7 @@ if (typeof window !== 'undefined' && window.location.href.includes('127.0.0.1'))
 <!-- Announcement bar -->
 {% block announce %}
   <style>.md-announce a,.md-announce a:focus,.md-announce a:hover{color:currentColor}.md-announce strong{white-space:nowrap}.md-announce .twitter{margin-left:.2em;color:#00acee}</style>
-    <strong><a href="https://docs.up42.com/sdk/changelog/">New in 0.37.0: Fixed unintentional removal of titles and tags during asset metadata updates</a></strong>
+    <strong><a href="https://docs.up42.com/sdk/changelog/">New in 0.37.1: Python 3.8 dropped, Python 3.12+ enabled</a></strong>
 {% endblock %}
 
 <!-- More minimal footer -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "up42-py"
-version = "0.37.1a11"
+version = "0.37.1"
 description = "Python SDK for UP42, the geospatial marketplace and developer platform."
 authors = ["UP42 GmbH <support@up42.com>"]
 license = "https://github.com/up42/up42-py/blob/master/LICENSE"


### PR DESCRIPTION
- Removed upper bound for Python 3.12.
- Dropped support for Python 3.8.
- New authentication token are retrieved upon expiration instead of every request.
- Dropped tenacity, requests-oauthlib and types-oauthlib as dependencies.
- Updated the deprecation date for `Jobs`, `Workflow`, and `Projects` related features.
- Multiple refactoring improvements.

Items:
* [ ] Implemented (new) unit tests
* [x] Updated [documentation](sdk.up42.com)

For release:
* [x] Bumped version
* [x] Added changelog
* [x] Updated announcement banner
