### PR TITLE
PT-6472 Redirect E2E failures to e2e-sdk-test-alerts channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ orbs:
 workspace: &workspace-dir /tmp/workspace
 
 # E2E Tests
-slack-channel-id-qa-alert: &slack-channel-id-qa-alert 'C04QXJP2RCZ'
+slack-channel-id-qa-alert: &slack-channel-id-qa-alert 'C06P4MXGY23'
 
 jobs:
   test:


### PR DESCRIPTION
Based on https://up42.atlassian.net/browse/PT-6472
 
Since the SDK is now owned by all teams, we need to move away from notifying Processing channel on failures and instead ping a generic channel: `e2e-sdk-test-alerts` where every other team can see.

Checklist:
* [x] Test coverage N/A
* [x] Version bump N/A
* [x] Changelog update N/A
