### PR TITLE
[PT-5138] Drop get blocks, get block details and block coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ You can check your current version with the following command:
     ```
 
 For more information, see [UP42 Python package description](https://pypi.org/project/up42-py/).
+## 1.0.0a7
+
+**Apr 16, 2024**
+- Dropped `get_blocks`, `get_block_details` and `get_block_coverage` from `main.py`
+
 ## 1.0.0a6
 
 **Apr 16, 2024**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "up42-py"
-version = "1.0.0a6"
+version = "1.0.0a7"
 description = "Python SDK for UP42, the geospatial marketplace and developer platform."
 authors = ["UP42 GmbH <support@up42.com>"]
 license = "https://github.com/up42/up42-py/blob/master/LICENSE"

--- a/tests/fixtures/fixtures_auth.py
+++ b/tests/fixtures/fixtures_auth.py
@@ -18,12 +18,6 @@ def auth_mock(requests_mock: req_mock.Mocker) -> up42_auth.Auth:
         url="https://api.up42.com/users/me",
         json={"data": {"id": constants.WORKSPACE_ID}},
     )
-    # get_blocks
-    url_get_blocks = f"{constants.API_HOST}/blocks"
-    requests_mock.get(
-        url=url_get_blocks,
-        json=constants.JSON_BLOCKS,
-    )
     # get_credits_balance
     url_get_credits_balance = f"{constants.API_HOST}/accounts/me/credits/balance"
     requests_mock.get(

--- a/tests/fixtures/fixtures_globals.py
+++ b/tests/fixtures/fixtures_globals.py
@@ -51,61 +51,6 @@ STAC_COLLECTION_ID = "e459db4c-3b9d-4aa1-8931-5df2517b49ba"
 
 WEBHOOK_ID = "123"
 
-
-JSON_BLOCKS = {
-    "data": [
-        {
-            "id": "4ed70368-d4e1-4462-bef6-14e768049471",
-            "name": "tiling",
-            "displayName": "Raster Tiling",
-            "type": "PROCESSING",
-        },
-        {
-            "id": "c0d04ec3-98d7-4183-902f-5bcb2a176d89",
-            "name": "sharpening",
-            "displayName": "Sharpening Filter",
-            "type": "PROCESSING",
-        },
-        {
-            "id": "c4cb8913-2ef3-4e82-a426-65ea8faacd9a",
-            "name": "esa-s2-l2a-gtiff-visual",
-            "displayName": "Sentinel-2 L2A Visual (GeoTIFF)",
-            "type": "DATA",
-        },
-    ],
-    "error": {},
-}
-
-JSON_WORKFLOW_ESTIMATION = {
-    "data": {
-        "esa-s2-l2a-gtiff-visual:1": {
-            "blockConsumption": {
-                "credit": {"max": 0, "min": 0},
-                "resources": {"max": 0, "min": 0, "unit": "SQUARE_KM"},
-            },
-            "machineConsumption": {
-                "credit": {"max": 1, "min": 1},
-                "duration": {"max": 0, "min": 0},
-            },
-        },
-        "tiling:1": {
-            "blockConsumption": {
-                "credit": {"max": 0, "min": 0},
-                "resources": {
-                    "max": 3.145728,
-                    "min": 3.145728,
-                    "unit": "MEGABYTE",
-                },
-            },
-            "machineConsumption": {
-                "credit": {"max": 9, "min": 2},
-                "duration": {"max": 428927, "min": 80930},
-            },
-        },
-    },
-    "error": {},
-}
-
 JSON_ASSET = {
     "accountId": "69353acb-f942-423f-8f32-11d6d67caa77",
     "createdAt": "2022-12-07T14:25:34.968Z",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,3 @@
-import pandas
 import pytest
 
 from up42 import main
@@ -10,89 +9,6 @@ from .fixtures import fixtures_globals as constants
 def setup_auth_mock(auth_mock):
     main._auth = auth_mock  # pylint: disable=protected-access
     yield
-
-
-def test_get_blocks(requests_mock):
-    url_get_blocks = f"{constants.API_HOST}/blocks"
-    requests_mock.get(
-        url=url_get_blocks,
-        json={
-            "data": [
-                {"id": "789-2736-212", "name": "tiling"},
-                {"id": "789-2736-212", "name": "sharpening"},
-            ],
-            "error": {},
-        },
-    )
-    blocks = main.get_blocks()
-    assert isinstance(blocks, dict)
-    assert "tiling" in list(blocks.keys())
-
-
-def test_get_blocks_not_basic_dataframe(requests_mock):
-    url_get_blocks = f"{constants.API_HOST}/blocks"
-    json_get_blocks = {
-        "data": [
-            {"id": "789-2736-212", "name": "tiling"},
-            {"id": "789-2736-212", "name": "sharpening"},
-        ],
-        "error": {},
-    }
-    requests_mock.get(url=url_get_blocks, json=json_get_blocks)
-
-    blocks_df = main.get_blocks(basic=False, as_dataframe=True)
-    assert isinstance(blocks_df, pandas.DataFrame)
-    assert "tiling" in blocks_df["name"].to_list()
-
-
-def test_get_block_details(requests_mock):
-    block_id = "273612-13"
-    url_get_blocks_details = f"{constants.API_HOST}/blocks/{block_id}"
-    requests_mock.get(
-        url=url_get_blocks_details,
-        json={
-            "data": {"id": "273612-13", "name": "tiling", "createdAt": "123"},
-            "error": {},
-        },
-    )
-    details = main.get_block_details(block_id=block_id)
-    assert isinstance(details, dict)
-    assert details["id"] == block_id
-    assert "createdAt" in details
-
-
-def test_get_block_coverage(requests_mock):
-    block_id = "273612-13"
-    url_get_blocks_coverage = f"{constants.API_HOST}/blocks/{block_id}/coverage"
-    requests_mock.get(
-        url=url_get_blocks_coverage,
-        json={
-            "data": {"url": "https://storage.googleapis.com/coverage-area-interstellar-prod/coverage.json"},
-            "error": {},
-        },
-    )
-    url_geojson_response = "https://storage.googleapis.com/coverage-area-interstellar-prod/coverage.json"
-    requests_mock.get(
-        url=url_geojson_response,
-        json={
-            "type": "FeatureCollection",
-            "name": "bundle6m",
-            "crs": {
-                "type": "name",
-                "properties": {"name": "urn:ogc:def:crs:OGC:1.3:CRS84"},
-            },
-            "features": [
-                {
-                    "type": "Feature",
-                    "properties": {},
-                    "geometry": {"type": "MultiPolygon", "coordinates": []},
-                }
-            ],
-        },
-    )
-    coverage = main.get_block_coverage(block_id=block_id)
-    assert isinstance(coverage, dict)
-    assert "features" in coverage
 
 
 def test_get_credits_balance():

--- a/up42/__init__.py
+++ b/up42/__init__.py
@@ -29,16 +29,7 @@ from up42.initialization import (
     initialize_tasking,
     initialize_webhook,
 )
-from up42.main import (
-    authenticate,
-    create_webhook,
-    get_block_coverage,
-    get_block_details,
-    get_blocks,
-    get_credits_balance,
-    get_webhook_events,
-    get_webhooks,
-)
+from up42.main import authenticate, create_webhook, get_credits_balance, get_webhook_events, get_webhooks
 from up42.order import Order
 from up42.storage import Storage
 from up42.tasking import Tasking
@@ -70,9 +61,6 @@ __all__ = [
         get_webhooks,
         create_webhook,
         get_webhook_events,
-        get_blocks,
-        get_block_details,
-        get_block_coverage,
         get_credits_balance,
     ]
 ]


### PR DESCRIPTION
Dropped `get_blocks`, `get_block_details` and `get_block_coverage` from `main.py`

Items:
* [ ] Implemented (new) unit tests
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [x] Bumped version
* [x] Added changelog
