### PR TITLE
PT-5266 Run sdk-tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ workflows:
           machine-size: medium+
           name: sdk-e2e-tests
           fingerprint: 'c5:5a:28:b3:5e:21:8d:9c:6c:b1:9b:a7:7b:f3:41:0c'
-          run-command: poetry run pytest spec --junitxml=./report/junit.xml
+          run-command: make test-all
           context:
             - 'sdk-tests-staging-build'
           post-steps:


### PR DESCRIPTION
Updating the run command for `sdk-tests`, so tests run with 10 workers in parallel, only merge after this https://github.com/up42/sdk-tests/pull/51 is merged!
