### PR TITLE
Update codeowners of __init__

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 pyproject.toml @up42/user-sdk @up42/data-sdk @up42/processing-sdk @up42/catalog-sdk
 CHANGELOG.md @up42/user-sdk @up42/data-sdk @up42/processing-sdk @up42/catalog-sdk
 /up42/http @up42/user-sdk
+/up42/__init__.py @up42/user-sdk @up42/data-sdk @up42/processing-sdk @up42/catalog-sdk
 /up42/asset.py @up42/processing-sdk
 /up42/base.py @up42/user-sdk
 /up42/host.py @up42/user-sdk


### PR DESCRIPTION
Explicitly allowing different teams to push changes into `/up42/__init__.py` without needing an approval from `@up42/sdk-team`.