### PR TITLE
PT-6450 use self-hosted runner to run sdk-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ workflows:
       - automated-test/run-sdk-tests:
           requires:
             - test
-          machine-size: medium+
+          machine-size: interstellar/gke-cpu-large
           name: sdk-e2e-tests
           fingerprint: 'c5:5a:28:b3:5e:21:8d:9c:6c:b1:9b:a7:7b:f3:41:0c'
           run-command: make test-all


### PR DESCRIPTION
With `up42-internal-api-test` client being removed, sdk-tests run need to use self-hosted runner to access internal endpoints. Otherwise, no token can be retrieved.

See changelog.

Checklist:
* [x] Test coverage (N/A)
* [x] Version bump (N/A)
* [x] Changelog update (N/A)
