### PR TITLE
[Bugfix] Missing workspace id in job execution request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ You can check your current version with the following command:
     ```
 
 For more information, see [UP42 Python package description](https://pypi.org/project/up42-py/).
+## 1.1.0a4
+
+**Jun 19, 2024**
+
+- Add missing workspace id query param to job execution.
+
 ## 1.1.0a3
 
 **Jun 19, 2024**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "up42-py"
-version = "1.1.0a3"
+version = "1.1.0a4"
 description = "Python SDK for UP42, the geospatial marketplace and developer platform."
 authors = ["UP42 GmbH <support@up42.com>"]
 license = "https://github.com/up42/up42-py/blob/master/LICENSE"

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -18,7 +18,9 @@ from up42 import processing, utils
 PROCESS_ID = "process-id"
 VALIDATION_URL = f"{constants.API_HOST}/v2/processing/processes/{PROCESS_ID}/validation"
 COST_URL = f"{constants.API_HOST}/v2/processing/processes/{PROCESS_ID}/cost"
-EXECUTION_URL = f"{constants.API_HOST}/v2/processing/processes/{PROCESS_ID}/execution"
+EXECUTION_URL = (
+    f"{constants.API_HOST}/v2/processing/processes/{PROCESS_ID}/execution?workspaceId={constants.WORKSPACE_ID}"
+)
 TITLE = "title"
 COLLECTION_ID = str(uuid.uuid4())
 COLLECTION_URL = f"https://collections/{COLLECTION_ID}"
@@ -108,6 +110,7 @@ class TestCost:
 class SampleJobTemplate(processing.JobTemplate):
     title: str
     process_id = PROCESS_ID
+    workspace_id = constants.WORKSPACE_ID
 
     @property
     def inputs(self) -> dict:

--- a/up42/processing.py
+++ b/up42/processing.py
@@ -262,7 +262,9 @@ class JobTemplate:
 
     def execute(self) -> Job:
         url = host.endpoint(f"/v2/processing/processes/{self.process_id}/execution")
-        job_metadata = self.session.post(url, json={"inputs": self.inputs}).json()
+        job_metadata = self.session.post(
+            url, params={"workspaceId": self.workspace_id}, json={"inputs": self.inputs}
+        ).json()
         return Job.from_metadata(job_metadata)
 
 


### PR DESCRIPTION
Job execution endpoint requires workspaceId as query parameter.

Items:
* [x] Implemented (new) unit tests

For release:
* [x] Bumped version
* [x] Added changelog
