### PR TITLE
[PT-5318] Deprecate legacy webhooks methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ You can check your current version with the following command:
     ```
 
 For more information, see [UP42 Python package description](https://pypi.org/project/up42-py/).
+## 1.0.4a18
+
+**Jun 13, 2024**
+
+- Deprecate legacy webhook code.
+- Drop long deprecated `Catalog::construct_parameters`.
+
 ## 1.0.4a17
 
 **Jun 13, 2024**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "up42-py"
-version = "1.0.4a17"
+version = "1.0.4a18"
 description = "Python SDK for UP42, the geospatial marketplace and developer platform."
 authors = ["UP42 GmbH <support@up42.com>"]
 license = "https://github.com/up42/up42-py/blob/master/LICENSE"

--- a/up42/catalog.py
+++ b/up42/catalog.py
@@ -205,11 +205,6 @@ class Catalog(CatalogBase):
             raise ValueError("Please provide the 'order_parameters' parameter!")
         return order.Order.estimate(self.auth, order_parameters)  # type: ignore
 
-    @utils.deprecation("construct_search_parameters", "0.25.0")
-    def construct_parameters(self, **kwargs):  # pragma: no cover
-        """Deprecated, see construct_search_parameters"""
-        return self.construct_search_parameters(**kwargs)
-
     @staticmethod
     def construct_search_parameters(
         geometry: Union[

--- a/up42/initialization.py
+++ b/up42/initialization.py
@@ -51,6 +51,7 @@ def initialize_asset(asset_id: str) -> asset.Asset:
     return up42_asset
 
 
+@utils.deprecation("up42.Webhook::get", "2.0.0")
 def initialize_webhook(webhook_id: str) -> webhooks.Webhook:
     """
     Returns a Webhook object (has to exist on UP42).
@@ -62,6 +63,7 @@ def initialize_webhook(webhook_id: str) -> webhooks.Webhook:
     return webhook
 
 
+@utils.deprecation("up42.Webhook::all", "2.0.0")
 def get_webhooks(return_json: bool = False) -> List[webhooks.Webhook]:
     """
     Gets all registered webhooks for this workspace.
@@ -74,6 +76,7 @@ def get_webhooks(return_json: bool = False) -> List[webhooks.Webhook]:
     return webhooks.Webhook.all(return_json=return_json)
 
 
+@utils.deprecation("up42.Webhook::save", "2.0.0")
 def create_webhook(
     name: str,
     url: str,
@@ -96,6 +99,7 @@ def create_webhook(
     return webhooks.Webhook.create(name=name, url=url, events=events, active=active, secret=secret)
 
 
+@utils.deprecation("up42.Webhook::get_webhook_events", "2.0.0")
 def get_webhook_events() -> dict:
     """
     Gets all available webhook events.

--- a/up42/utils.py
+++ b/up42/utils.py
@@ -72,26 +72,23 @@ logger = get_logger(__name__)
 
 
 def deprecation(
-    replacement_name: str,
+    replacement_name: Optional[str],
     version: str,
-    extra_message: str = "",
 ):
     """
     Decorator for custom deprecation warnings.
 
     Args:
         replacement_name: Name of the replacement function.
-        version: The package version in which the deprecation will happen.
+        version: The breaking package version
         extra_message: Optional message after default deprecation warning.
     """
 
     def actual_decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            message = (
-                f"`{func.__name__}` will be deprecated in version {version}, "
-                f"use `{replacement_name}` instead! {extra_message}"
-            )
+            replace_with = f", use `{replacement_name}` instead" if replacement_name else ""
+            message = f"`{func.__name__}` is deprecated and will be dropped in version {version}{replace_with}."
             warnings.warn(message, DeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)
 

--- a/up42/webhooks.py
+++ b/up42/webhooks.py
@@ -1,4 +1,5 @@
 import dataclasses
+import warnings
 from typing import List, Optional
 
 from up42 import base, host, utils
@@ -68,10 +69,12 @@ class Webhook:
         return cls.from_metadata(metadata)
 
     @property
+    @utils.deprecation("up42.Webhook properties", "2.0.0")
     def info(self) -> dict:
         return dataclasses.asdict(self)
 
     @property
+    @utils.deprecation("up42.Webhook.id", "2.0.0")
     def webhook_id(self):
         return self.id
 
@@ -86,6 +89,7 @@ class Webhook:
         url = host.endpoint(f"/workspaces/{self.workspace_id}/webhooks/{self.id}/tests")
         return self.session.post(url=url).json()["data"]
 
+    @utils.deprecation("up42.Webhook::save", "2.0.0")
     def update(
         self,
         name: Optional[str] = None,
@@ -151,10 +155,16 @@ class Webhook:
         logger.info("Queried %s webhooks.", len(payload))
 
         if return_json:
+            warnings.warn(
+                "return_json is deprecated and will be dropped in version 2.0.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return payload
         return [cls.from_metadata(metadata) for metadata in payload]
 
     @classmethod
+    @utils.deprecation("up42.Webhook::save", "2.0.0")
     def create(
         cls,
         name: str,

--- a/up42/webhooks.py
+++ b/up42/webhooks.py
@@ -74,7 +74,7 @@ class Webhook:
         return dataclasses.asdict(self)
 
     @property
-    @utils.deprecation("up42.Webhook.id", "2.0.0")
+    @utils.deprecation("up42.Webhook::id", "2.0.0")
     def webhook_id(self):
         return self.id
 


### PR DESCRIPTION
Deprecate the following functions:
1. initialization::create_webhook
2. initialization::initialize_webhook
3. initialization::get_webhooks
4. initialization::get_webhook_events
5. Webhook::id
6. Webhook::info
7. Webhook::create
8. Webhook::update
9. return_json in Webhook::all

Items:
* [ ] Implemented (new) unit tests
* [ ] Updated [documentation](sdk.up42.com)

For release:
* [ ] Bumped version
* [ ] Added changelog
