### PR TITLE
[PT-5013] Drop Webhooks class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ For more information, see [UP42 Python package description](https://pypi.org/pro
 
 **May 30, 2024**
 
-- Moved instance methods of `Webhook` class to class methods of `Webhook` class and dropped the former.
+- Moved instance methods of `Webhooks` class to class methods of `Webhook` class and dropped the former.
 
 ## 1.0.4a6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ You can check your current version with the following command:
     ```
 
 For more information, see [UP42 Python package description](https://pypi.org/project/up42-py/).
+## 1.0.4a7
+
+**May 30, 2024**
+
+- Moved instance methods of `Webhook` class to class methods of `Webhook` class and dropped the former.
+
 ## 1.0.4a6
 
 **May 30, 2024**

--- a/docs/macros.py
+++ b/docs/macros.py
@@ -77,7 +77,6 @@ def define_env(env):
     env.variables.docstring_order = indent(up42.order.Order.__doc__)
     env.variables.docstring_storage = indent(up42.storage.Storage.__doc__)
     env.variables.docstring_asset = indent(up42.asset.Asset.__doc__)
-    env.variables.docstring_webhooks = indent(up42.webhooks.Webhooks.__doc__)
 
     # Class functions for reference and structure chapter
     env.variables.funcs_up42 = get_methods(up42)
@@ -86,5 +85,4 @@ def define_env(env):
     env.variables.funcs_order = get_methods(up42.order.Order)
     env.variables.funcs_storage = get_methods(up42.storage.Storage)
     env.variables.funcs_asset = get_methods(up42.asset.Asset)
-    env.variables.funcs_webhooks = get_methods(up42.webhooks.Webhooks)
     env.variables.funcs_webhook = get_methods(up42.webhooks.Webhook)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "up42-py"
-version = "1.0.4a6"
+version = "1.0.4a7"
 description = "Python SDK for UP42, the geospatial marketplace and developer platform."
 authors = ["UP42 GmbH <support@up42.com>"]
 license = "https://github.com/up42/up42-py/blob/master/LICENSE"

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -17,10 +17,9 @@ def workspace(auth_mock):
 
 
 @pytest.fixture(name="webhooks")
-def _webhooks(auth_mock):
-    with mock.patch("up42.webhooks.Webhooks") as webhooks_class_mock:
-        yield webhooks_class_mock.return_value
-    webhooks_class_mock.assert_called_with(auth=auth_mock, workspace_id=constants.WORKSPACE_ID)
+def _webhooks():
+    with mock.patch("up42.webhooks.Webhook") as webhooks_class_mock:
+        yield webhooks_class_mock
 
 
 def test_should_initialize_objects(
@@ -51,9 +50,9 @@ def test_should_get_webhook_events(webhooks: mock.MagicMock):
 @pytest.mark.parametrize("return_json", [False, True])
 def test_should_get_webhooks(webhooks: mock.MagicMock, return_json):
     hooks = mock.MagicMock()
-    webhooks.get_webhooks.return_value = hooks
+    webhooks.all.return_value = hooks
     assert up42.get_webhooks(return_json=return_json) == hooks
-    webhooks.get_webhooks.assert_called_with(return_json=return_json)
+    webhooks.all.assert_called_with(return_json=return_json)
 
 
 def test_should_create_webhook(webhooks: mock.MagicMock):
@@ -63,6 +62,6 @@ def test_should_create_webhook(webhooks: mock.MagicMock):
     active = True
     secret = "secret"
     webhook = mock.MagicMock()
-    webhooks.create_webhook.return_value = webhook
+    webhooks.create.return_value = webhook
     assert webhook == up42.create_webhook(name, url, events, active, secret)
-    webhooks.create_webhook.assert_called_with(name=name, url=url, events=events, active=active, secret=secret)
+    webhooks.create.assert_called_with(name=name, url=url, events=events, active=active, secret=secret)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -166,12 +166,6 @@ class TestWebhook:
         assert hook == dataclasses.replace(webhook, updated_at=updated_at, **updates)
         assert requests_mock.last_request and requests_mock.last_request.json() == updates
 
-
-class TestWebhooks:
-    @pytest.fixture(autouse=True)
-    def setup_webhooks(self, auth_mock):
-        self.webhooks = webhooks.Webhooks(auth_mock, constants.WORKSPACE_ID)
-
     def test_should_get_webhook_events(self, requests_mock: req_mock.Mocker):
         url = f"{constants.API_HOST}/webhooks/events"
         events = ["some-event"]
@@ -182,18 +176,18 @@ class TestWebhooks:
                 "error": {},
             },
         )
-        assert self.webhooks.get_webhook_events() == events
+        assert webhooks.Webhook.get_webhook_events() == events
 
-    def test_should_get_webhooks(self, requests_mock: req_mock.Mocker, webhook: webhooks.Webhook):
+    def test_should_get_all_webhooks(self, requests_mock: req_mock.Mocker, webhook: webhooks.Webhook):
         requests_mock.get(HOOKS_URL, json={"data": [metadata]})
-        assert self.webhooks.get_webhooks() == [webhook]
+        assert webhooks.Webhook.all() == [webhook]
 
-    def test_should_get_webhooks_as_dict(self, requests_mock: req_mock.Mocker):
+    def test_should_get_all_webhooks_as_dict(self, requests_mock: req_mock.Mocker):
         requests_mock.get(HOOKS_URL, json={"data": [metadata]})
-        assert self.webhooks.get_webhooks(return_json=True) == [metadata]
+        assert webhooks.Webhook.all(return_json=True) == [metadata]
 
     @pytest.mark.parametrize("secret", [random_alphanumeric(), None])
-    def test_should_create_webhook(
+    def test_should_create(
         self,
         requests_mock: req_mock.Mocker,
         webhook: webhooks.Webhook,
@@ -204,7 +198,7 @@ class TestWebhooks:
         events = [random_alphanumeric()]
         active = random.choice([True, False])
         requests_mock.post(HOOKS_URL, json={"data": metadata})
-        assert self.webhooks.create_webhook(
+        assert webhooks.Webhook.create(
             name=name, url=url, events=events, active=active, secret=secret
         ) == dataclasses.replace(webhook, name=name, url=url, active=active, events=events, secret=secret)
 

--- a/up42/initialization.py
+++ b/up42/initialization.py
@@ -71,9 +71,7 @@ def get_webhooks(return_json: bool = False) -> List[webhooks.Webhook]:
     Returns:
         A list of the registered webhooks for this workspace.
     """
-    return webhooks.Webhooks(auth=base.workspace.auth, workspace_id=base.workspace.id).get_webhooks(
-        return_json=return_json
-    )
+    return webhooks.Webhook.all(return_json=return_json)
 
 
 def create_webhook(
@@ -95,9 +93,7 @@ def create_webhook(
     Returns:
         A dict with details of the registered webhook.
     """
-    return webhooks.Webhooks(auth=base.workspace.auth, workspace_id=base.workspace.id).create_webhook(
-        name=name, url=url, events=events, active=active, secret=secret
-    )
+    return webhooks.Webhook.create(name=name, url=url, events=events, active=active, secret=secret)
 
 
 def get_webhook_events() -> dict:
@@ -107,4 +103,4 @@ def get_webhook_events() -> dict:
     Returns:
         A dict of the available webhook events.
     """
-    return webhooks.Webhooks(auth=base.workspace.auth, workspace_id=base.workspace.id).get_webhook_events()
+    return webhooks.Webhook.get_webhook_events()


### PR DESCRIPTION
Drops Webhooks class and moves its legacy instance methods as class methods to Webhook class

Items:
* [x] Implemented (new) unit tests
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [x] Bumped version
* [x] Added changelog
