### PR TITLE
[Bugix] Convert relative job links to absolute links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ You can check your current version with the following command:
     ```
 
 For more information, see [UP42 Python package description](https://pypi.org/project/up42-py/).
+## 1.1.0a2
+
+**Jun 18, 2024**
+
+- Convert relative paths in processing job page links to absolute ones.
+
 ## 1.1.0a1
 
 **Jun 18, 2024**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "up42-py"
-version = "1.1.0a1"
+version = "1.1.0a2"
 description = "Python SDK for UP42, the geospatial marketplace and developer platform."
 authors = ["UP42 GmbH <support@up42.com>"]
 license = "https://github.com/up42/up42-py/blob/master/LICENSE"

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -391,7 +391,7 @@ class TestJob:
 
         query = urllib.parse.urlencode(query_params)
 
-        next_page_url = f"{JOBS_URL}/next"
+        next_page_url = "/v2/processing/jobs/next"
         requests_mock.get(
             url=JOBS_URL + (query and f"?{query}"),
             json={
@@ -400,7 +400,7 @@ class TestJob:
             },
         )
         requests_mock.get(
-            url=next_page_url,
+            url=f"{constants.API_HOST}{next_page_url}",
             json={
                 "jobs": [JOB_METADATA] * 2,
                 "links": [],

--- a/up42/processing.py
+++ b/up42/processing.py
@@ -175,7 +175,7 @@ class Job:
                     (link["href"] for link in page["links"] if link["rel"] == "next"),
                     None,
                 )
-                page = next_page_url and cls.session.get(next_page_url).json()
+                page = next_page_url and cls.session.get(host.endpoint(next_page_url)).json()
 
         for page in get_pages():
             for metadata in page:


### PR DESCRIPTION
Job registry returns page links as relative paths

Items:
* [x] Implemented (new) unit tests

For release:
* [x] Bumped version
* [x] Added changelog
