### PR TITLE
Change feasibility endpoint url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ You can check your current version with the following command:
     ```
 
 For more information, see [UP42 Python package description](https://pypi.org/project/up42-py/).
+
+## 2.2.0a26
+**Mar 20, 2025**
+- Updated feasibility endpoint URL.
+
 ## 2.2.0a25
 **Mar 19, 2025**
 - Added sorting fields to `QuotationSorting`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "up42-py"
-version = "2.2.0a25"
+version = "2.2.0a26"
 description = "Python SDK for UP42, the geospatial marketplace and developer platform."
 authors = ["UP42 GmbH <support@up42.com>"]
 license = "https://github.com/up42/up42-py/blob/master/LICENSE"

--- a/tests/test_tasking.py
+++ b/tests/test_tasking.py
@@ -194,7 +194,7 @@ class TestTasking:
             query_params["orderId"] = order_id
         if decision:
             query_params["decision"] = decision
-        base_url = f"{constants.API_HOST}/v2/tasking/feasibility"
+        base_url = f"{constants.API_HOST}/v2/tasking/feasibility-studies"
         expected = [{"id": f"id{idx}"} for idx in [1, 2, 3, 4]]
         for page in [0, 1]:
             query_params["page"] = page
@@ -219,7 +219,7 @@ class TestTasking:
     def test_should_choose_feasibility(self, requests_mock: req_mock.Mocker, tasking_obj: tasking.Tasking):
         accepted_option_id = "accepted-option-id"
         payload = {"acceptedOptionId": accepted_option_id}
-        url = f"{constants.API_HOST}/v2/tasking/feasibility/{FEASIBILITY_ID}"
+        url = f"{constants.API_HOST}/v2/tasking/feasibility-studies/{FEASIBILITY_ID}"
         expected = {
             "id": FEASIBILITY_ID,
             "decisionOption": {

--- a/up42/tasking.py
+++ b/up42/tasking.py
@@ -188,7 +188,7 @@ class Tasking(catalog.CatalogBase):
             "decision": decision,
             "sort": utils.SortingField(sortby, not descending),
         }
-        return list(utils.paged_query(params, "/v2/tasking/feasibility", self.session))
+        return list(utils.paged_query(params, "/v2/tasking/feasibility-studies", self.session))
 
     @utils.deprecation(None, "3.0.0")
     def choose_feasibility(self, feasibility_id: str, accepted_option_id: str) -> dict:
@@ -202,7 +202,7 @@ class Tasking(catalog.CatalogBase):
         Returns:
             dict: The confirmation to the decided quotation plus metadata.
         """
-        url = host.endpoint(f"/v2/tasking/feasibility/{feasibility_id}")
+        url = host.endpoint(f"/v2/tasking/feasibility-studies/{feasibility_id}")
         return self.session.patch(url=url, json={"acceptedOptionId": accepted_option_id}).json()
 
 


### PR DESCRIPTION
The endpoint `/v2/tasking/feasibility` is deprecated and should be replaced with `/v2/tasking/feasibility-studies`.

Refer to the [UP42 API reference](https://developer.up42.com/reference/listtaskingfeasibilitystudies)


Checklist:
* [x] Test coverage
* [x] Version bump
* [x] Changelog update
